### PR TITLE
Wrap NavigationContainer in SafeAreaProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AppNavigator from './navigation/AppNavigator';
 import NotificationService from './services/NotificationService';
@@ -22,9 +23,11 @@ const App: React.FC = () => {
   }, []);
 
   return (
-    <NavigationContainer>
-      <AppNavigator />
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <AppNavigator />
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- `react-native-safe-area-context@^5.7.0` is already a dependency, but the root `App` component never rendered a `SafeAreaProvider`, so screens could draw under the Android gesture nav bar / camera notch and React Navigation v7 warned about the missing provider.
- Wrap `NavigationContainer` (and therefore every screen) in `<SafeAreaProvider>` in `src/App.tsx:25`.

## Test plan
- [ ] `yarn tsc --noEmit` (or project equivalent) succeeds.
- [ ] Launch on an Android device with gesture navigation / notch and confirm screen content no longer sits under system UI.
- [ ] Verify no "SafeAreaProvider" warning from React Navigation in the Metro console.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeX2GjrpQTmcwQ7BYu2DAf)_