### PR TITLE
Add CI/CD pipeline and improve code quality configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,12 @@
 module.exports = {
   root: true,
-  extends: '@react-native',
+  extends: [
+    '@react-native',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  rules: {
+    'no-console': 'warn',
+  },
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint-and-type-check:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run TypeScript compiler
+        run: npx tsc --noEmit
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest with coverage
+        run: npx jest --coverage --ci
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-cov
+
+      - name: Run pytest with coverage
+        run: pytest --cov=app --cov-report=term-missing --cov-fail-under=85
+
+  e2e-tests:
+    name: E2E Tests
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install CocoaPods dependencies
+        run: cd ios && pod install
+
+      - name: Build Detox debug configuration
+        run: npx detox build --configuration ios.sim.debug
+
+      - name: Run Detox tests
+        run: npx detox test --configuration ios.sim.debug --cleanup

--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ src/
 e2e/             # Detox end-to-end tests
 ```
 
+## CI / Branch Protection
+
+This project uses GitHub Actions for continuous integration. The workflow is defined in `.github/workflows/ci.yml`.
+
+### CI Jobs
+
+| Job                  | Trigger                          | Runner         | Description                                      |
+|----------------------|----------------------------------|----------------|--------------------------------------------------|
+| `lint-and-type-check`| Push/PR to `main`               | `ubuntu-latest`| Runs ESLint and TypeScript compiler (`tsc --noEmit`) |
+| `unit-tests`         | Push/PR to `main`               | `ubuntu-latest`| Runs Jest with `--coverage --ci`, uploads coverage artifact |
+| `backend-tests`      | Push/PR to `main`               | `ubuntu-latest`| Runs pytest with coverage (minimum 85%)          |
+| `e2e-tests`          | Manual (`workflow_dispatch`) or push to `main` | `macos-latest` | Builds and runs Detox E2E tests on iOS Simulator |
+
+### Branch Protection Rules
+
+The following rules should be configured in **Settings > Branches > Branch protection rules** for `main`:
+
+- **Require status checks to pass before merging:**
+  - `lint-and-type-check`
+  - `unit-tests`
+  - `backend-tests`
+- **`e2e-tests`** runs on-demand via `workflow_dispatch` and is **not** a required check (it is expensive and uses a macOS runner).
+
+### Coverage Thresholds
+
+- **Frontend (Jest):** 80% minimum for lines, functions, and branches (enforced in `jest.config.js`).
+- **Backend (pytest):** 85% minimum line coverage (enforced via `--cov-fail-under=85`).
+
 ## Troubleshooting
 
 - **Pod install fails**: Make sure you have the correct Ruby version and run `sudo gem install cocoapods` first.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,20 @@ module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFilesAfterSetup: [],
+  moduleNameMapper: {
+    '^@nozbe/watermelondb$': '<rootDir>/node_modules/@nozbe/watermelondb',
+    '^@nozbe/watermelondb/(.*)$': '<rootDir>/node_modules/@nozbe/watermelondb/$1',
+    '^react-native$': '<rootDir>/node_modules/react-native',
+  },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|@nozbe)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|@nozbe|@notifee|@react-native-async-storage|react-native-safe-area-context|react-native-screens|react-native-uuid)/)',
   ],
+  coverageThreshold: {
+    global: {
+      lines: 80,
+      functions: 80,
+      branches: 80,
+    },
+  },
   forceExit: true,
 };


### PR DESCRIPTION
## Summary
This PR establishes a comprehensive CI/CD pipeline using GitHub Actions and enhances code quality tooling configuration. It introduces automated testing, linting, and type checking across frontend and backend codebases, with clear branch protection rules for the main branch.

## Key Changes

### CI/CD Pipeline (.github/workflows/ci.yml)
- **New GitHub Actions workflow** with four jobs:
  - `lint-and-type-check`: Runs ESLint and TypeScript compiler on every push/PR to main
  - `unit-tests`: Executes Jest tests with coverage reporting and artifact uploads
  - `backend-tests`: Runs pytest with 85% minimum coverage threshold on Python backend
  - `e2e-tests`: Conditional Detox E2E tests on macOS (manual trigger or main branch pushes)
- Configured appropriate runners (ubuntu-latest for most jobs, macos-latest for E2E)
- Coverage artifacts retained for 14 days

### Jest Configuration (jest.config.js)
- Added `moduleNameMapper` to properly resolve WatermelonDB and React Native modules
- Expanded `transformIgnorePatterns` to include additional packages (@notifee, @react-native-async-storage, react-native-safe-area-context, react-native-screens, react-native-uuid)
- **Enforced coverage thresholds**: 80% minimum for lines, functions, and branches

### ESLint Configuration (.eslintrc.js)
- Extended configuration with TypeScript support (`@typescript-eslint/recommended`)
- Added TypeScript parser and plugin
- Added `no-console` rule as warning for better code quality

### Documentation (README.md)
- Added comprehensive CI/CD section documenting:
  - All workflow jobs, triggers, and runners
  - Branch protection rules required for main branch
  - Coverage thresholds for both frontend and backend

## Implementation Details
- E2E tests are intentionally not required checks due to cost and macOS runner constraints
- Backend coverage threshold (85%) is stricter than frontend (80%) to ensure critical backend code quality
- All required checks must pass before merging to main, ensuring code quality standards are maintained

https://claude.ai/code/session_01TsrERnMv36V1DfCjxqNhwt