### PR TITLE
Decode JWT payload as base64url in SyncService

### DIFF
--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -37,7 +37,9 @@ function decodeJwtPayload(token: string): {exp?: number} {
     if (parts.length !== 3) {
       return {};
     }
-    const payload = JSON.parse(atob(parts[1]));
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const payload = JSON.parse(atob(padded));
     return payload;
   } catch {
     return {};


### PR DESCRIPTION
## Summary
- `decodeJwtPayload` in `src/services/SyncService.ts` used `atob(parts[1])` directly, which requires strict base64. Real JWTs (signed by python-jose on the backend) use base64url — `+`→`-`, `/`→`_`, and may omit `=` padding.
- For any payload whose base64 chunk happened to contain a URL-safe substitution, `atob` threw, the catch silently returned `{}`, and `isAuthenticated()` reported `false`. The Settings sync badge would intermittently flip to "offline" for fully-online users depending on the `exp` value.
- The existing unit test only exercises a trivial `{sub, exp}` payload whose base64 happens to be URL-safe, so it never tripped the bug.

Fix: convert base64url → base64 and re-pad before `atob`:

```ts
const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
const payload = JSON.parse(atob(padded));
```

## Test plan
- [ ] Add a unit test that decodes a JWT payload containing characters that base64url-substitute (`-`/`_`) and verifies `isAuthenticated()` returns `true` while `exp` is in the future.
- [ ] Sign in against the real backend and confirm the Settings sync badge stays "online" across a fresh token.

https://claude.ai/code/session_01TBESrsLVMRhggNCrDdKLV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBESrsLVMRhggNCrDdKLV2)_