### PR TITLE
Subscribe SettingsScreen pending-sync count to a live observable

### DIFF
--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -78,6 +78,7 @@ function createMockHabitService(
     getActiveHabits: jest.fn().mockReturnValue(of([])),
     toggleHabitActive: jest.fn().mockResolvedValue(undefined),
     getUnsyncedLogs: jest.fn().mockResolvedValue(unsyncedLogs),
+    observeUnsyncedCount: jest.fn().mockReturnValue(of(unsyncedCount)),
     createHabit: jest.fn().mockResolvedValue(undefined),
     toggleHabitCompletion: jest.fn().mockResolvedValue(undefined),
     calculateStreak: jest.fn().mockResolvedValue(0),

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -451,6 +451,47 @@ describe('HabitService', () => {
     });
   });
 
+  // ─── observeUnsyncedCount ──────────────────────────────────────────
+
+  describe('observeUnsyncedCount', () => {
+    it('emits the combined count of unsynced logs and habits and reacts to changes', async () => {
+      const habit = await createTestHabit(database, 'h', true);
+
+      const observable = service.observeUnsyncedCount();
+      const emissions: number[] = [];
+      const sub = observable.subscribe(v => emissions.push(v));
+
+      const waitForCount = (target: number) =>
+        new Promise<void>((resolve, reject) => {
+          const start = Date.now();
+          const check = () => {
+            if (emissions[emissions.length - 1] === target) {
+              resolve();
+            } else if (Date.now() - start > 2000) {
+              reject(
+                new Error(
+                  `timeout waiting for count ${target}; emissions=${JSON.stringify(emissions)}`,
+                ),
+              );
+            } else {
+              setTimeout(check, 10);
+            }
+          };
+          check();
+        });
+
+      await waitForCount(0);
+
+      await createTestLog(database, habit.id, '2026-03-01', false);
+      await waitForCount(1);
+
+      await service.toggleHabitActive(habit.id);
+      await waitForCount(2);
+
+      sub.unsubscribe();
+    });
+  });
+
   // ─── getActiveHabits ───────────────────────────────────────────────
 
   describe('getActiveHabits', () => {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -49,9 +49,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
 
   const allHabits$ = useMemo(() => hService.getAllHabits(), [hService]);
   const habits = useHabitObservable<Habit[]>(allHabits$, []);
+  const unsyncedCount$ = useMemo(() => hService.observeUnsyncedCount(), [hService]);
+  const unsyncedCount = useHabitObservable<number>(unsyncedCount$, 0);
   const [reminderEnabled, setReminderEnabled] = useState(false);
   const [reminderTime, setReminderTime] = useState('08:00');
-  const [unsyncedCount, setUnsyncedCount] = useState(0);
   const [syncStatus, setSyncStatus] = useState<'online' | 'offline' | 'auth_failed'>('online');
   const [lastSyncTime, setLastSyncTime] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
@@ -70,16 +71,17 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     })();
   }, []);
 
-  // Load sync info
+  // Load sync info (status + last-sync timestamp). The pending count is
+  // sourced from observeUnsyncedCount above so it updates live as the user
+  // edits habits on other tabs without remounting this screen.
   useEffect(() => {
     (async () => {
       const status = await sService.getSyncStatus();
-      setUnsyncedCount(status.pendingCount);
       setSyncStatus(status.status);
       const ts = await AsyncStorage.getItem(LAST_SYNC_KEY);
       setLastSyncTime(ts);
     })();
-  }, [hService, sService]);
+  }, [sService]);
 
   const handleToggleActive = useCallback(
     async (habitId: string) => {
@@ -146,7 +148,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         setLastSyncTime(now);
       }
       const status = await sService.getSyncStatus();
-      setUnsyncedCount(status.pendingCount);
       setSyncStatus(status.status);
     } finally {
       setSyncing(false);

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -1,6 +1,7 @@
 import {Q} from '@nozbe/watermelondb';
 import type {Database} from '@nozbe/watermelondb';
-import type {Observable} from 'rxjs';
+import {combineLatest, type Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 import {subDays, format} from 'date-fns';
 import type Habit from '../models/Habit';
 import type HabitLog from '../models/HabitLog';
@@ -169,6 +170,20 @@ export default class HabitService {
         ),
       );
     });
+  }
+
+  observeUnsyncedCount(): Observable<number> {
+    const logs$ = this.database
+      .get<HabitLog>('habit_logs')
+      .query(Q.where('synced', false))
+      .observe();
+    const habits$ = this.database
+      .get<Habit>('habits')
+      .query(Q.where('synced', false))
+      .observe();
+    return combineLatest([logs$, habits$]).pipe(
+      map(([logs, habits]) => logs.length + habits.length),
+    );
   }
 
   async calculateStreak(


### PR DESCRIPTION
## Summary

`SettingsScreen`'s unsynced-count `useEffect` (src/screens/SettingsScreen.tsx:74-82) depended only on the stable `hService` / `sService` singletons, so it ran exactly once at mount. With bottom-tab navigation the screen stays mounted across tab switches, so creating or toggling a habit on the Dashboard tab left the "N logs pending" count stale until the user manually tapped Sync Now.

## Changes

- Added `HabitService.observeUnsyncedCount()` that combines two WatermelonDB queries (`habits` and `habit_logs` where `synced = false`) via `combineLatest` and emits the summed count.
- Replaced the one-shot pending-count state in `SettingsScreen` with `useHabitObservable(unsyncedCount$, 0)`, so the count reflects edits made on other tabs in real time. The status / last-sync `useEffect` stays as-is (status changes are user-initiated and infrequent).
- Updated the `SettingsScreen` test mock to return an observable for `observeUnsyncedCount`, and added a `HabitService` test that verifies the observable re-emits when logs and habits are created.

## Test plan

- [x] `npx jest` — 189 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Manual: toggle a habit on Dashboard tab, switch to Settings, verify the pending count updates without tapping Sync Now

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMNYCyFsbGTFXUQK47LJtM)_