### PR TITLE
Only mark sync auth as failed on a real 401 from /auth/token

### DIFF
--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -396,6 +396,69 @@ describe('SyncService Hardening', () => {
       expect(logs[0].markSynced).not.toHaveBeenCalled();
     });
 
+    it('does NOT set auth_failed flag when re-auth fails with a network error', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      const authError = {
+        response: {status: 401, data: {detail: 'Token expired'}},
+        message: 'Unauthorized',
+      };
+      const networkError = {message: 'Network Error'};
+      (apiClient.post as jest.Mock)
+        .mockRejectedValueOnce(authError)
+        .mockRejectedValueOnce(networkError);
+
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+        if (key === SYNC_SECRET_KEY) {
+          return Promise.resolve('my-secret');
+        }
+        if (key === SYNC_AUTH_FAILED_KEY) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(result).toEqual({pushed: 0, failed: 0});
+    });
+
+    it('does NOT set auth_failed flag when re-auth fails with a 5xx error', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      const authError = {
+        response: {status: 401, data: {detail: 'Token expired'}},
+        message: 'Unauthorized',
+      };
+      const serverError = {
+        response: {status: 502, data: {detail: 'Bad Gateway'}},
+        message: 'Server Error',
+      };
+      (apiClient.post as jest.Mock)
+        .mockRejectedValueOnce(authError)
+        .mockRejectedValueOnce(serverError);
+
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+        if (key === SYNC_SECRET_KEY) {
+          return Promise.resolve('my-secret');
+        }
+        if (key === SYNC_AUTH_FAILED_KEY) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(result).toEqual({pushed: 0, failed: 0});
+    });
+
     it('sets auth_failed flag when no stored secret exists for re-auth', async () => {
       const logs = [createMockLog('habit-1', '2025-01-01')];
       const habitService = createMockHabitService(logs);

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -298,8 +298,10 @@ export default class SyncService {
       await AsyncStorage.setItem(AUTH_TOKEN_KEY, access_token);
       await AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY);
       return true;
-    } catch {
-      await AsyncStorage.setItem(SYNC_AUTH_FAILED_KEY, 'true');
+    } catch (e) {
+      if (is401Error(e as SyncError)) {
+        await AsyncStorage.setItem(SYNC_AUTH_FAILED_KEY, 'true');
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- `SyncService.attemptReauth` was setting `sync_auth_failed=true` on any error from `/auth/token`. A tunnel outage or 502 during a token-expiry retry would lock sync until the user manually re-entered the secret in Settings (nothing in the UI clears the flag automatically).
- Narrow the flag to real `401`s via `is401Error`. Network failures and 5xx now bubble up as transient — the next sync attempt retries normally.

## Test plan
- [x] Added two new cases to `SyncService.hardening.test.ts` covering re-auth failing with a network error and with a 502, asserting `SYNC_AUTH_FAILED_KEY` is never set to `'true'`.
- [x] Existing 401 re-auth and "no stored secret" cases still set the flag.
- [x] `npm test -- src/__tests__/services/SyncService.hardening.test.ts` — 34/34 passing.
- [x] `npx tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm6EUg36EDxMA6wvS8pf6r)_