### PR TITLE
Use atomic upsert for /logs/sync so concurrent requests stop crashing

### DIFF
--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -1,7 +1,10 @@
+import uuid
 from datetime import date, datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
+from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
@@ -16,13 +19,47 @@ router = APIRouter(
 )
 
 
+def _upsert_habit_log_stmt(dialect_name: str, values: dict[str, Any]):
+    """Build a dialect-native atomic upsert for habit_logs.
+
+    Required because two concurrent /logs/sync requests racing on the same
+    (habit_id, completed_date) both pass a SELECT existence check and then
+    both INSERT, violating uq_habit_date on the second commit.
+    """
+    if dialect_name in ("mysql", "mariadb"):
+        stmt = mysql.insert(HabitLog).values(**values)
+        return stmt.on_duplicate_key_update(
+            synced_at=stmt.inserted.synced_at,
+            deleted_at=stmt.inserted.deleted_at,
+        )
+    if dialect_name == "postgresql":
+        stmt = postgresql.insert(HabitLog).values(**values)
+        return stmt.on_conflict_do_update(
+            constraint="uq_habit_date",
+            set_={
+                "synced_at": stmt.excluded.synced_at,
+                "deleted_at": stmt.excluded.deleted_at,
+            },
+        )
+    if dialect_name == "sqlite":
+        stmt = sqlite.insert(HabitLog).values(**values)
+        return stmt.on_conflict_do_update(
+            index_elements=["habit_id", "completed_date"],
+            set_={
+                "synced_at": stmt.excluded.synced_at,
+                "deleted_at": stmt.excluded.deleted_at,
+            },
+        )
+    raise NotImplementedError(f"Unsupported dialect for upsert: {dialect_name}")
+
+
 @router.post("/sync", response_model=SyncResponse)
 async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
     synced = 0
     errors: list[SyncError] = []
+    dialect_name = db.bind.dialect.name
 
     for entry in body.logs:
-        # Check if the habit exists
         habit = await db.get(Habit, entry.habit_id)
         if not habit:
             errors.append(
@@ -34,26 +71,15 @@ async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
             )
             continue
 
-        # Upsert: check if log already exists
-        stmt = select(HabitLog).where(
-            HabitLog.habit_id == entry.habit_id,
-            HabitLog.completed_date == entry.completed_date,
-        )
-        result = await db.execute(stmt)
-        existing = result.scalar_one_or_none()
-
         now = datetime.now(timezone.utc)
-        if existing:
-            existing.synced_at = now
-            existing.deleted_at = now if entry.deleted else None
-        else:
-            log = HabitLog(
-                habit_id=entry.habit_id,
-                completed_date=entry.completed_date,
-                deleted_at=now if entry.deleted else None,
-            )
-            db.add(log)
-
+        values = {
+            "id": str(uuid.uuid4()),
+            "habit_id": entry.habit_id,
+            "completed_date": entry.completed_date,
+            "synced_at": now,
+            "deleted_at": now if entry.deleted else None,
+        }
+        await db.execute(_upsert_habit_log_stmt(dialect_name, values))
         synced += 1
 
     await db.commit()

--- a/backend/tests/test_logs.py
+++ b/backend/tests/test_logs.py
@@ -1,7 +1,15 @@
+import asyncio
 import uuid
 
 import pytest
-from httpx import AsyncClient
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.database import get_db
+from app.main import app
+from app.models import Base
 
 
 # ── Helper ──────────────────────────────────────────────
@@ -225,6 +233,84 @@ async def test_sync_logs_concurrent_overlapping(client: AsyncClient, auth_header
     dates = [log["completed_date"] for log in logs]
     assert len(dates) == 3
     assert sorted(dates) == ["2026-04-01", "2026-04-02", "2026-04-03"]
+
+
+# ── POST /logs/sync truly concurrent ────────────────────
+
+
+@pytest_asyncio.fixture
+async def concurrent_client():
+    """Client whose get_db yields a fresh session per request against a
+    shared in-memory SQLite engine, enabling real concurrent requests."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async def _override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sync_logs_truly_concurrent_overlapping(
+    concurrent_client: AsyncClient, auth_header: dict
+):
+    """Two simultaneous sync requests with an overlapping (habit_id,
+    completed_date) must both succeed without raising uq_habit_date.
+
+    Note: SQLite serializes writes on a shared connection, so this test
+    cannot fully reproduce the MVCC interleaving that triggers the race
+    on MySQL/Postgres. It still acts as a behavioral contract: dispatch
+    two overlapping requests via asyncio.gather and demand 200s + no
+    duplicate rows. The real correctness guarantee comes from using a
+    dialect-native atomic upsert in the route handler."""
+    habit_id = await _create_habit(concurrent_client, auth_header)
+
+    payload1 = {
+        "logs": [
+            {"habit_id": habit_id, "completed_date": "2026-04-01"},
+            {"habit_id": habit_id, "completed_date": "2026-04-02"},
+        ]
+    }
+    payload2 = {
+        "logs": [
+            {"habit_id": habit_id, "completed_date": "2026-04-02"},
+            {"habit_id": habit_id, "completed_date": "2026-04-03"},
+        ]
+    }
+
+    resp1, resp2 = await asyncio.gather(
+        concurrent_client.post("/logs/sync", json=payload1, headers=auth_header),
+        concurrent_client.post("/logs/sync", json=payload2, headers=auth_header),
+    )
+
+    assert resp1.status_code == 200, resp1.text
+    assert resp2.status_code == 200, resp2.text
+    assert resp1.json()["synced"] == 2
+    assert resp2.json()["synced"] == 2
+
+    resp = await concurrent_client.get(
+        f"/logs/{habit_id}?start=2026-04-01&end=2026-04-03", headers=auth_header
+    )
+    assert resp.status_code == 200
+    dates = sorted(log["completed_date"] for log in resp.json())
+    assert dates == ["2026-04-01", "2026-04-02", "2026-04-03"]
 
 
 # ── GET /logs/{habit_id} ────────────────────────────────


### PR DESCRIPTION
## Summary

`POST /logs/sync` implements upsert as SELECT-then-INSERT-or-UPDATE at the ORM level, which is not atomic. Two simultaneous syncs for the same `(habit_id, completed_date)` both observe no existing row, both `db.add()`, and the second `commit()` raises `IntegrityError` on `uq_habit_date` — the whole request returns 500 and `SyncService.handleSyncError` silently swallows it, leaving the entire batch unsynced.

This PR switches the route to a dialect-native atomic upsert:

- MySQL/MariaDB: `mysql.insert(...).on_duplicate_key_update(...)`
- Postgres: `postgresql.insert(...).on_conflict_do_update(...)` on `uq_habit_date`
- SQLite (tests): `sqlite.insert(...).on_conflict_do_update(...)` on `(habit_id, completed_date)`

The existing `test_sync_logs_concurrent_overlapping` test explicitly admits it's sequential, so a new `test_sync_logs_truly_concurrent_overlapping` is added that dispatches overlapping syncs through `asyncio.gather` against a per-request-session client. The test's docstring notes that SQLite serializes writes on the test pool, so it acts as a behavioral contract rather than a full reproduction of the MVCC race — the real correctness guarantee is the atomic statement.

## Test plan

- [x] `pytest backend/tests/test_logs.py` — 19 passed (18 existing + 1 new)
- [x] `pytest backend/tests` — 47 passed
- [ ] Manual smoke against MySQL: fire two overlapping `/logs/sync` requests and confirm both return 200


---
_Generated by [Claude Code](https://claude.ai/code/session_012ak5UYAvooHRDJcvLJALeZ)_