### PR TITLE
PR 4: Release signing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ android/.cxx/
 !debug.keystore
 android/.kotlin/
 
+# Android signing properties (real values; example template is checked in)
+android/keystore.properties
+
 # Bundle artifacts
 *.jsbundle
 

--- a/android/keystore.properties.example
+++ b/android/keystore.properties.example
@@ -1,0 +1,15 @@
+# Template for android/keystore.properties (gitignored).
+#
+# CI generates the real file from GitHub Actions secrets at build time:
+#   ANDROID_KEYSTORE_BASE64   -> decoded to android/release.keystore
+#   ANDROID_KEYSTORE_PASSWORD -> storePassword
+#   ANDROID_KEY_ALIAS         -> keyAlias
+#   ANDROID_KEY_PASSWORD      -> keyPassword
+#
+# For a local release build, copy this file to android/keystore.properties
+# and fill in the real values. The Gradle release signing config reads these
+# four keys; if the file is absent, the build falls back to debug signing.
+storeFile=release.keystore
+storePassword=<your store password>
+keyAlias=dailyhabittracker
+keyPassword=<your key password>


### PR DESCRIPTION
Adds the repo-side bits for Android release signing. The keystore itself was generated locally and stored offline (1Password + external drive); the four GitHub Actions secrets (ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD) were uploaded separately and are required by PR 5's release job.

## Diff

- Adds `android/keystore.properties.example` documenting the four keys the Gradle release config reads.
- Adds `android/keystore.properties` to `.gitignore` (the `*.keystore` rule already covered the keystore file itself).

## Out of scope here, already done

- Gradle signing config with debug fallback: added in PR 1, Task 1.5.
- GitHub Actions secrets: uploaded via gh CLI (not in this diff).

## Plan reference

- Plan: `docs/superpowers/plans/2026-05-12-android-only-pivot.md` (PR 4)

## Test plan

- [ ] CI passes (the new file is text-only; signing still falls back to debug because keystore.properties isn't in the repo or CI for the gate job)