### PR TITLE
Add WatermelonDB models for Habit and HabitLog

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFilesAfterSetup: [],
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|@nozbe)/)',
   ],
+  forceExit: true,
 };

--- a/src/__tests__/models/models.test.ts
+++ b/src/__tests__/models/models.test.ts
@@ -1,0 +1,102 @@
+import {Database} from '@nozbe/watermelondb';
+import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
+import {schema} from '../../models/schema';
+import Habit from '../../models/Habit';
+import HabitLog from '../../models/HabitLog';
+
+function createTestDatabase(): Database {
+  const adapter = new LokiJSAdapter({schema, useWebWorker: false, useIncrementalIndexedDB: false});
+  return new Database({
+    adapter,
+    modelClasses: [Habit, HabitLog],
+  });
+}
+
+describe('Habit model', () => {
+  let database: Database;
+
+  beforeEach(() => {
+    database = createTestDatabase();
+  });
+
+  it('can be created with default is_active = true', async () => {
+    const habit = await database.write(async () => {
+      return database.get<Habit>('habits').create(h => {
+        h.name = 'Exercise';
+        h.createdAt = Date.now();
+        h.isActive = true;
+      });
+    });
+
+    expect(habit.name).toBe('Exercise');
+    expect(habit.isActive).toBe(true);
+  });
+
+  it('markInactive sets is_active to false', async () => {
+    const habit = await database.write(async () => {
+      return database.get<Habit>('habits').create(h => {
+        h.name = 'Read';
+        h.createdAt = Date.now();
+        h.isActive = true;
+      });
+    });
+
+    expect(habit.isActive).toBe(true);
+
+    await habit.markInactive();
+
+    expect(habit.isActive).toBe(false);
+  });
+});
+
+describe('HabitLog model', () => {
+  let database: Database;
+
+  beforeEach(() => {
+    database = createTestDatabase();
+  });
+
+  it('can be created linked to a Habit', async () => {
+    const {habit, log} = await database.write(async () => {
+      const h = await database.get<Habit>('habits').create(rec => {
+        rec.name = 'Meditate';
+        rec.createdAt = Date.now();
+        rec.isActive = true;
+      });
+
+      const l = await database.get<HabitLog>('habit_logs').create(rec => {
+        rec.habitId = h.id;
+        rec.completedDate = '2026-03-07';
+        rec.synced = false;
+      });
+
+      return {habit: h, log: l};
+    });
+
+    expect(log.habitId).toBe(habit.id);
+    expect(log.completedDate).toBe('2026-03-07');
+    expect(log.synced).toBe(false);
+  });
+
+  it('markSynced sets synced to true', async () => {
+    const log = await database.write(async () => {
+      const h = await database.get<Habit>('habits').create(rec => {
+        rec.name = 'Journal';
+        rec.createdAt = Date.now();
+        rec.isActive = true;
+      });
+
+      return database.get<HabitLog>('habit_logs').create(rec => {
+        rec.habitId = h.id;
+        rec.completedDate = '2026-03-07';
+        rec.synced = false;
+      });
+    });
+
+    expect(log.synced).toBe(false);
+
+    await log.markSynced();
+
+    expect(log.synced).toBe(true);
+  });
+});

--- a/src/models/Habit.ts
+++ b/src/models/Habit.ts
@@ -1,0 +1,26 @@
+import {Model} from '@nozbe/watermelondb';
+import {field, children, lazy, writer} from '@nozbe/watermelondb/decorators';
+import type {Query} from '@nozbe/watermelondb';
+import type HabitLog from './HabitLog';
+
+export default class Habit extends Model {
+  static table = 'habits';
+
+  static associations = {
+    habit_logs: {type: 'has_many' as const, foreignKey: 'habit_id'},
+  };
+
+  @field('name') name!: string;
+  @field('created_at') createdAt!: number;
+  @field('is_active') isActive!: boolean;
+
+  @children('habit_logs') habitLogs!: Query<HabitLog>;
+
+  @lazy logs = this.collections.get<HabitLog>('habit_logs').query();
+
+  @writer async markInactive(): Promise<void> {
+    await this.update(habit => {
+      habit.isActive = false;
+    });
+  }
+}

--- a/src/models/HabitLog.ts
+++ b/src/models/HabitLog.ts
@@ -1,0 +1,29 @@
+import {Model} from '@nozbe/watermelondb';
+import {field, relation, writer} from '@nozbe/watermelondb/decorators';
+import type {Relation} from '@nozbe/watermelondb';
+import type Habit from './Habit';
+
+// NOTE: The pair (habit_id, completed_date) should be treated as logically
+// unique. Enforce this in the service layer since WatermelonDB does not
+// support compound unique constraints natively.
+
+export default class HabitLog extends Model {
+  static table = 'habit_logs';
+
+  static associations = {
+    habits: {type: 'belongs_to' as const, key: 'habit_id'},
+  };
+
+  @field('habit_id') habitId!: string;
+  // Plain string in "YYYY-MM-DD" format to avoid timezone issues.
+  @field('completed_date') completedDate!: string;
+  @field('synced') synced!: boolean;
+
+  @relation('habits', 'habit_id') habit!: Relation<Habit>;
+
+  @writer async markSynced(): Promise<void> {
+    await this.update(log => {
+      log.synced = true;
+    });
+  }
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,18 @@
+import {Database} from '@nozbe/watermelondb';
+import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
+import {schema} from './schema';
+import Habit from './Habit';
+import HabitLog from './HabitLog';
+
+const adapter = new SQLiteAdapter({
+  schema,
+  jsi: true,
+});
+
+const database = new Database({
+  adapter,
+  modelClasses: [Habit, HabitLog],
+});
+
+export default database;
+export {Habit, HabitLog};

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,0 +1,27 @@
+import {appSchema, tableSchema} from '@nozbe/watermelondb';
+
+export const schema = appSchema({
+  version: 1,
+  tables: [
+    tableSchema({
+      name: 'habits',
+      columns: [
+        {name: 'name', type: 'string'},
+        {name: 'created_at', type: 'number'},
+        {name: 'is_active', type: 'boolean'},
+      ],
+    }),
+    tableSchema({
+      name: 'habit_logs',
+      columns: [
+        {name: 'habit_id', type: 'string', isIndexed: true},
+        // Stored as "YYYY-MM-DD" string to avoid timezone issues.
+        // NOTE: The pair (habit_id, completed_date) should be treated as
+        // logically unique. Enforce this in the service layer since
+        // WatermelonDB does not support compound unique constraints natively.
+        {name: 'completed_date', type: 'string'},
+        {name: 'synced', type: 'boolean', isIndexed: true},
+      ],
+    }),
+  ],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noEmit": true,
     "isolatedModules": true,
     "strict": true,
+    "experimentalDecorators": true,
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
This PR introduces the database layer for the habit tracking application using WatermelonDB, a high-performance reactive database for React Native. It includes model definitions for Habit and HabitLog entities, database schema configuration, and comprehensive tests.

## Key Changes
- **Added Habit model** (`src/models/Habit.ts`): Represents a habit with name, creation timestamp, and active status. Includes a `markInactive()` method to deactivate habits and relationships to associated habit logs.
- **Added HabitLog model** (`src/models/HabitLog.ts`): Represents a completion log entry for a habit on a specific date. Includes a `markSynced()` method to track synchronization status and a relationship back to the parent Habit.
- **Added database schema** (`src/models/schema.ts`): Defines the structure for both `habits` and `habit_logs` tables with appropriate column types and indexing.
- **Added database initialization** (`src/models/index.ts`): Exports a configured WatermelonDB instance with SQLite adapter for production use.
- **Added comprehensive tests** (`src/__tests__/models/models.test.ts`): Tests for creating habits, marking them inactive, creating habit logs linked to habits, and marking logs as synced.
- **Updated Jest configuration**: Added `@nozbe` to transformIgnorePatterns and enabled `forceExit` for proper test cleanup.
- **Updated TypeScript configuration**: Enabled `experimentalDecorators` to support WatermelonDB's decorator syntax.

## Notable Implementation Details
- Habit logs use a compound logical unique constraint on `(habit_id, completed_date)` enforced at the service layer, as WatermelonDB doesn't support native compound constraints.
- Completed dates are stored as "YYYY-MM-DD" strings to avoid timezone-related issues.
- The `synced` field is indexed for efficient querying of unsynced records.
- Tests use LokiJS adapter (in-memory) for fast, isolated test execution.

https://claude.ai/code/session_01441M4fGnAQNkDNoT7Aa75r