### PR TITLE
Soft-delete habit log tombstones to keep client and server in sync

### DIFF
--- a/backend/alembic/versions/002_add_deleted_at.py
+++ b/backend/alembic/versions/002_add_deleted_at.py
@@ -1,0 +1,28 @@
+"""add deleted_at tombstone column to habit_logs
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-15
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "habit_logs",
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("habit_logs", "deleted_at")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -40,5 +40,11 @@ class HabitLog(Base):
     synced_at: Mapped[datetime] = mapped_column(
         DateTime, server_default=func.now()
     )
+    # Tombstone timestamp. Null = active log; non-null = deleted by the
+    # client. Deletions are pushed via /logs/sync so the server can stay
+    # in sync after an offline un-toggle of a previously-synced day.
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, default=None
+    )
 
     habit: Mapped["Habit"] = relationship(back_populates="logs")

--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -42,12 +42,15 @@ async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
         result = await db.execute(stmt)
         existing = result.scalar_one_or_none()
 
+        now = datetime.now(timezone.utc)
         if existing:
-            existing.synced_at = datetime.now(timezone.utc)
+            existing.synced_at = now
+            existing.deleted_at = now if entry.deleted else None
         else:
             log = HabitLog(
                 habit_id=entry.habit_id,
                 completed_date=entry.completed_date,
+                deleted_at=now if entry.deleted else None,
             )
             db.add(log)
 
@@ -75,6 +78,7 @@ async def get_logs(
             HabitLog.habit_id == habit_id,
             HabitLog.completed_date >= start,
             HabitLog.completed_date <= end,
+            HabitLog.deleted_at.is_(None),
         )
         .order_by(HabitLog.completed_date)
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -46,6 +46,7 @@ class HabitRead(BaseModel):
 class HabitLogCreate(BaseModel):
     habit_id: str
     completed_date: date
+    deleted: bool = False
 
 
 class HabitLogRead(BaseModel):

--- a/backend/tests/test_logs.py
+++ b/backend/tests/test_logs.py
@@ -117,6 +117,76 @@ async def test_sync_logs_all_invalid(client: AsyncClient, auth_header: dict):
 
 
 @pytest.mark.asyncio
+async def test_sync_logs_deletion_removes_log_from_get(
+    client: AsyncClient, auth_header: dict
+):
+    """Client pushes a tombstone -> server soft-deletes -> GET /logs hides it."""
+    habit_id = await _create_habit(client, auth_header)
+
+    # Create then delete the same log
+    await client.post(
+        "/logs/sync",
+        json={"logs": [{"habit_id": habit_id, "completed_date": "2026-05-01"}]},
+        headers=auth_header,
+    )
+    resp = await client.post(
+        "/logs/sync",
+        json={
+            "logs": [
+                {
+                    "habit_id": habit_id,
+                    "completed_date": "2026-05-01",
+                    "deleted": True,
+                }
+            ]
+        },
+        headers=auth_header,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["synced"] == 1
+
+    # GET should not return the tombstoned log
+    resp = await client.get(
+        f"/logs/{habit_id}?start=2026-05-01&end=2026-05-01", headers=auth_header
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_sync_logs_revive_after_deletion(
+    client: AsyncClient, auth_header: dict
+):
+    """Tombstone then re-create the same date -> log is visible again."""
+    habit_id = await _create_habit(client, auth_header)
+
+    await client.post(
+        "/logs/sync",
+        json={
+            "logs": [
+                {
+                    "habit_id": habit_id,
+                    "completed_date": "2026-05-02",
+                    "deleted": True,
+                }
+            ]
+        },
+        headers=auth_header,
+    )
+    await client.post(
+        "/logs/sync",
+        json={"logs": [{"habit_id": habit_id, "completed_date": "2026-05-02"}]},
+        headers=auth_header,
+    )
+
+    resp = await client.get(
+        f"/logs/{habit_id}?start=2026-05-02&end=2026-05-02", headers=auth_header
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+@pytest.mark.asyncio
 async def test_sync_logs_concurrent_overlapping(client: AsyncClient, auth_header: dict):
     """Simulate two sync requests with overlapping logs — verify no integrity errors."""
     habit_id = await _create_habit(client, auth_header)

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -155,6 +155,39 @@ describe('HabitService', () => {
         .fetch();
       expect(logs).toHaveLength(0);
     });
+
+    it('toggle off of a synced log leaves a tombstone for sync', async () => {
+      const habit = await createTestHabit(database);
+      const date = '2026-03-07';
+      await createTestLog(database, habit.id, date, true);
+
+      await service.toggleHabitCompletion(habit.id, date);
+
+      const logs = await database
+        .get<HabitLog>('habit_logs')
+        .query()
+        .fetch();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].deletedAt).not.toBeNull();
+      expect(logs[0].synced).toBe(false);
+    });
+
+    it('re-toggling a tombstoned day revives the log and marks it unsynced', async () => {
+      const habit = await createTestHabit(database);
+      const date = '2026-03-07';
+      await createTestLog(database, habit.id, date, true);
+
+      await service.toggleHabitCompletion(habit.id, date); // tombstone
+      await service.toggleHabitCompletion(habit.id, date); // revive
+
+      const logs = await database
+        .get<HabitLog>('habit_logs')
+        .query()
+        .fetch();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].deletedAt).toBeNull();
+      expect(logs[0].synced).toBe(false);
+    });
   });
 
   // ─── Streak calculation tests ──────────────────────────────────────
@@ -273,6 +306,19 @@ describe('HabitService', () => {
 
       const streak = await service.calculateStreak(habit.id, '2026-01-01');
       expect(streak).toBe(3);
+    });
+
+    it('does not count tombstoned days', async () => {
+      const habit = await createTestHabit(database);
+      await createTestLog(database, habit.id, '2026-03-05', true);
+      await createTestLog(database, habit.id, '2026-03-06', true);
+      await createTestLog(database, habit.id, '2026-03-07', true);
+
+      // Tombstone the middle day via the service
+      await service.toggleHabitCompletion(habit.id, '2026-03-06');
+
+      const streak = await service.calculateStreak(habit.id, '2026-03-07');
+      expect(streak).toBe(1);
     });
   });
 

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -40,6 +40,7 @@ function createMockLog(habitId: string, completedDate: string) {
     habitId,
     completedDate,
     synced: false,
+    deletedAt: null as number | null,
     markSynced: jest.fn().mockResolvedValue(undefined),
   };
 }

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -32,11 +32,16 @@ jest.mock('react-native', () => ({
   },
 }));
 
-function createMockLog(habitId: string, completedDate: string) {
+function createMockLog(
+  habitId: string,
+  completedDate: string,
+  deletedAt: number | null = null,
+) {
   return {
     habitId,
     completedDate,
     synced: false,
+    deletedAt,
     markSynced: jest.fn().mockResolvedValue(undefined),
   };
 }
@@ -76,8 +81,30 @@ describe('SyncService', () => {
 
       expect(apiClient.post).toHaveBeenCalledWith('/logs/sync', {
         logs: [
-          {habit_id: 'habit-1', completed_date: '2025-01-01'},
-          {habit_id: 'habit-2', completed_date: '2025-01-02'},
+          {habit_id: 'habit-1', completed_date: '2025-01-01', deleted: false},
+          {habit_id: 'habit-2', completed_date: '2025-01-02', deleted: false},
+        ],
+      });
+    });
+
+    it('flags tombstoned logs as deleted in the payload', async () => {
+      const logs = [
+        createMockLog('habit-1', '2025-01-01'),
+        createMockLog('habit-2', '2025-01-02', Date.now()),
+      ];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockResolvedValueOnce({
+        data: {synced: 2, errors: []},
+      });
+
+      await syncService.pushUnsyncedLogs();
+
+      expect(apiClient.post).toHaveBeenCalledWith('/logs/sync', {
+        logs: [
+          {habit_id: 'habit-1', completed_date: '2025-01-01', deleted: false},
+          {habit_id: 'habit-2', completed_date: '2025-01-02', deleted: true},
         ],
       });
     });

--- a/src/models/HabitLog.ts
+++ b/src/models/HabitLog.ts
@@ -3,9 +3,11 @@ import {field, relation, writer} from '@nozbe/watermelondb/decorators';
 import type {Relation} from '@nozbe/watermelondb';
 import type Habit from './Habit';
 
-// NOTE: The pair (habit_id, completed_date) should be treated as logically
-// unique. Enforce this in the service layer since WatermelonDB does not
-// support compound unique constraints natively.
+// NOTE: The pair (habit_id, completed_date) is logically unique among
+// non-tombstoned rows. Tombstones (deletedAt != null) are kept after a
+// log is "uncompleted" so the deletion can be pushed to the server;
+// without them, an offline un-toggle of a previously-synced day would
+// leave the server permanently out of sync with the client.
 
 export default class HabitLog extends Model {
   static table = 'habit_logs';
@@ -18,6 +20,7 @@ export default class HabitLog extends Model {
   // Plain string in "YYYY-MM-DD" format to avoid timezone issues.
   @field('completed_date') completedDate!: string;
   @field('synced') synced!: boolean;
+  @field('deleted_at') deletedAt!: number | null;
 
   @relation('habits', 'habit_id') habit!: Relation<Habit>;
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,11 +1,13 @@
 import {Database} from '@nozbe/watermelondb';
 import SQLiteAdapter from '@nozbe/watermelondb/adapters/sqlite';
 import {schema} from './schema';
+import {migrations} from './migrations';
 import Habit from './Habit';
 import HabitLog from './HabitLog';
 
 const adapter = new SQLiteAdapter({
   schema,
+  migrations,
   jsi: true,
 });
 

--- a/src/models/migrations.ts
+++ b/src/models/migrations.ts
@@ -1,0 +1,18 @@
+import {
+  schemaMigrations,
+  addColumns,
+} from '@nozbe/watermelondb/Schema/migrations';
+
+export const migrations = schemaMigrations({
+  migrations: [
+    {
+      toVersion: 2,
+      steps: [
+        addColumns({
+          table: 'habit_logs',
+          columns: [{name: 'deleted_at', type: 'number', isOptional: true}],
+        }),
+      ],
+    },
+  ],
+});

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export const schema = appSchema({
-  version: 1,
+  version: 2,
   tables: [
     tableSchema({
       name: 'habits',
@@ -17,10 +17,16 @@ export const schema = appSchema({
         {name: 'habit_id', type: 'string', isIndexed: true},
         // Stored as "YYYY-MM-DD" string to avoid timezone issues.
         // NOTE: The pair (habit_id, completed_date) should be treated as
-        // logically unique. Enforce this in the service layer since
-        // WatermelonDB does not support compound unique constraints natively.
+        // logically unique among non-tombstoned rows. Enforce this in the
+        // service layer since WatermelonDB does not support compound unique
+        // constraints natively.
         {name: 'completed_date', type: 'string'},
         {name: 'synced', type: 'boolean', isIndexed: true},
+        // Tombstone timestamp (ms). Null = active log; non-null = deleted.
+        // Tombstones are kept locally until the deletion has been pushed
+        // to the server, after which they remain as "synced deletions"
+        // so that any concurrent revival can be detected and pushed.
+        {name: 'deleted_at', type: 'number', isOptional: true},
       ],
     }),
   ],

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -68,15 +68,40 @@ export default class HabitService {
         )
         .fetch();
 
-      if (existing.length > 0) {
-        await existing[0].destroyPermanently();
-      } else {
-        await this.database.get<HabitLog>('habit_logs').create(log => {
-          log.habitId = habitId;
-          log.completedDate = date;
+      const active = existing.find(l => l.deletedAt == null);
+      if (active) {
+        if (active.synced) {
+          // Server has this log — leave a tombstone so the deletion gets
+          // pushed on the next sync. Without this, an offline un-toggle
+          // would silently desync from the server forever.
+          await active.update(log => {
+            log.deletedAt = Date.now();
+            log.synced = false;
+          });
+        } else {
+          // Never reached the server — safe to drop the row entirely.
+          await active.destroyPermanently();
+        }
+        return;
+      }
+
+      const tombstone = existing.find(l => l.deletedAt != null);
+      if (tombstone) {
+        // Re-toggling on a previously-deleted day: revive the row and
+        // mark it for re-sync so the server clears its deleted_at.
+        await tombstone.update(log => {
+          log.deletedAt = null;
           log.synced = false;
         });
+        return;
       }
+
+      await this.database.get<HabitLog>('habit_logs').create(log => {
+        log.habitId = habitId;
+        log.completedDate = date;
+        log.synced = false;
+        log.deletedAt = null;
+      });
     });
   }
 
@@ -95,6 +120,7 @@ export default class HabitService {
         Q.where('habit_id', habitId),
         Q.where('completed_date', Q.gte(startDate)),
         Q.where('completed_date', Q.lte(endDate)),
+        Q.where('deleted_at', null),
       )
       .fetch();
   }
@@ -127,6 +153,7 @@ export default class HabitService {
         Q.where('habit_id', habitId),
         Q.where('completed_date', Q.gte(cutoffDate)),
         Q.where('completed_date', Q.lte(asOfDate)),
+        Q.where('deleted_at', null),
       )
       .fetch();
 

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -124,6 +124,7 @@ export default class SyncService {
       logs: logs.map(log => ({
         habit_id: log.habitId,
         completed_date: log.completedDate,
+        deleted: log.deletedAt != null,
       })),
     };
 


### PR DESCRIPTION
## Summary

Fixes finding **N-C1** — un-toggling a previously-synced completion silently desynced from the server.

- `HabitService.toggleHabitCompletion` used to call `destroyPermanently()` on the local row. The sync protocol is push-only with upsert semantics and no delete endpoint, so the server kept the deleted completion forever. After a reinstall/restore, streak math would silently diverge.
- Add `deleted_at` (tombstone) column on `habit_logs` — client schema bumped to v2 with a WatermelonDB migration; backend gets Alembic revision `002_add_deleted_at`.
- Toggle logic now: synced rows are tombstoned (`deleted_at = now`, `synced = false`) so the deletion can be pushed; unsynced rows are still hard-deleted (no need to tell the server about something it never saw); re-toggling a tombstoned day revives the row and re-syncs.
- `SyncService` includes `{deleted: bool}` per log in the `/logs/sync` payload; the backend upserts `deleted_at` accordingly.
- Streak and range queries now filter out tombstones on both ends, so `GET /logs/{habit_id}` and `calculateStreak` stay consistent.

## Test plan

- [x] `npx jest` — 182 tests pass, including new tests for: tombstoning a synced toggle-off, reviving on re-toggle, streak skipping tombstoned days, and `SyncService` sending the `deleted` flag.
- [x] `pytest backend/tests` — 41 tests pass, including new tests for sync deletion → hidden from `GET /logs`, and sync revival after deletion.
- [x] `tsc --noEmit` clean.
- [ ] Manual: install on a device with previously-synced data, un-toggle a past day offline, come online, and confirm the server reflects the deletion (Alembic upgrade needs to run first).

---
_Generated by [Claude Code](https://claude.ai/code/session_016LMamhu9CyNacefxGs5a3z)_