### PR TITLE
Update lastSyncTime on every successful Sync Now

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -139,15 +139,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   const handleSyncNow = useCallback(async () => {
     setSyncing(true);
     try {
-      const result = await sService.pushUnsyncedLogs();
-      if (result.pushed > 0) {
+      await sService.pushUnsyncedLogs();
+      const status = await sService.getSyncStatus();
+      setUnsyncedCount(status.pendingCount);
+      setSyncStatus(status.status);
+      if (status.status !== 'offline' && status.status !== 'auth_failed') {
         const now = new Date().toISOString();
         await AsyncStorage.setItem(LAST_SYNC_KEY, now);
         setLastSyncTime(now);
       }
-      const status = await sService.getSyncStatus();
-      setUnsyncedCount(status.pendingCount);
-      setSyncStatus(status.status);
     } finally {
       setSyncing(false);
     }


### PR DESCRIPTION
## Summary
- `handleSyncNow` in `src/screens/SettingsScreen.tsx` only persisted `lastSyncTime` when `result.pushed > 0`, so a successful "Sync Now" with no pending logs left an old/stale timestamp visible indefinitely.
- A successful sync — even with nothing to push — still confirms connectivity, so the timestamp should advance.
- Moved the timestamp update to after `getSyncStatus()` and gated it on `status.status !== 'offline' && status.status !== 'auth_failed'`, using the freshly fetched status rather than stale React state.

## Test plan
- [ ] Press "Sync Now" with zero pending logs and verify the `Last synced` stamp advances.
- [ ] Press "Sync Now" with pending logs and verify the stamp still updates after the push.
- [ ] Press "Sync Now" while offline / with auth failure and verify the stamp does NOT advance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ug7NQ5832dKYAXzGJBB8ug)_