### PR TITLE
PR 5: Add gated release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,63 @@ jobs:
 
       - name: Assemble release APK
         run: cd android && ./gradlew assembleRelease
+
+  release:
+    name: Release
+    needs: [lint-and-type-check, unit-tests, backend-tests, android-build]
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Derive version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          RUN_COUNT=$(git rev-list --count HEAD)
+          echo "VERSION_CODE=$RUN_COUNT" >> $GITHUB_ENV
+          echo "VERSION_NAME=v${VERSION}-r${RUN_COUNT}" >> $GITHUB_ENV
+          echo "version_name=v${VERSION}-r${RUN_COUNT}" >> $GITHUB_OUTPUT
+
+      - name: Decode keystore
+        run: |
+          printf '%s' "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/release.keystore
+          cat > android/keystore.properties <<EOF
+          storeFile=release.keystore
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          EOF
+
+      - name: Assemble signed release APK
+        run: cd android && ./gradlew assembleRelease
+
+      - name: Verify signing
+        run: $ANDROID_HOME/build-tools/35.0.0/apksigner verify --verbose android/app/build/outputs/apk/release/app-release.apk
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version_name }}" \
+            android/app/build/outputs/apk/release/app-release.apk \
+            --generate-notes \
+            --target ${{ github.sha }}


### PR DESCRIPTION
Adds the release job to ci.yml. On push to main (or workflow_dispatch from main), after all four gate jobs pass, this job pauses for manual approval in the 'production' environment, then decodes the keystore from secrets, builds the signed release APK, verifies APK Signature Scheme v2 + v3 via apksigner, and publishes a GitHub Release with app-release.apk attached.

## Properties

- needs: [lint-and-type-check, unit-tests, backend-tests, android-build] — any gate failure aborts release
- if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' — PRs skip it
- environment: production — manual approval gate
- fetch-depth: 0 — required for git rev-list --count HEAD
- versionCode: git rev-list --count HEAD (monotonic per commit, survives workflow rename)
- versionName: v<package.json.version>-r<count>

## Plan reference

- Plan: docs/superpowers/plans/2026-05-12-android-only-pivot.md (PR 5)

## Required follow-up (manual)

After this PR merges, you need to create the 'production' environment in repo Settings → Environments and add yourself as a required reviewer. Without it, the release job will run unattended. The Settings → Environments page is per-repo.

## Test plan

- [ ] Lint, typecheck, unit tests, backend tests, android-build all pass on the PR
- [ ] Release job is SKIPPED on the PR (PRs don't satisfy the if: condition)
- [ ] After merge + production environment created, workflow_dispatch from main will trigger the full chain and pause for approval