### PR TITLE
Guard pushUnsyncedLogs against concurrent invocations

### DIFF
--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -232,6 +232,71 @@ describe('SyncService', () => {
       expect(result).toEqual({pushed: 0, failed: 0});
     });
 
+    it('coalesces concurrent invocations so the second caller is a no-op', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      let resolveFirst: (value: unknown) => void = () => {};
+      (apiClient.post as jest.Mock).mockImplementationOnce(
+        () => new Promise(resolve => {
+          resolveFirst = resolve;
+        }),
+      );
+
+      const first = syncService.pushUnsyncedLogs();
+      // Let the first call advance past its initial AsyncStorage/getUnsyncedLogs awaits
+      // and reach the in-flight POST.
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+      const second = await syncService.pushUnsyncedLogs();
+
+      expect(second).toEqual({pushed: 0, failed: 0});
+      expect(apiClient.post).toHaveBeenCalledTimes(1);
+
+      resolveFirst({data: {synced: 1, errors: []}});
+      await first;
+
+      expect(logs[0].markSynced).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the in-flight guard after completion so later calls proceed', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock)
+        .mockResolvedValueOnce({data: {synced: 1, errors: []}})
+        .mockResolvedValueOnce({data: {synced: 1, errors: []}});
+
+      await syncService.pushUnsyncedLogs();
+      await syncService.pushUnsyncedLogs();
+
+      expect(apiClient.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('releases the in-flight guard even when an inner call throws', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      // First invocation: getUnsyncedLogs throws after we are already inside
+      // the try block, so finally must still clear the in-flight flag.
+      (habitService.getUnsyncedLogs as jest.Mock)
+        .mockRejectedValueOnce(new Error('db unavailable'))
+        .mockResolvedValueOnce(logs);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockResolvedValueOnce({
+        data: {synced: 1, errors: []},
+      });
+
+      await expect(syncService.pushUnsyncedLogs()).rejects.toThrow('db unavailable');
+
+      // If finally didn't run, this second call would early-return {0, 0}.
+      const result = await syncService.pushUnsyncedLogs();
+      expect(result.pushed).toBe(1);
+    });
+
     it('does not mark failed logs as synced when server returns partial errors', async () => {
       const logs = [
         createMockLog('habit-1', '2025-01-01'),

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -78,6 +78,7 @@ export default class SyncService {
   private habitService: HabitService;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null;
+  private inFlight = false;
 
   constructor(habitService: HabitService) {
     this.habitService = habitService;
@@ -99,35 +100,45 @@ export default class SyncService {
   }
 
   async pushUnsyncedLogs(): Promise<SyncResult> {
-    // If auth previously failed permanently, don't retry
-    const authFailed = await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY);
-    if (authFailed === 'true') {
+    // Concurrent callers would both read the same unsynced rows and race on
+    // markSynced — the loser hits a WatermelonDB "record was deleted" error.
+    if (this.inFlight) {
       return {pushed: 0, failed: 0};
     }
+    this.inFlight = true;
+    try {
+      // If auth previously failed permanently, don't retry
+      const authFailed = await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY);
+      if (authFailed === 'true') {
+        return {pushed: 0, failed: 0};
+      }
 
-    // Push habits first so the server knows about every habit referenced by
-    // a log. Otherwise the log push returns "Habit not found" for every log
-    // of a locally-created habit, and those logs accumulate forever.
-    const habitsPushed = await this.pushUnsyncedHabits();
+      // Push habits first so the server knows about every habit referenced by
+      // a log. Otherwise the log push returns "Habit not found" for every log
+      // of a locally-created habit, and those logs accumulate forever.
+      const habitsPushed = await this.pushUnsyncedHabits();
 
-    const unsyncedLogs = await this.habitService.getUnsyncedLogs();
+      const unsyncedLogs = await this.habitService.getUnsyncedLogs();
 
-    if (unsyncedLogs.length === 0) {
-      return {pushed: 0, failed: 0};
+      if (unsyncedLogs.length === 0) {
+        return {pushed: 0, failed: 0};
+      }
+
+      // If habit push failed (auth or network), skip the log push so we don't
+      // burn through the batch only to have every entry rejected.
+      if (!habitsPushed) {
+        return {pushed: 0, failed: 0};
+      }
+
+      // If more than MAX_UNBATCHED logs, chunk into batches
+      if (unsyncedLogs.length > MAX_UNBATCHED) {
+        return await this.pushInBatches(unsyncedLogs);
+      }
+
+      return await this.pushBatch(unsyncedLogs);
+    } finally {
+      this.inFlight = false;
     }
-
-    // If habit push failed (auth or network), skip the log push so we don't
-    // burn through the batch only to have every entry rejected.
-    if (!habitsPushed) {
-      return {pushed: 0, failed: 0};
-    }
-
-    // If more than MAX_UNBATCHED logs, chunk into batches
-    if (unsyncedLogs.length > MAX_UNBATCHED) {
-      return this.pushInBatches(unsyncedLogs);
-    }
-
-    return this.pushBatch(unsyncedLogs);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `pushUnsyncedLogs` had no in-flight guard, so `startBackgroundSync`, `debouncedSync`, and Settings' "Sync Now" could fire it concurrently (e.g. foreground transition + the user tapping the button).
- Both callers would see the same unsynced rows and both call `markSynced`; the losing call races against records the winner already updated and surfaces as a WatermelonDB "record was deleted" error, on top of wasted bandwidth.
- Added a boolean `inFlight` mutex with a try/finally release. The second concurrent caller short-circuits to `{pushed: 0, failed: 0}` instead of duplicating the push.

## Test plan
- [x] `yarn test src/__tests__/services/SyncService.test.ts` (25/25 passing, including new tests for the mutex)
- [x] `yarn test` full suite (198/198)
- [x] `yarn typecheck`
- New tests cover: (1) second concurrent caller is a no-op while the first is in flight, (2) guard is released on completion so later calls proceed, (3) guard is released even when an inner call throws.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEi99ypQmL3MpdGCbS7iy9)_