### PR TITLE
Batch markSynced into a single WatermelonDB transaction

### DIFF
--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -405,6 +405,52 @@ describe('HabitService', () => {
     });
   });
 
+  // ─── markLogsSynced / markHabitsSynced ─────────────────────────────
+
+  describe('markLogsSynced', () => {
+    it('flips synced=true on every log in the batch', async () => {
+      const habit = await createTestHabit(database, 'h', true);
+      const log1 = await createTestLog(database, habit.id, '2025-01-01', false);
+      const log2 = await createTestLog(database, habit.id, '2025-01-02', false);
+
+      await service.markLogsSynced([log1, log2]);
+
+      const remaining = await service.getUnsyncedLogs();
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('is a no-op for an empty batch', async () => {
+      await expect(service.markLogsSynced([])).resolves.toBeUndefined();
+    });
+
+    it('only marks the logs that were passed in', async () => {
+      const habit = await createTestHabit(database, 'h', true);
+      const log1 = await createTestLog(database, habit.id, '2025-01-01', false);
+      await createTestLog(database, habit.id, '2025-01-02', false);
+
+      await service.markLogsSynced([log1]);
+
+      const remaining = await service.getUnsyncedLogs();
+      expect(remaining.map(l => l.completedDate)).toEqual(['2025-01-02']);
+    });
+  });
+
+  describe('markHabitsSynced', () => {
+    it('flips synced=true on every habit in the batch', async () => {
+      const h1 = await createTestHabit(database, 'a', false);
+      const h2 = await createTestHabit(database, 'b', false);
+
+      await service.markHabitsSynced([h1, h2]);
+
+      const remaining = await service.getUnsyncedHabits();
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('is a no-op for an empty batch', async () => {
+      await expect(service.markHabitsSynced([])).resolves.toBeUndefined();
+    });
+  });
+
   // ─── getActiveHabits ───────────────────────────────────────────────
 
   describe('getActiveHabits', () => {

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -52,6 +52,20 @@ function createMockHabitService(logs: ReturnType<typeof createMockLog>[] = []) {
     // already synced; an empty unsynced-habits result keeps the new
     // habit-push step a no-op so existing assertions still hold.
     getUnsyncedHabits: jest.fn().mockResolvedValue([]),
+    markLogsSynced: jest
+      .fn()
+      .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {
+        for (const log of batch) {
+          await log.markSynced();
+        }
+      }),
+    markHabitsSynced: jest
+      .fn()
+      .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {
+        for (const habit of batch) {
+          await habit.markSynced();
+        }
+      }),
   } as unknown as HabitService;
 }
 

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -64,6 +64,20 @@ function createMockHabitService(
   return {
     getUnsyncedLogs: jest.fn().mockResolvedValue(logs),
     getUnsyncedHabits: jest.fn().mockResolvedValue(habits),
+    markLogsSynced: jest
+      .fn()
+      .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {
+        for (const log of batch) {
+          await log.markSynced();
+        }
+      }),
+    markHabitsSynced: jest
+      .fn()
+      .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {
+        for (const habit of batch) {
+          await habit.markSynced();
+        }
+      }),
   } as unknown as HabitService;
 }
 

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -141,6 +141,36 @@ export default class HabitService {
       .fetch();
   }
 
+  async markLogsSynced(logs: HabitLog[]): Promise<void> {
+    if (logs.length === 0) {
+      return;
+    }
+    await this.database.write(async () => {
+      await this.database.batch(
+        ...logs.map(log =>
+          log.prepareUpdate(l => {
+            l.synced = true;
+          }),
+        ),
+      );
+    });
+  }
+
+  async markHabitsSynced(habits: Habit[]): Promise<void> {
+    if (habits.length === 0) {
+      return;
+    }
+    await this.database.write(async () => {
+      await this.database.batch(
+        ...habits.map(habit =>
+          habit.prepareUpdate(h => {
+            h.synced = true;
+          }),
+        ),
+      );
+    });
+  }
+
   async calculateStreak(
     habitId: string,
     asOfDate: string,

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -174,11 +174,8 @@ export default class SyncService {
 
     const syncedIds: string[] = response!.data?.synced_ids ?? [];
     const syncedSet = new Set(syncedIds);
-    for (const habit of unsyncedHabits) {
-      if (syncedSet.has(habit.id)) {
-        await habit.markSynced();
-      }
-    }
+    const syncedHabits = unsyncedHabits.filter(habit => syncedSet.has(habit.id));
+    await this.habitService.markHabitsSynced(syncedHabits);
     // Only proceed to logs if every habit was accepted; otherwise some logs
     // would still hit "Habit not found".
     return syncedSet.size === unsyncedHabits.length;
@@ -230,9 +227,7 @@ export default class SyncService {
       log => !errorSet.has(`${log.habitId}:${log.completedDate}`),
     );
 
-    for (const log of succeeded) {
-      await log.markSynced();
-    }
+    await this.habitService.markLogsSynced(succeeded);
 
     const errorMessages = (syncErrors || []).map(
       (e: {habit_id: string; completed_date: string; reason: string}) =>


### PR DESCRIPTION
## Summary
- `SyncService.pushBatch` and `pushUnsyncedHabits` previously awaited `model.markSynced()` per row, opening a fresh `@writer` transaction for each one. A 100-log batch produced 100 sequential SQLite commits, and a mid-loop crash left local rows desynced from the server while `result.pushed` reported the server-side count.
- Add `HabitService.markLogsSynced` / `markHabitsSynced` that combine `prepareUpdate()` calls into a single `database.batch()` inside one `database.write()`, and route `SyncService` through them.
- The model-level `@writer markSynced` methods stay in place for direct callers / unit tests.

## Test plan
- [x] `npx tsc --noEmit` — clean (only pre-existing config deprecation warnings)
- [x] `npx jest src/__tests__/services/SyncService.test.ts src/__tests__/services/SyncService.hardening.test.ts` — 54/54 pass
- [x] `npx jest src/__tests__/services/HabitService.test.ts src/__tests__/models/models.test.ts` — 33/33 pass
- [x] `npx jest` — 188/188 pass
- [x] `npx eslint` on touched files — no new errors/warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_012UqDi1DXsuYZseVCsBNdxD)_