### PR TITLE
Add Cloudflare Tunnel setup guide and Docker Compose support

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,75 @@
+# Habit Tracker — Backend
+
+FastAPI application that powers the Habit Tracker mobile app.
+
+## Quick Start
+
+```bash
+# Create a virtualenv and install dependencies
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# Copy the example env file and edit as needed
+cp .env.example .env
+
+# Run database migrations
+alembic upgrade head
+
+# Start the development server
+uvicorn app.main:app --reload --port 8000
+```
+
+## Running with Docker Compose
+
+```bash
+docker compose up -d
+```
+
+This starts:
+- **db** — MariaDB 11 on port 3306.
+- **api** — FastAPI on port 8000.
+
+## Running Tests
+
+```bash
+pytest
+```
+
+## Deployment
+
+### Docker Compose (basic)
+
+The default `docker-compose.yml` is suitable for single-server deployments.
+Configure production secrets through a `.env` file rather than the example
+defaults:
+
+```bash
+cp .env.example .env
+# Edit .env with real database credentials, JWT secret, etc.
+docker compose up -d
+```
+
+### Exposing the API with Cloudflare Tunnels
+
+Cloudflare Tunnels let you securely expose `localhost:8000` to the internet
+without opening inbound ports or configuring a reverse proxy.
+
+**Option A — Docker Compose (recommended)**
+
+1. Create a tunnel and download the credentials JSON from Cloudflare
+   (see [`docs/cloudflare-tunnel-setup.md`](../docs/cloudflare-tunnel-setup.md)
+   for the full walkthrough).
+2. Edit `cloudflared-config.yml` — set your tunnel UUID and hostname.
+3. Place your credentials JSON next to the compose file (or set
+   `CLOUDFLARED_CREDENTIALS_FILE` to its path).
+4. Start everything including the tunnel:
+
+   ```bash
+   docker compose --profile tunnel up -d
+   ```
+
+**Option B — Standalone `cloudflared` / systemd**
+
+Install `cloudflared` on the host, authenticate, create a tunnel, and run it
+as a systemd service. The full guide is at
+[`docs/cloudflare-tunnel-setup.md`](../docs/cloudflare-tunnel-setup.md).

--- a/backend/cloudflared-config.yml
+++ b/backend/cloudflared-config.yml
@@ -1,0 +1,21 @@
+# Cloudflare Tunnel configuration for the Habit Tracker API.
+#
+# Usage (standalone / systemd):
+#   1. Replace <TUNNEL_UUID> with your tunnel UUID.
+#   2. Update credentials-file to point to your credentials JSON.
+#   3. Replace api.example.com with your actual subdomain.
+#   4. Copy this file to ~/.cloudflared/config.yml or pass it via --config.
+#
+# Usage (Docker Compose):
+#   The docker-compose tunnel service bind-mounts this file and the
+#   credentials JSON into /etc/cloudflared/. Set the service field to
+#   http://api:8000 so the tunnel container reaches the API container
+#   over the Compose network.
+
+tunnel: <TUNNEL_UUID>
+credentials-file: /etc/cloudflared/credentials.json
+
+ingress:
+  - hostname: api.example.com
+    service: http://api:8000
+  - service: http_status:404

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,5 +24,18 @@ services:
       db:
         condition: service_healthy
 
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      - ./cloudflared-config.yml:/etc/cloudflared/config.yml:ro
+      - ${CLOUDFLARED_CREDENTIALS_FILE:-./cloudflared-credentials.json}:/etc/cloudflared/credentials.json:ro
+    depends_on:
+      api:
+        condition: service_started
+    restart: unless-stopped
+    profiles:
+      - tunnel
+
 volumes:
   db_data:

--- a/docs/cloudflare-tunnel-setup.md
+++ b/docs/cloudflare-tunnel-setup.md
@@ -1,0 +1,174 @@
+# Cloudflare Tunnel Setup for Habit Tracker API
+
+This guide walks through exposing the FastAPI backend (`localhost:8000`) to the
+internet using [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/).
+
+## Prerequisites
+
+- A Cloudflare account with an active domain (zone) added.
+- A running instance of the Habit Tracker API on `localhost:8000`.
+
+---
+
+## 1. Install `cloudflared`
+
+### Debian / Ubuntu
+
+```bash
+curl -L https://pkg.cloudflare.com/cloudflare-main.gpg \
+  | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+
+echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] \
+  https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/cloudflared.list
+
+sudo apt update && sudo apt install -y cloudflared
+```
+
+### macOS (Homebrew)
+
+```bash
+brew install cloudflared
+```
+
+### Verify
+
+```bash
+cloudflared --version
+```
+
+---
+
+## 2. Authenticate with Cloudflare
+
+```bash
+cloudflared tunnel login
+```
+
+This opens a browser window. Select the domain you want to use and authorise
+the connection. A certificate is saved to `~/.cloudflared/cert.pem`.
+
+---
+
+## 3. Create a Tunnel
+
+```bash
+cloudflared tunnel create habit-tracker
+```
+
+Note the **Tunnel UUID** printed in the output (e.g.
+`a1b2c3d4-e5f6-7890-abcd-ef1234567890`). A credentials file is saved to
+`~/.cloudflared/<TUNNEL_UUID>.json`.
+
+---
+
+## 4. Configure the Tunnel
+
+Create (or copy) the configuration file. A ready-made template lives at
+`backend/cloudflared-config.yml` in this repository.
+
+```yaml
+tunnel: <TUNNEL_UUID>
+credentials-file: /home/<user>/.cloudflared/<TUNNEL_UUID>.json
+
+ingress:
+  - hostname: api.example.com
+    service: http://localhost:8000
+  - service: http_status:404
+```
+
+Replace:
+- `<TUNNEL_UUID>` with your tunnel's UUID.
+- `<user>` with the OS user that owns the credentials file.
+- `api.example.com` with your chosen subdomain.
+
+Place the file at `~/.cloudflared/config.yml` or pass its path explicitly with
+the `--config` flag.
+
+---
+
+## 5. DNS Configuration
+
+Create a CNAME record that points your subdomain to the tunnel:
+
+```bash
+cloudflared tunnel route dns habit-tracker api.example.com
+```
+
+This adds a CNAME record in Cloudflare DNS:
+
+| Type  | Name  | Target                                         |
+|-------|-------|-------------------------------------------------|
+| CNAME | api   | `<TUNNEL_UUID>.cfargotunnel.com`                |
+
+You can verify the record in the Cloudflare dashboard under **DNS > Records**.
+
+---
+
+## 6. Run the Tunnel
+
+### Manual (foreground)
+
+```bash
+cloudflared tunnel --config ~/.cloudflared/config.yml run habit-tracker
+```
+
+### As a systemd Service (recommended for production)
+
+Install the service:
+
+```bash
+sudo cloudflared service install
+```
+
+This copies your config and credentials into `/etc/cloudflared/` and creates a
+`cloudflared.service` unit. If you prefer to point at a custom config path:
+
+```bash
+sudo cp ~/.cloudflared/config.yml /etc/cloudflared/config.yml
+sudo cp ~/.cloudflared/<TUNNEL_UUID>.json /etc/cloudflared/<TUNNEL_UUID>.json
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl enable cloudflared
+sudo systemctl start cloudflared
+```
+
+Check the status:
+
+```bash
+sudo systemctl status cloudflared
+journalctl -u cloudflared -f
+```
+
+The service is configured to restart on failure automatically via systemd's
+`Restart=on-failure` directive.
+
+---
+
+## 7. Docker Compose (alternative)
+
+Instead of installing `cloudflared` on the host, you can run the tunnel as a
+Docker container alongside the API. See the `tunnel` service in
+`backend/docker-compose.yml`:
+
+```bash
+cd backend
+docker compose --profile tunnel up -d
+```
+
+This requires you to bind-mount your `cloudflared-config.yml` and tunnel
+credentials file. See the `docker-compose.yml` comments for details.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `ERR  Unable to reach the origin service` | Ensure the API is running on `localhost:8000`. |
+| `failed to sufficiently increase receive buffer size` | Ignored safely; this is a UDP tuning warning. |
+| DNS record not propagating | Wait a few minutes; check the Cloudflare dashboard for the CNAME. |
+| 502 Bad Gateway | The tunnel is running but the backend is down. Start the API first. |


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and Docker Compose integration for exposing the Habit Tracker API to the internet using Cloudflare Tunnels, eliminating the need to open inbound ports or configure a reverse proxy.

## Key Changes

- **New documentation** (`docs/cloudflare-tunnel-setup.md`): Complete step-by-step guide covering:
  - Installation of `cloudflared` on Debian/Ubuntu and macOS
  - Authentication with Cloudflare
  - Tunnel creation and configuration
  - DNS setup via CNAME records
  - Running the tunnel manually or as a systemd service
  - Troubleshooting common issues

- **Backend README updates** (`backend/README.md`): Added deployment section documenting:
  - Docker Compose-based tunnel setup (recommended)
  - Standalone `cloudflared` / systemd alternative
  - Links to the full setup guide

- **Tunnel configuration template** (`backend/cloudflared-config.yml`): Ready-to-use configuration file with:
  - Placeholder values for tunnel UUID and hostname
  - Inline comments for both standalone and Docker Compose usage
  - Proper ingress routing to the API service

- **Docker Compose integration** (`backend/docker-compose.yml`): Added optional `tunnel` service:
  - Uses official `cloudflare/cloudflared` image
  - Bind-mounts configuration and credentials files
  - Depends on the API service being started
  - Gated behind `--profile tunnel` flag for opt-in usage
  - Auto-restart on failure

## Implementation Details

- The tunnel service is optional and only runs when explicitly enabled with `docker compose --profile tunnel up`
- Credentials file path is configurable via `CLOUDFLARED_CREDENTIALS_FILE` environment variable, defaulting to `./cloudflared-credentials.json`
- The tunnel container communicates with the API container via the Docker Compose network (`http://api:8000`)
- All documentation includes both Docker and standalone approaches to accommodate different deployment preferences

https://claude.ai/code/session_015EXHMQbKQuC9ENSoiNyUEJ