### PR TITLE
PR 6: Phone setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ This project uses GitHub Actions for continuous integration. The workflow is def
 - **Frontend (Jest):** 55% minimum for branches; 80% minimum for lines and functions (enforced in `jest.config.js`).
 - **Backend (pytest):** 85% minimum line coverage (enforced via `--cov-fail-under=85`).
 
+## Distribution
+
+Releases are produced automatically on every push to `main` and published as GitHub Releases with the signed APK attached. The target phone receives silent over-the-air updates via Obtainium. See `docs/android-setup.md` for the one-time phone setup and troubleshooting.
+
 ## Troubleshooting
 
 - **Gradle build fails with Kotlin metadata version error**: Confirm `@react-native-async-storage/async-storage` is pinned to `^2.x` (not `^3.x`); v3 requires Kotlin 2.2+ but RN 0.78 ships Kotlin 2.0.x.

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,28 +1,42 @@
-# Android Setup — Sideload + Obtainium
+# Android Setup — Sideload + Obtainium (tap-to-update)
 
 One-time setup on the target phone. After this, every release published to
-GitHub installs silently within the Obtainium poll interval.
+GitHub triggers a notification on the phone; one tap opens the installer,
+one more tap confirms the update.
+
+## Why tap-to-update (not silent)
+
+The original plan called for silent installs via `adb shell pm grant
+INSTALL_PACKAGES`, but on modern Android (Pixel + Android 14+ at minimum),
+`INSTALL_PACKAGES` is signature-protected and cannot be granted to a normal
+app at runtime. Obtainium's "Install silently" toggle therefore only works
+with one of: Shizuku, root, or device-owner setup — all of which add
+brittleness (Shizuku breaks on reboot; root is a non-starter; device-owner
+requires factory reset).
+
+Tap-to-update is the realistic default for a non-rooted Pixel.
 
 ## Prerequisites
 
 - Phone with Android 7+ (we target API 35).
-- Laptop with `adb` installed (`brew install android-platform-tools` on macOS,
-  or the SDK Platform-Tools from Android Studio on Linux/Windows).
 - A published release on
   https://github.com/domicy/daily-habit-tracker/releases.
+- The repo is public (Obtainium uses unauthenticated GitHub API calls; a
+  private repo returns 404).
 
 ## Steps
 
 ### 1. Enable installation from unknown sources
 
 Settings → Apps → Special app access → Install unknown apps → enable for the
-browser or file manager that will receive the first APK.
+browser or file manager that will receive the first APK, and for Obtainium
+itself.
 
 ### 2. Install Obtainium
 
 Download the latest Obtainium APK from
-https://github.com/ImranR98/Obtainium/releases and install. Obtainium self-
-updates from its own GitHub Releases after the first install.
+https://github.com/ImranR98/Obtainium/releases (or F-Droid) and install.
+Obtainium self-updates from its own GitHub Releases after the first install.
 
 ### 3. First install of DailyHabitTracker
 
@@ -39,55 +53,55 @@ association with the installed DailyHabitTracker app.
 
 In Obtainium settings:
 
-- Update check interval: 1 hour.
+- Update check interval: 1 hour (or any value you like).
 - Auto-update: on.
-- Install method: "Silently" (requires the ADB grant in step 5).
+- Notifications: on.
+- Install method: leave at default ("Normal" / "Prompt"). Do **not** enable
+  "Install silently" — see Why tap-to-update above.
 
-### 5. Grant Obtainium silent-install permission (one-time, via ADB)
-
-Enable USB debugging: Settings → About phone → tap Build Number 7 times,
-then Developer Options → USB debugging → on.
-
-Plug the phone into your laptop, accept the RSA prompt, then run:
-
-```bash
-adb shell pm grant <OBTAINIUM_PACKAGE_NAME> android.permission.INSTALL_PACKAGES
-```
-
-Replace `<OBTAINIUM_PACKAGE_NAME>` with the actual package name. To find it:
-
-```bash
-adb shell pm list packages | grep -i obtainium
-```
-
-At the time of writing this doc the package name is `<INSERT VERIFIED NAME>`.
-Obtainium's namespace has shifted across versions, so always verify.
-
-### 6. Verify the loop
+### 5. Verify the loop
 
 Trigger a release (push to `main`, or `gh workflow run ci.yml --ref main`).
-Wait up to one hour. The phone should install the update silently — no
-notification, no tap.
+Within the Obtainium poll interval (or sooner if you open Obtainium and
+pull-to-refresh):
+
+1. Obtainium shows a notification: "Updates available for DailyHabitTracker".
+2. Tap the notification, or open Obtainium and tap the app.
+3. Tap "Update" / "Install".
+4. Android's standard installer appears; tap "Update".
+5. Done. The app is on the new version.
 
 ## Troubleshooting
 
-Silent updates stopped working? Check, in order of likelihood:
+**Obtainium returns 404 when adding the URL.** Repo is private — make it
+public, or configure Obtainium → the GitHub source with a fine-grained
+Personal Access Token scoped to read this repo only.
 
-1. **ADB grant lost.** Re-run `adb shell pm grant ... INSTALL_PACKAGES`. The
-   grant does NOT survive a factory reset, and may not survive an Obtainium
-   reinstall on some Android versions.
-2. **Obtainium package name changed.** If `pm grant` reports "Unknown
-   package," verify with `pm list packages | grep obtainium`.
-3. **Keystore mismatch.** A new keystore = a new signing identity =
-   Android rejects the APK replacement. Verify the GitHub secret
-   `ANDROID_KEYSTORE_BASE64` matches the keystore originally used to sign
-   the installed version.
-4. **versionCode didn't increment.** Silent installs require monotonically
-   increasing `versionCode`. The release workflow uses
-   `git rev-list --count HEAD`, which should always increase on `main`. If
-   someone force-pushed to `main`, the count could regress.
-5. **Network blocked.** Confirm the phone has internet access during the
-   Obtainium update window.
+**Update notification never appears.** Check, in order:
+1. Network: is the phone online and Obtainium not battery-restricted?
+2. Open Obtainium → tap the app → tap the refresh icon to force a check.
+3. Compare versions: Obtainium shows installed vs. latest. If they match, no
+   update was published.
+4. Confirm the latest release on GitHub actually has `app-release.apk`
+   attached as an asset.
+
+**Install fails with "App not installed: package conflicts with existing
+package".** Signature mismatch. Either the keystore changed (see Keystore
+mismatch below) or you previously installed a debug build over the release
+build (or vice versa). Resolve by uninstalling first, then reinstalling from
+the GitHub release.
+
+**Keystore mismatch:** A new keystore = a new signing identity = Android
+rejects the APK replacement. Verify the GitHub secret
+`ANDROID_KEYSTORE_BASE64` matches the keystore originally used to sign the
+installed version. Recovery: uninstall + reinstall once (loses local-only
+state; backend sync recovers data).
+
+**`versionCode` regression.** Silent installs require monotonically
+increasing `versionCode`. The release workflow uses `git rev-list --count
+HEAD`, which should always increase on `main`. If someone force-pushed to
+`main`, the count could regress; a force-push to revert that history fixes
+it.
 
 ## Apksigner verification (one-time, after first release)
 
@@ -106,15 +120,31 @@ Verified using v2 scheme (APK Signature Scheme v2): true
 Verified using v3 scheme (APK Signature Scheme v3): true
 ```
 
-If v2 is false, silent updates via Obtainium will not work. Fix the signing
-config in `android/app/build.gradle` and reinstall.
+If v2 is false, Android may refuse the APK on modern firmware. Fix the
+signing config in `android/app/build.gradle`.
 
 ## Release pipeline notes
 
-This repo's CI workflow (`.github/workflows/ci.yml`) runs the release job
-automatically on every push to `main`, with no manual approval gate (GitHub
-free-tier private repos cannot enforce `environment` protection rules
-without GitHub Team). Every merge to `main` ships to the phone. Use commit
-discipline accordingly: if you need to pause shipping, either pause
-Obtainium on the phone or commit-revert quickly to ship a fix-forward
-release.
+The CI workflow (`.github/workflows/ci.yml`) runs the release job
+automatically on every push to `main`. The `environment: production` block
+is present in the YAML for future manual-approval support, but private free
+GitHub repos cannot enforce the required-reviewer rule (it needs GitHub
+Team). Since this repo is now public, the environment protection rules
+*are* available — to enable: Settings → Environments → production →
+Required reviewers → add self. Without it, every merge to `main` ships
+immediately.
+
+## Upgrade path: real silent install if you ever want it
+
+Two options if tap-to-update becomes annoying:
+
+1. **Shizuku.** Install from F-Droid, pair via Wireless Debugging (one-time
+   ADB session, persists until phone reboot). Configure Obtainium →
+   Installation → "Use Shizuku" → on. Catch: Shizuku service dies on phone
+   reboot; user must reopen Shizuku and tap "Start via Wireless Debugging"
+   to restore silent installs.
+
+2. **Device owner.** Most powerful but requires factory reset + provisioning
+   Obtainium as device owner. Not practical for an in-use phone.
+
+Neither is recommended for the default setup.

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,0 +1,120 @@
+# Android Setup — Sideload + Obtainium
+
+One-time setup on the target phone. After this, every release published to
+GitHub installs silently within the Obtainium poll interval.
+
+## Prerequisites
+
+- Phone with Android 7+ (we target API 35).
+- Laptop with `adb` installed (`brew install android-platform-tools` on macOS,
+  or the SDK Platform-Tools from Android Studio on Linux/Windows).
+- A published release on
+  https://github.com/domicy/daily-habit-tracker/releases.
+
+## Steps
+
+### 1. Enable installation from unknown sources
+
+Settings → Apps → Special app access → Install unknown apps → enable for the
+browser or file manager that will receive the first APK.
+
+### 2. Install Obtainium
+
+Download the latest Obtainium APK from
+https://github.com/ImranR98/Obtainium/releases and install. Obtainium self-
+updates from its own GitHub Releases after the first install.
+
+### 3. First install of DailyHabitTracker
+
+On the phone, open the latest release on
+https://github.com/domicy/daily-habit-tracker/releases, tap
+`app-release.apk`, install. Open the app once, allow notifications when
+prompted.
+
+### 4. Configure Obtainium
+
+Open Obtainium → "+" → paste
+`https://github.com/domicy/daily-habit-tracker` → save. Confirm
+association with the installed DailyHabitTracker app.
+
+In Obtainium settings:
+
+- Update check interval: 1 hour.
+- Auto-update: on.
+- Install method: "Silently" (requires the ADB grant in step 5).
+
+### 5. Grant Obtainium silent-install permission (one-time, via ADB)
+
+Enable USB debugging: Settings → About phone → tap Build Number 7 times,
+then Developer Options → USB debugging → on.
+
+Plug the phone into your laptop, accept the RSA prompt, then run:
+
+```bash
+adb shell pm grant <OBTAINIUM_PACKAGE_NAME> android.permission.INSTALL_PACKAGES
+```
+
+Replace `<OBTAINIUM_PACKAGE_NAME>` with the actual package name. To find it:
+
+```bash
+adb shell pm list packages | grep -i obtainium
+```
+
+At the time of writing this doc the package name is `<INSERT VERIFIED NAME>`.
+Obtainium's namespace has shifted across versions, so always verify.
+
+### 6. Verify the loop
+
+Trigger a release (push to `main`, or `gh workflow run ci.yml --ref main`).
+Wait up to one hour. The phone should install the update silently — no
+notification, no tap.
+
+## Troubleshooting
+
+Silent updates stopped working? Check, in order of likelihood:
+
+1. **ADB grant lost.** Re-run `adb shell pm grant ... INSTALL_PACKAGES`. The
+   grant does NOT survive a factory reset, and may not survive an Obtainium
+   reinstall on some Android versions.
+2. **Obtainium package name changed.** If `pm grant` reports "Unknown
+   package," verify with `pm list packages | grep obtainium`.
+3. **Keystore mismatch.** A new keystore = a new signing identity =
+   Android rejects the APK replacement. Verify the GitHub secret
+   `ANDROID_KEYSTORE_BASE64` matches the keystore originally used to sign
+   the installed version.
+4. **versionCode didn't increment.** Silent installs require monotonically
+   increasing `versionCode`. The release workflow uses
+   `git rev-list --count HEAD`, which should always increase on `main`. If
+   someone force-pushed to `main`, the count could regress.
+5. **Network blocked.** Confirm the phone has internet access during the
+   Obtainium update window.
+
+## Apksigner verification (one-time, after first release)
+
+After the first release publishes, download the APK and confirm v2 + v3
+signing:
+
+```bash
+gh release download <tag> -p app-release.apk
+apksigner verify --verbose app-release.apk
+```
+
+Expected:
+
+```
+Verified using v2 scheme (APK Signature Scheme v2): true
+Verified using v3 scheme (APK Signature Scheme v3): true
+```
+
+If v2 is false, silent updates via Obtainium will not work. Fix the signing
+config in `android/app/build.gradle` and reinstall.
+
+## Release pipeline notes
+
+This repo's CI workflow (`.github/workflows/ci.yml`) runs the release job
+automatically on every push to `main`, with no manual approval gate (GitHub
+free-tier private repos cannot enforce `environment` protection rules
+without GitHub Team). Every merge to `main` ships to the phone. Use commit
+discipline accordingly: if you need to pause shipping, either pause
+Obtainium on the phone or commit-revert quickly to ship a fix-forward
+release.

--- a/docs/superpowers/specs/2026-05-12-android-only-pivot-design.md
+++ b/docs/superpowers/specs/2026-05-12-android-only-pivot-design.md
@@ -1,7 +1,7 @@
 # Android-Only Pivot — Design
 
 **Date:** 2026-05-12
-**Status:** Approved (pending user review)
+**Status:** Implemented with two deviations (see "Deviations from spec" at the end)
 **Author:** Patrick Darling, with Claude
 
 ## Motivation
@@ -516,3 +516,42 @@ These are decisions deferred from spec to implementation because they depend on 
 - [ ] Re-grep `src/App.tsx`, `src/services/api.ts`, `src/__tests__/services/SyncService.test.ts` for `Platform.OS` and `'ios'` to confirm no real branches were missed in initial scan.
 - [ ] `jest-circus` removal safety — after dropping Detox, run `npm test` without `jest-circus` in `devDependencies` and confirm it still passes (it ships transitively with Jest 27+).
 - [ ] `apksigner verify --verbose` output — confirm v2 + v3 present on first CI release build.
+
+---
+
+## Deviations from spec (added 2026-05-15)
+
+Two real-world constraints required deviating from the design as written. The pivot is functional and shipping, but in slightly different shape than originally specced.
+
+### 1. No manual approval gate at release time
+
+**Spec said:** `environment: production` with a required reviewer in repo Settings → Environments would pause the release job for one-click approval before publishing.
+
+**What actually happened:** GitHub free-tier *private* repos cannot enforce environment protection rules (Required reviewers, deployment branches) — that feature requires GitHub Team or above. The `environment: production` block in `ci.yml` still runs, but it no-ops without protection rules. Every push to `main` ships immediately.
+
+**Resolution:** The repo was subsequently made public (see deviation #2 below), so environment protection rules *are* now available on this repo. To re-enable the approval gate: Settings → Environments → `production` → Required reviewers → add self. This was not done as part of the original implementation; it's available to turn on at any time without code changes.
+
+**Risk accepted in the meantime:** A bad merge silently ships to the phone. Mitigation: commit-revert quickly to ship a fix-forward release, or pause Obtainium on the phone before a risky merge.
+
+### 2. Tap-to-update instead of silent install
+
+**Spec said:** Obtainium → Install silently → on, backed by `adb shell pm grant <obtainium-package> android.permission.INSTALL_PACKAGES`. The plan included the ADB grant as a one-time step.
+
+**What actually happened:** On modern Android (verified on Pixel 6 Pro; same applies to Pixel 10a), `INSTALL_PACKAGES` is a signature-protected permission and cannot be granted to a normal app via `pm grant`. The command rejects with `SecurityException: Permission android.permission.INSTALL_PACKAGES requested by package <X> is not a changeable permission type`. Obtainium's documentation appears to predate this Android hardening. Silent install via Obtainium on a non-rooted Pixel now requires either Shizuku (brittle across phone reboots), root (non-starter), or device-owner setup (requires factory reset).
+
+**Resolution:** Dropped to **tap-to-update**: Obtainium polls, posts a notification when a new release is available, user taps notification → taps Install → done. Two taps per update. Reliable across reboots. Documented in `docs/android-setup.md`.
+
+**Upgrade path:** If two taps per update becomes annoying, the user can install Shizuku and flip Obtainium → "Use Shizuku" → on. Documented in `docs/android-setup.md` under "Upgrade path: real silent install."
+
+### 3. Repo visibility flipped to public
+
+**Spec implied:** repo stays private; Obtainium uses the repo URL directly.
+
+**What actually happened:** Obtainium queries the GitHub REST API unauthenticated by default, which returns 404 on private repos. The repo was made public to resolve this. The Obtainium PAT alternative was offered but not chosen due to PAT rotation overhead.
+
+**Side benefits:**
+- Unlimited Actions minutes (vs 2000/month on private free).
+- Environment protection rules unlocked (see deviation #1).
+
+**Side risks:** All committed config uses placeholders (`<TUNNEL_UUID>`, `change-me`, `api.example.com`, `habit-tracker.tunnel.example.com`); GitHub Actions secrets are never exposed regardless of repo visibility; personal info in git history is the email on commit authors and references to the wife / Pixel 10a context in design docs. Audit was clean before the flip.
+


### PR DESCRIPTION
Adds docs/android-setup.md covering the one-time phone setup procedure (Obtainium install, first APK sideload, configure auto-update, grant INSTALL_PACKAGES via ADB), the silent-update verification loop, apksigner v2/v3 expected output, and troubleshooting for the five most common failure modes.

README gets a Distribution section linking to the new doc.

## Open before merging

The `<INSERT VERIFIED NAME>` placeholder in step 5 of docs/android-setup.md needs to be replaced with the actual Obtainium package name discovered via:

```bash
adb shell pm list packages | grep -i obtainium
```

once Obtainium is installed on the target phone. Will push a follow-up commit once verified.

## Plan reference

- Plan: docs/superpowers/plans/2026-05-12-android-only-pivot.md (PR 6)

## Test plan

- [ ] CI passes
- [ ] After merge, the merge itself triggers the second release; that release should install silently on the Pixel within an hour, confirming the full loop works end-to-end