### PR TITLE
Implement comprehensive Settings screen with habit management

### DIFF
--- a/src/__tests__/screens/CreateHabitModal.test.tsx
+++ b/src/__tests__/screens/CreateHabitModal.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
+import CreateHabitModal from '../../screens/CreateHabitModal';
+import HabitService from '../../services/HabitService';
+
+// Mock the database import to avoid SQLite initialization in tests
+jest.mock('../../models', () => ({}));
+
+function createMockHabitService() {
+  return {
+    createHabit: jest.fn().mockResolvedValue({id: 'new-1', name: 'Test'}),
+    getActiveHabits: jest.fn(),
+    getAllHabits: jest.fn(),
+    toggleHabitActive: jest.fn(),
+    toggleHabitCompletion: jest.fn(),
+    calculateStreak: jest.fn(),
+    getLogsForHabit: jest.fn(),
+    getUnsyncedLogs: jest.fn(),
+    getHabitById: jest.fn(),
+  } as unknown as jest.Mocked<HabitService>;
+}
+
+describe('CreateHabitModal', () => {
+  it('disables Create button when input is empty', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    const createButton = getByTestId('create-button');
+    expect(createButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('disables Create button when input is whitespace-only', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.changeText(getByTestId('habit-name-input'), '   ');
+
+    const createButton = getByTestId('create-button');
+    expect(createButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('calls createHabit with trimmed name on Create press', async () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.changeText(getByTestId('habit-name-input'), '  Drink Water  ');
+
+    await act(async () => {
+      fireEvent.press(getByTestId('create-button'));
+    });
+
+    expect(service.createHabit).toHaveBeenCalledWith('Drink Water');
+    expect(navigation.goBack).toHaveBeenCalled();
+  });
+
+  it('enforces max length of 50 characters', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    const input = getByTestId('habit-name-input');
+    // maxLength is set on the TextInput — verify the prop
+    expect(input.props.maxLength).toBe(50);
+  });
+
+  it('shows live character counter', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    expect(getByTestId('char-counter').props.children).toEqual([
+      0,
+      '/',
+      50,
+    ]);
+
+    fireEvent.changeText(getByTestId('habit-name-input'), 'Hello');
+
+    expect(getByTestId('char-counter').props.children).toEqual([
+      5,
+      '/',
+      50,
+    ]);
+  });
+
+  it('dismisses modal without creating when Cancel is pressed', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.press(getByTestId('cancel-button'));
+
+    expect(navigation.goBack).toHaveBeenCalled();
+    expect(service.createHabit).not.toHaveBeenCalled();
+  });
+
+  it('enables Create button when valid text is entered', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.changeText(getByTestId('habit-name-input'), 'Read 10 Pages');
+
+    const createButton = getByTestId('create-button');
+    expect(createButton.props.accessibilityState?.disabled).toBeFalsy();
+  });
+
+  it('has correct placeholder text', () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    const input = getByTestId('habit-name-input');
+    expect(input.props.placeholder).toBe(
+      'e.g., Drink Water, Read 10 Pages',
+    );
+  });
+});

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
+import SettingsScreen from '../../screens/SettingsScreen';
+import HabitService from '../../services/HabitService';
+import SyncService from '../../services/SyncService';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {of} from 'rxjs';
+
+// Mock the database import to avoid SQLite initialization in tests
+jest.mock('../../models', () => ({}));
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Mock date-fns format for deterministic output
+jest.mock('date-fns', () => ({
+  ...jest.requireActual('date-fns'),
+  format: (date: Date, fmt: string) => {
+    if (fmt === 'MMM d, yyyy') {
+      return 'Jan 1, 2026';
+    }
+    if (fmt === 'MMM d, yyyy h:mm a') {
+      return 'Mar 5, 2026 8:00 AM';
+    }
+    return jest.requireActual('date-fns').format(date, fmt);
+  },
+}));
+
+// Mock Alert
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native');
+  RN.Alert.alert = jest.fn();
+  return RN;
+});
+
+function createMockHabits(
+  items: Array<{id: string; name: string; isActive: boolean; createdAt?: number}>,
+) {
+  return items.map(h => ({
+    id: h.id,
+    name: h.name,
+    isActive: h.isActive,
+    createdAt: h.createdAt ?? 1704067200000, // Jan 1, 2024
+  }));
+}
+
+function createMockHabitService(
+  habits: Array<{id: string; name: string; isActive: boolean}>,
+  unsyncedCount = 0,
+) {
+  const mockHabits = createMockHabits(habits);
+  const unsyncedLogs = Array.from({length: unsyncedCount}, (_, i) => ({
+    id: `log-${i}`,
+    habitId: 'h1',
+    completedDate: '2026-03-05',
+    synced: false,
+  }));
+
+  return {
+    getAllHabits: jest.fn().mockReturnValue(of(mockHabits)),
+    getActiveHabits: jest.fn().mockReturnValue(of([])),
+    toggleHabitActive: jest.fn().mockResolvedValue(undefined),
+    getUnsyncedLogs: jest.fn().mockResolvedValue(unsyncedLogs),
+    createHabit: jest.fn().mockResolvedValue(undefined),
+    toggleHabitCompletion: jest.fn().mockResolvedValue(undefined),
+    calculateStreak: jest.fn().mockResolvedValue(0),
+    getLogsForHabit: jest.fn().mockResolvedValue([]),
+    getHabitById: jest.fn().mockResolvedValue(null),
+  } as unknown as jest.Mocked<HabitService>;
+}
+
+function createMockSyncService() {
+  return {
+    pushUnsyncedLogs: jest.fn().mockResolvedValue({pushed: 0, failed: 0}),
+    authenticate: jest.fn().mockResolvedValue(undefined),
+    startBackgroundSync: jest.fn(),
+    stopBackgroundSync: jest.fn(),
+    debouncedSync: jest.fn(),
+    getAuthToken: jest.fn().mockResolvedValue(null),
+    isAuthenticated: jest.fn().mockResolvedValue(false),
+  } as unknown as jest.Mocked<SyncService>;
+}
+
+describe('SettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('lists all habits including active and inactive', async () => {
+    const habits = [
+      {id: '1', name: 'Exercise', isActive: true},
+      {id: '2', name: 'Read', isActive: false},
+      {id: '3', name: 'Meditate', isActive: true},
+    ];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+
+    const {getByText, getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('habit-row-1')).toBeTruthy();
+      expect(getByTestId('habit-row-2')).toBeTruthy();
+      expect(getByTestId('habit-row-3')).toBeTruthy();
+    });
+
+    expect(getByText('Exercise')).toBeTruthy();
+    expect(getByText('Read')).toBeTruthy();
+    expect(getByText('Meditate')).toBeTruthy();
+  });
+
+  it('calls toggleHabitActive when toggling a habit switch', async () => {
+    const habits = [
+      {id: 'h1', name: 'Exercise', isActive: true},
+    ];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('toggle-active-h1')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('toggle-active-h1'), 'valueChange', false);
+    });
+
+    expect(service.toggleHabitActive).toHaveBeenCalledWith('h1');
+  });
+
+  it('displays correct unsynced logs count', async () => {
+    const service = createMockHabitService([], 5);
+    const syncService = createMockSyncService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-status')).toBeTruthy();
+    });
+
+    expect(getByTestId('sync-status').props.children).toEqual([
+      5,
+      ' ',
+      'logs',
+      ' pending sync',
+    ]);
+  });
+
+  it('displays app version and server URL', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('app-version')).toBeTruthy();
+    });
+
+    expect(getByTestId('app-version').props.children).toBe('0.0.1');
+    expect(getByTestId('server-url').props.children).toBe(
+      'https://habit-tracker.tunnel.example.com',
+    );
+  });
+
+  it('calls pushUnsyncedLogs when Sync Now is pressed', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-now-button')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('sync-now-button'));
+    });
+
+    expect(syncService.pushUnsyncedLogs).toHaveBeenCalled();
+  });
+
+  it('displays "1 log pending sync" for singular count', async () => {
+    const service = createMockHabitService([], 1);
+    const syncService = createMockSyncService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-status')).toBeTruthy();
+    });
+
+    expect(getByTestId('sync-status').props.children).toEqual([
+      1,
+      ' ',
+      'log',
+      ' pending sync',
+    ]);
+  });
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import DashboardScreen from '../screens/DashboardScreen';
 import StatsScreen from '../screens/StatsScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import CreateHabitModal from '../screens/CreateHabitModal';
 
 const HomeStack = createNativeStackNavigator();
 const SettingsStack = createNativeStackNavigator();
@@ -13,6 +14,11 @@ const HomeStackScreen: React.FC = () => (
   <HomeStack.Navigator screenOptions={{headerShown: false}}>
     <HomeStack.Screen name="Dashboard" component={DashboardScreen} />
     <HomeStack.Screen name="Stats" component={StatsScreen} />
+    <HomeStack.Screen
+      name="CreateHabit"
+      component={CreateHabitModal}
+      options={{presentation: 'modal'}}
+    />
   </HomeStack.Navigator>
 );
 

--- a/src/screens/CreateHabitModal.tsx
+++ b/src/screens/CreateHabitModal.tsx
@@ -1,0 +1,182 @@
+import React, {useCallback, useState} from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import {colors} from '../theme/colors';
+import {fontFamily, typeScale} from '../theme/typography';
+import {spacing} from '../theme/spacing';
+import HabitService from '../services/HabitService';
+import database from '../models';
+
+const MAX_LENGTH = 50;
+
+interface CreateHabitModalProps {
+  navigation?: {goBack: () => void};
+  habitService?: HabitService;
+}
+
+const defaultHabitService = new HabitService(database);
+
+const CreateHabitModal: React.FC<CreateHabitModalProps> = ({
+  navigation,
+  habitService,
+}) => {
+  const service = habitService ?? defaultHabitService;
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const trimmedName = name.trim();
+  const isValid = trimmedName.length > 0;
+
+  const handleCreate = useCallback(async () => {
+    if (!isValid || creating) {
+      return;
+    }
+    setCreating(true);
+    try {
+      await service.createHabit(trimmedName);
+      navigation?.goBack();
+    } catch {
+      setCreating(false);
+    }
+  }, [isValid, creating, service, trimmedName, navigation]);
+
+  const handleCancel = useCallback(() => {
+    navigation?.goBack();
+  }, [navigation]);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      testID="create-habit-modal">
+      <View style={styles.container}>
+        <Text style={styles.title}>New Habit</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="e.g., Drink Water, Read 10 Pages"
+          placeholderTextColor={colors.textSecondary}
+          value={name}
+          onChangeText={setName}
+          maxLength={MAX_LENGTH}
+          autoFocus
+          testID="habit-name-input"
+          accessibilityLabel="Habit name"
+        />
+
+        <Text style={styles.counter} testID="char-counter">
+          {name.length}/{MAX_LENGTH}
+        </Text>
+
+        <View style={styles.buttons}>
+          <TouchableOpacity
+            style={styles.cancelButton}
+            onPress={handleCancel}
+            testID="cancel-button">
+            <Text style={styles.cancelButtonText}>Cancel</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.createButton, !isValid && styles.createButtonDisabled]}
+            onPress={handleCreate}
+            disabled={!isValid || creating}
+            testID="create-button">
+            <Text
+              style={[
+                styles.createButtonText,
+                !isValid && styles.createButtonTextDisabled,
+              ]}>
+              Create
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.background,
+    justifyContent: 'center',
+  },
+  container: {
+    marginHorizontal: spacing.md,
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    padding: spacing.lg,
+  },
+  title: {
+    fontFamily: fontFamily.heading,
+    ...typeScale.h2,
+    color: colors.clemsonOrange,
+    marginBottom: spacing.lg,
+    textAlign: 'center',
+  },
+  input: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+    backgroundColor: colors.background,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  counter: {
+    fontFamily: fontFamily.body,
+    ...typeScale.caption,
+    color: colors.textSecondary,
+    textAlign: 'right',
+    marginTop: spacing.xs,
+    marginBottom: spacing.lg,
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  cancelButton: {
+    flex: 1,
+    marginRight: spacing.sm,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+  },
+  cancelButtonText: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textSecondary,
+  },
+  createButton: {
+    flex: 1,
+    marginLeft: spacing.sm,
+    borderRadius: 8,
+    backgroundColor: colors.clemsonOrange,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+  },
+  createButtonDisabled: {
+    backgroundColor: colors.border,
+  },
+  createButtonText: {
+    fontFamily: fontFamily.heading,
+    ...typeScale.body,
+    color: colors.textPrimary,
+  },
+  createButtonTextDisabled: {
+    color: colors.textSecondary,
+  },
+});
+
+export default CreateHabitModal;

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,25 +1,400 @@
-import React from 'react';
-import {StyleSheet, Text, View} from 'react-native';
+import React, {useCallback, useEffect, useState} from 'react';
+import {
+  View,
+  Text,
+  Switch,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+  ScrollView,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {format} from 'date-fns';
+import {colors} from '../theme/colors';
+import {fontFamily, typeScale} from '../theme/typography';
+import {spacing} from '../theme/spacing';
+import HabitService from '../services/HabitService';
+import SyncService from '../services/SyncService';
+import {API_BASE_URL} from '../services/api';
+import database from '../models';
+import type Habit from '../models/Habit';
 
-const SettingsScreen: React.FC = () => {
+const APP_VERSION = '0.0.1';
+const REMINDER_ENABLED_KEY = 'reminder_enabled';
+const REMINDER_TIME_KEY = 'reminder_time';
+const LAST_SYNC_KEY = 'last_sync_timestamp';
+
+interface SettingsScreenProps {
+  habitService?: HabitService;
+  syncService?: SyncService;
+}
+
+const defaultHabitService = new HabitService(database);
+const defaultSyncService = new SyncService(defaultHabitService);
+
+const SettingsScreen: React.FC<SettingsScreenProps> = ({
+  habitService,
+  syncService,
+}) => {
+  const hService = habitService ?? defaultHabitService;
+  const sService = syncService ?? defaultSyncService;
+
+  const [habits, setHabits] = useState<Habit[]>([]);
+  const [reminderEnabled, setReminderEnabled] = useState(false);
+  const [reminderTime, setReminderTime] = useState('08:00');
+  const [unsyncedCount, setUnsyncedCount] = useState(0);
+  const [lastSyncTime, setLastSyncTime] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  // Subscribe to all habits
+  useEffect(() => {
+    const subscription = hService.getAllHabits().subscribe({
+      next: allHabits => setHabits(allHabits),
+    });
+    return () => subscription.unsubscribe();
+  }, [hService]);
+
+  // Load notification preferences
+  useEffect(() => {
+    (async () => {
+      const enabled = await AsyncStorage.getItem(REMINDER_ENABLED_KEY);
+      if (enabled !== null) {
+        setReminderEnabled(enabled === 'true');
+      }
+      const time = await AsyncStorage.getItem(REMINDER_TIME_KEY);
+      if (time !== null) {
+        setReminderTime(time);
+      }
+    })();
+  }, []);
+
+  // Load sync info
+  useEffect(() => {
+    (async () => {
+      const logs = await hService.getUnsyncedLogs();
+      setUnsyncedCount(logs.length);
+      const ts = await AsyncStorage.getItem(LAST_SYNC_KEY);
+      setLastSyncTime(ts);
+    })();
+  }, [hService]);
+
+  const handleToggleActive = useCallback(
+    async (habitId: string) => {
+      await hService.toggleHabitActive(habitId);
+    },
+    [hService],
+  );
+
+  const handleDelete = useCallback(
+    (habitId: string, habitName: string) => {
+      Alert.alert(
+        'Deactivate Habit',
+        `Are you sure you want to deactivate "${habitName}"? Historical logs will be preserved.`,
+        [
+          {text: 'Cancel', style: 'cancel'},
+          {
+            text: 'Deactivate',
+            style: 'destructive',
+            onPress: async () => {
+              await hService.toggleHabitActive(habitId);
+            },
+          },
+        ],
+      );
+    },
+    [hService],
+  );
+
+  const handleReminderToggle = useCallback(async (value: boolean) => {
+    setReminderEnabled(value);
+    await AsyncStorage.setItem(REMINDER_ENABLED_KEY, String(value));
+  }, []);
+
+  const handleTimeChange = useCallback(async (hour: number) => {
+    const timeStr = `${String(hour).padStart(2, '0')}:00`;
+    setReminderTime(timeStr);
+    await AsyncStorage.setItem(REMINDER_TIME_KEY, timeStr);
+  }, []);
+
+  const handleSyncNow = useCallback(async () => {
+    setSyncing(true);
+    try {
+      await sService.pushUnsyncedLogs();
+      const now = new Date().toISOString();
+      await AsyncStorage.setItem(LAST_SYNC_KEY, now);
+      setLastSyncTime(now);
+      const logs = await hService.getUnsyncedLogs();
+      setUnsyncedCount(logs.length);
+    } finally {
+      setSyncing(false);
+    }
+  }, [sService, hService]);
+
+  const renderHabitRow = useCallback(
+    ({item}: {item: Habit}) => (
+      <TouchableOpacity
+        style={styles.habitRow}
+        testID={`habit-row-${item.id}`}
+        onLongPress={() => handleDelete(item.id, item.name)}
+        accessibilityLabel={`${item.name} habit`}>
+        <View style={styles.habitInfo}>
+          <Text style={styles.habitName}>{item.name}</Text>
+          <Text style={styles.habitDate}>
+            Created {format(new Date(item.createdAt), 'MMM d, yyyy')}
+          </Text>
+        </View>
+        <Switch
+          testID={`toggle-active-${item.id}`}
+          value={item.isActive}
+          onValueChange={() => handleToggleActive(item.id)}
+          trackColor={{false: colors.border, true: colors.clemsonOrange}}
+          thumbColor={colors.textPrimary}
+        />
+      </TouchableOpacity>
+    ),
+    [handleToggleActive, handleDelete],
+  );
+
+  const hours = Array.from({length: 24}, (_, i) => i);
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Settings</Text>
-    </View>
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      testID="settings-screen">
+      {/* Your Habits */}
+      <Text style={styles.sectionTitle}>Your Habits</Text>
+      <View style={styles.section}>
+        {habits.length === 0 ? (
+          <Text style={styles.emptyText}>No habits yet.</Text>
+        ) : (
+          <FlatList
+            data={habits}
+            renderItem={renderHabitRow}
+            keyExtractor={item => item.id}
+            scrollEnabled={false}
+            testID="habits-list"
+          />
+        )}
+      </View>
+
+      {/* Notifications */}
+      <Text style={styles.sectionTitle}>Notifications</Text>
+      <View style={styles.section}>
+        <View style={styles.row}>
+          <Text style={styles.rowLabel}>Daily Reminder</Text>
+          <Switch
+            testID="reminder-toggle"
+            value={reminderEnabled}
+            onValueChange={handleReminderToggle}
+            trackColor={{false: colors.border, true: colors.clemsonOrange}}
+            thumbColor={colors.textPrimary}
+          />
+        </View>
+        {reminderEnabled && (
+          <View style={styles.timePickerContainer}>
+            <Text style={styles.rowLabel}>Reminder Time</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.timePicker}
+              testID="time-picker">
+              {hours.map(hour => (
+                <TouchableOpacity
+                  key={hour}
+                  testID={`time-option-${hour}`}
+                  style={[
+                    styles.timeOption,
+                    reminderTime === `${String(hour).padStart(2, '0')}:00` &&
+                      styles.timeOptionSelected,
+                  ]}
+                  onPress={() => handleTimeChange(hour)}>
+                  <Text
+                    style={[
+                      styles.timeOptionText,
+                      reminderTime === `${String(hour).padStart(2, '0')}:00` &&
+                        styles.timeOptionTextSelected,
+                    ]}>
+                    {hour === 0
+                      ? '12 AM'
+                      : hour < 12
+                        ? `${hour} AM`
+                        : hour === 12
+                          ? '12 PM'
+                          : `${hour - 12} PM`}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+          </View>
+        )}
+      </View>
+
+      {/* Sync */}
+      <Text style={styles.sectionTitle}>Sync</Text>
+      <View style={styles.section}>
+        <Text style={styles.syncStatus} testID="sync-status">
+          {unsyncedCount} {unsyncedCount === 1 ? 'log' : 'logs'} pending sync
+        </Text>
+        <TouchableOpacity
+          style={styles.syncButton}
+          onPress={handleSyncNow}
+          disabled={syncing}
+          testID="sync-now-button">
+          {syncing ? (
+            <ActivityIndicator color={colors.textPrimary} testID="sync-spinner" />
+          ) : (
+            <Text style={styles.syncButtonText}>Sync Now</Text>
+          )}
+        </TouchableOpacity>
+        {lastSyncTime && (
+          <Text style={styles.lastSync} testID="last-sync-time">
+            Last sync: {format(new Date(lastSyncTime), 'MMM d, yyyy h:mm a')}
+          </Text>
+        )}
+      </View>
+
+      {/* About */}
+      <Text style={styles.sectionTitle}>About</Text>
+      <View style={styles.section}>
+        <View style={styles.row}>
+          <Text style={styles.rowLabel}>Version</Text>
+          <Text style={styles.rowValue} testID="app-version">
+            {APP_VERSION}
+          </Text>
+        </View>
+        <View style={styles.row}>
+          <Text style={styles.rowLabel}>Server URL</Text>
+          <Text
+            style={[styles.rowValue, styles.serverUrl]}
+            testID="server-url"
+            numberOfLines={1}>
+            {API_BASE_URL}
+          </Text>
+        </View>
+      </View>
+    </ScrollView>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#ffffff',
+    backgroundColor: colors.background,
   },
-  title: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1a1a1a',
+  content: {
+    padding: spacing.md,
+    paddingBottom: spacing.xxl,
+  },
+  sectionTitle: {
+    fontFamily: fontFamily.heading,
+    ...typeScale.h2,
+    color: colors.clemsonOrange,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  section: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: spacing.md,
+  },
+  habitRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  habitInfo: {
+    flex: 1,
+  },
+  habitName: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+  },
+  habitDate: {
+    fontFamily: fontFamily.body,
+    ...typeScale.caption,
+    color: colors.textSecondary,
+    marginTop: 2,
+  },
+  emptyText: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    paddingVertical: spacing.md,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm,
+  },
+  rowLabel: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+  },
+  rowValue: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textSecondary,
+  },
+  serverUrl: {
+    flex: 1,
+    textAlign: 'right',
+    marginLeft: spacing.md,
+  },
+  timePickerContainer: {
+    paddingVertical: spacing.sm,
+  },
+  timePicker: {
+    marginTop: spacing.sm,
+  },
+  timeOption: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+    backgroundColor: colors.border,
+    marginRight: spacing.sm,
+  },
+  timeOptionSelected: {
+    backgroundColor: colors.clemsonOrange,
+  },
+  timeOptionText: {
+    fontFamily: fontFamily.body,
+    ...typeScale.caption,
+    color: colors.textSecondary,
+  },
+  timeOptionTextSelected: {
+    color: colors.textPrimary,
+  },
+  syncStatus: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+    marginBottom: spacing.sm,
+  },
+  syncButton: {
+    backgroundColor: colors.clemsonOrange,
+    borderRadius: 8,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  syncButtonText: {
+    fontFamily: fontFamily.heading,
+    ...typeScale.body,
+    color: colors.textPrimary,
+  },
+  lastSync: {
+    fontFamily: fontFamily.body,
+    ...typeScale.caption,
+    color: colors.textSecondary,
   },
 });
 

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -19,6 +19,22 @@ export default class HabitService {
       .observe();
   }
 
+  getAllHabits(): Observable<Habit[]> {
+    return this.database
+      .get<Habit>('habits')
+      .query(Q.sortBy('created_at', Q.asc))
+      .observe();
+  }
+
+  async toggleHabitActive(habitId: string): Promise<void> {
+    const habit = await this.database.get<Habit>('habits').find(habitId);
+    await this.database.write(async () => {
+      await habit.update(h => {
+        h.isActive = !h.isActive;
+      });
+    });
+  }
+
   async createHabit(name: string): Promise<Habit> {
     const trimmed = name.trim();
     if (trimmed.length === 0) {


### PR DESCRIPTION
## Summary
This PR implements a fully-featured Settings screen that allows users to manage their habits, configure notification preferences, sync data with the server, and view app information. It also introduces a new CreateHabitModal for adding habits and extends HabitService with additional functionality.

## Key Changes

### Settings Screen (`src/screens/SettingsScreen.tsx`)
- **Complete redesign** from a minimal placeholder to a comprehensive settings interface
- **Habit Management**: Display all habits (active and inactive) with ability to toggle active status and long-press to deactivate
- **Notification Settings**: Toggle daily reminders and select reminder time (0-23 hours) with horizontal time picker
- **Sync Management**: Display unsynced logs count, manual sync button with loading state, and last sync timestamp
- **App Information**: Display app version (0.0.1) and server URL
- Integrated with HabitService and SyncService for data operations
- Uses AsyncStorage for persisting user preferences (reminders, sync timestamps)
- Comprehensive styling with theme colors, typography, and spacing

### Create Habit Modal (`src/screens/CreateHabitModal.tsx`)
- New modal screen for creating habits with form validation
- Text input with 50-character limit and live character counter
- Cancel and Create buttons with proper disabled states
- Trims whitespace and validates non-empty input before creation
- Keyboard-aware layout for iOS and Android

### HabitService Extensions (`src/services/HabitService.ts`)
- Added `getAllHabits()`: Observable stream of all habits sorted by creation date
- Added `toggleHabitActive(habitId)`: Toggle habit active/inactive status

### Navigation Updates (`src/navigation/AppNavigator.tsx`)
- Added CreateHabitModal to the navigation stack

### Test Coverage
- **SettingsScreen tests** (`src/__tests__/screens/SettingsScreen.test.tsx`): 215 lines covering habit listing, toggling, sync status display, version/URL display, and sync functionality
- **CreateHabitModal tests** (`src/__tests__/screens/CreateHabitModal.test.tsx`): 145 lines covering input validation, character counter, creation flow, and cancellation

## Notable Implementation Details
- Settings screen uses RxJS subscriptions for reactive habit updates
- Proper cleanup of subscriptions in useEffect hooks
- Mock services support for dependency injection in tests
- Comprehensive test mocks for AsyncStorage, date-fns, and Alert
- Accessible components with testID and accessibilityLabel attributes
- Responsive time picker with horizontal scroll for hour selection
- Singular/plural handling for "log" vs "logs" in sync status

https://claude.ai/code/session_013ehBiKzRFNYkt5v4iLVgFV