### PR TITLE
Bound the unsynced-logs scan with per-log retry tracking

### DIFF
--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -3,7 +3,10 @@ import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
 import {schema} from '../../models/schema';
 import Habit from '../../models/Habit';
 import HabitLog from '../../models/HabitLog';
-import HabitService from '../../services/HabitService';
+import HabitService, {
+  MAX_LOG_RETRIES,
+  backoffMsFor,
+} from '../../services/HabitService';
 import {format, subDays} from 'date-fns';
 
 function createTestDatabase(): Database {
@@ -375,6 +378,155 @@ describe('HabitService', () => {
       const unsynced = await service.getUnsyncedLogs();
       expect(unsynced).toHaveLength(2);
       unsynced.forEach(log => expect(log.synced).toBe(false));
+    });
+
+    it('excludes logs that have hit the permanent-failure cap', async () => {
+      const habit = await createTestHabit(database);
+      const log1 = await createTestLog(database, habit.id, '2026-03-01', false);
+      const log2 = await createTestLog(database, habit.id, '2026-03-02', false);
+
+      // Simulate log1 hitting the retry cap (e.g. habit-not-found loop).
+      await database.write(async () => {
+        await log1.update(l => {
+          l.retryCount = MAX_LOG_RETRIES;
+          l.lastAttemptAt = Date.now() - 24 * 60 * 60 * 1000;
+        });
+      });
+
+      const unsynced = await service.getUnsyncedLogs();
+      expect(unsynced.map(l => l.id)).toEqual([log2.id]);
+    });
+
+    it('skips logs that are inside their exponential-backoff window', async () => {
+      const habit = await createTestHabit(database);
+      const fresh = await createTestLog(database, habit.id, '2026-03-01', false);
+      const backoff = await createTestLog(database, habit.id, '2026-03-02', false);
+
+      // backoff has retry_count=1 (1 minute backoff) and was just attempted.
+      await database.write(async () => {
+        await backoff.update(l => {
+          l.retryCount = 1;
+          l.lastAttemptAt = Date.now();
+        });
+      });
+
+      const unsynced = await service.getUnsyncedLogs();
+      expect(unsynced.map(l => l.id)).toEqual([fresh.id]);
+    });
+
+    it('includes logs whose backoff window has elapsed', async () => {
+      const habit = await createTestHabit(database);
+      const log = await createTestLog(database, habit.id, '2026-03-02', false);
+
+      await database.write(async () => {
+        await log.update(l => {
+          l.retryCount = 1;
+          // 10 minutes ago — well past the 1-minute backoff for retry_count=1.
+          l.lastAttemptAt = Date.now() - 10 * 60 * 1000;
+        });
+      });
+
+      const unsynced = await service.getUnsyncedLogs();
+      expect(unsynced.map(l => l.id)).toEqual([log.id]);
+    });
+  });
+
+  describe('markLogsRetryFailed', () => {
+    it('increments retry_count and stamps last_attempt_at', async () => {
+      const habit = await createTestHabit(database);
+      const log = await createTestLog(database, habit.id, '2026-03-01', false);
+
+      const before = Date.now();
+      await service.markLogsRetryFailed([log]);
+      const after = Date.now();
+
+      const reloaded = await database.get<HabitLog>('habit_logs').find(log.id);
+      expect(reloaded.retryCount).toBe(1);
+      expect(reloaded.lastAttemptAt).not.toBeNull();
+      expect(reloaded.lastAttemptAt!).toBeGreaterThanOrEqual(before);
+      expect(reloaded.lastAttemptAt!).toBeLessThanOrEqual(after);
+    });
+
+    it('is a no-op for an empty batch', async () => {
+      await expect(service.markLogsRetryFailed([])).resolves.toBeUndefined();
+    });
+
+    it('a log capped at MAX_LOG_RETRIES is no longer returned by getUnsyncedLogs', async () => {
+      const habit = await createTestHabit(database);
+      const log = await createTestLog(database, habit.id, '2026-03-01', false);
+
+      for (let i = 0; i < MAX_LOG_RETRIES; i++) {
+        await service.markLogsRetryFailed([log]);
+      }
+
+      const unsynced = await service.getUnsyncedLogs();
+      expect(unsynced.map(l => l.id)).not.toContain(log.id);
+    });
+
+    it('observeUnsyncedCount also excludes capped logs', async () => {
+      const habit = await createTestHabit(database, 'h', true);
+      const log = await createTestLog(database, habit.id, '2026-03-01', false);
+      await database.write(async () => {
+        await log.update(l => {
+          l.retryCount = MAX_LOG_RETRIES;
+          l.lastAttemptAt = Date.now();
+        });
+      });
+
+      const observable = service.observeUnsyncedCount();
+      const count = await new Promise<number>(resolve => {
+        const sub = observable.subscribe(v => {
+          resolve(v);
+          Promise.resolve().then(() => sub.unsubscribe());
+        });
+      });
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('backoffMsFor', () => {
+    it('returns 0 for retry_count=0', () => {
+      expect(backoffMsFor(0)).toBe(0);
+    });
+
+    it('grows exponentially up to a cap', () => {
+      expect(backoffMsFor(1)).toBe(60_000);
+      expect(backoffMsFor(2)).toBe(120_000);
+      expect(backoffMsFor(3)).toBe(240_000);
+      // Cap at 6 hours.
+      expect(backoffMsFor(100)).toBe(6 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('markHabitsSynced resets per-log retry state', () => {
+    it('clears retry_count for unsynced logs of newly-synced habits', async () => {
+      const habit = await createTestHabit(database, 'h', false);
+      const log = await createTestLog(database, habit.id, '2026-03-01', false);
+      await service.markLogsRetryFailed([log]);
+
+      let reloaded = await database.get<HabitLog>('habit_logs').find(log.id);
+      expect(reloaded.retryCount).toBe(1);
+
+      await service.markHabitsSynced([habit]);
+
+      reloaded = await database.get<HabitLog>('habit_logs').find(log.id);
+      expect(reloaded.retryCount).toBe(0);
+      expect(reloaded.lastAttemptAt).toBeNull();
+    });
+
+    it('does not touch logs of other habits', async () => {
+      const habitA = await createTestHabit(database, 'A', false);
+      const habitB = await createTestHabit(database, 'B', false);
+      const logA = await createTestLog(database, habitA.id, '2026-03-01', false);
+      const logB = await createTestLog(database, habitB.id, '2026-03-01', false);
+      await service.markLogsRetryFailed([logA, logB]);
+
+      await service.markHabitsSynced([habitA]);
+
+      const reloadedA = await database.get<HabitLog>('habit_logs').find(logA.id);
+      const reloadedB = await database.get<HabitLog>('habit_logs').find(logB.id);
+      expect(reloadedA.retryCount).toBe(0);
+      expect(reloadedB.retryCount).toBe(1);
     });
   });
 

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -59,6 +59,7 @@ function createMockHabitService(logs: ReturnType<typeof createMockLog>[] = []) {
           await log.markSynced();
         }
       }),
+    markLogsRetryFailed: jest.fn().mockResolvedValue(undefined),
     markHabitsSynced: jest
       .fn()
       .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {
@@ -227,6 +228,68 @@ describe('SyncService Hardening', () => {
 
       await syncService.pushUnsyncedLogs();
       expect(failedLog.markSynced).toHaveBeenCalled();
+    });
+
+    it('records retry failures so the persistent backlog gets bounded', async () => {
+      const log = createMockLog('habit-1', '2025-01-01');
+      const habitService = createMockHabitService([log]);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockResolvedValueOnce({
+        data: {
+          synced: 0,
+          errors: [
+            {habit_id: 'habit-1', completed_date: '2025-01-01', reason: 'Habit not found'},
+          ],
+        },
+      });
+
+      await syncService.pushUnsyncedLogs();
+
+      expect(habitService.markLogsRetryFailed).toHaveBeenCalledTimes(1);
+      const failedBatch = (habitService.markLogsRetryFailed as jest.Mock).mock.calls[0][0];
+      expect(failedBatch).toHaveLength(1);
+      expect(failedBatch[0].habitId).toBe('habit-1');
+      // Successful logs are never passed to markLogsRetryFailed.
+      expect(log.markSynced).not.toHaveBeenCalled();
+    });
+
+    it('only records the rejected logs as retry-failed, not the successful ones', async () => {
+      const ok = createMockLog('habit-1', '2025-01-01');
+      const bad = createMockLog('habit-2', '2025-01-02');
+      const habitService = createMockHabitService([ok, bad]);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockResolvedValueOnce({
+        data: {
+          synced: 1,
+          errors: [
+            {habit_id: 'habit-2', completed_date: '2025-01-02', reason: 'Habit not found'},
+          ],
+        },
+      });
+
+      await syncService.pushUnsyncedLogs();
+
+      expect(ok.markSynced).toHaveBeenCalled();
+      const failedBatch = (habitService.markLogsRetryFailed as jest.Mock).mock.calls[0][0];
+      expect(failedBatch.map((l: {habitId: string}) => l.habitId)).toEqual(['habit-2']);
+    });
+
+    it('does NOT call markLogsRetryFailed on network/5xx failures (whole-batch retry)', async () => {
+      const log = createMockLog('habit-1', '2025-01-01');
+      const habitService = createMockHabitService([log]);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockRejectedValueOnce(
+        Object.assign(new Error('Network Error'), {code: 'ERR_NETWORK'}),
+      );
+
+      await syncService.pushUnsyncedLogs();
+
+      // On a transport-level failure the whole batch is retried next cycle —
+      // no per-log retry counter should advance.
+      expect(habitService.markLogsRetryFailed).not.toHaveBeenCalled();
     });
 
     it('handles all logs failing in the errors array', async () => {

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -71,6 +71,7 @@ function createMockHabitService(
           await log.markSynced();
         }
       }),
+    markLogsRetryFailed: jest.fn().mockResolvedValue(undefined),
     markHabitsSynced: jest
       .fn()
       .mockImplementation(async (batch: {markSynced: () => Promise<void>}[]) => {

--- a/src/models/HabitLog.ts
+++ b/src/models/HabitLog.ts
@@ -21,6 +21,8 @@ export default class HabitLog extends Model {
   @field('completed_date') completedDate!: string;
   @field('synced') synced!: boolean;
   @field('deleted_at') deletedAt!: number | null;
+  @field('retry_count') retryCount!: number;
+  @field('last_attempt_at') lastAttemptAt!: number | null;
 
   @relation('habits', 'habit_id') habit!: Relation<Habit>;
 

--- a/src/models/migrations.ts
+++ b/src/models/migrations.ts
@@ -21,5 +21,20 @@ export const migrations = schemaMigrations({
         }),
       ],
     },
+    {
+      toVersion: 3,
+      steps: [
+        // Per-log retry tracking. Existing rows default to retry_count=0 and
+        // last_attempt_at=null, so they retry immediately on the next sync —
+        // identical to the pre-migration behavior.
+        addColumns({
+          table: 'habit_logs',
+          columns: [
+            {name: 'retry_count', type: 'number', isIndexed: true},
+            {name: 'last_attempt_at', type: 'number', isOptional: true},
+          ],
+        }),
+      ],
+    },
   ],
 });

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export const schema = appSchema({
-  version: 2,
+  version: 3,
   tables: [
     tableSchema({
       name: 'habits',
@@ -28,6 +28,16 @@ export const schema = appSchema({
         // to the server, after which they remain as "synced deletions"
         // so that any concurrent revival can be detected and pushed.
         {name: 'deleted_at', type: 'number', isOptional: true},
+        // Number of server-rejected sync attempts (per-log errors like
+        // "Habit not found"). Indexed so the unsynced-logs query can filter
+        // out dead-end rows at the SQL layer rather than scanning them
+        // every cycle. Once it reaches MAX_LOG_RETRIES the row is treated
+        // as permanently rejected and excluded from sync entirely.
+        {name: 'retry_count', type: 'number', isIndexed: true},
+        // Timestamp (ms) of the last server-rejected attempt. Used by the
+        // service layer to apply exponential backoff between retries so
+        // a transient per-log error doesn't get retried every minute.
+        {name: 'last_attempt_at', type: 'number', isOptional: true},
       ],
     }),
   ],

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -6,6 +6,25 @@ import {subDays, format} from 'date-fns';
 import type Habit from '../models/Habit';
 import type HabitLog from '../models/HabitLog';
 
+// After this many server-rejected attempts a log is treated as permanently
+// dead and excluded from the sync queue. Prevents per-log failures like
+// "Habit not found" from forcing a growing full-table scan on every sync.
+export const MAX_LOG_RETRIES = 10;
+
+// Exponential backoff between server-rejected retries: 1m, 2m, 4m, ...
+// capped at 6 hours. Multiplied against retry_count so a single per-log
+// error doesn't get retried every minute alongside healthy traffic.
+const BACKOFF_BASE_MS = 60_000;
+const BACKOFF_CAP_MS = 6 * 60 * 60 * 1000;
+
+export function backoffMsFor(retryCount: number): number {
+  if (retryCount <= 0) {
+    return 0;
+  }
+  const exp = Math.min(retryCount - 1, 30);
+  return Math.min(BACKOFF_BASE_MS * 2 ** exp, BACKOFF_CAP_MS);
+}
+
 export default class HabitService {
   private database: Database;
 
@@ -80,6 +99,10 @@ export default class HabitService {
           await active.update(log => {
             log.deletedAt = Date.now();
             log.synced = false;
+            // Fresh user action — clear prior retry backoff so the deletion
+            // is attempted on the very next sync.
+            log.retryCount = 0;
+            log.lastAttemptAt = null;
           });
         } else {
           // Never reached the server — safe to drop the row entirely.
@@ -95,6 +118,8 @@ export default class HabitService {
         await tombstone.update(log => {
           log.deletedAt = null;
           log.synced = false;
+          log.retryCount = 0;
+          log.lastAttemptAt = null;
         });
         return;
       }
@@ -104,6 +129,8 @@ export default class HabitService {
         log.completedDate = date;
         log.synced = false;
         log.deletedAt = null;
+        log.retryCount = 0;
+        log.lastAttemptAt = null;
       });
     });
   }
@@ -129,10 +156,28 @@ export default class HabitService {
   }
 
   async getUnsyncedLogs(): Promise<HabitLog[]> {
-    return this.database
+    // SQL-level filter: skip logs that have hit the permanent-failure cap.
+    // Without this, dead-end logs (e.g. ones whose habit doesn't exist on
+    // the server) get rescanned on every sync, growing the work per cycle
+    // without bound.
+    const eligible = await this.database
       .get<HabitLog>('habit_logs')
-      .query(Q.where('synced', false))
+      .query(
+        Q.where('synced', false),
+        Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
+      )
       .fetch();
+
+    // Application-level filter: enforce exponential backoff between
+    // server-rejected attempts. Logs in backoff stay in the table but are
+    // skipped this cycle.
+    const now = Date.now();
+    return eligible.filter(log => {
+      if (log.retryCount === 0 || log.lastAttemptAt == null) {
+        return true;
+      }
+      return now - log.lastAttemptAt >= backoffMsFor(log.retryCount);
+    });
   }
 
   async getUnsyncedHabits(): Promise<Habit[]> {
@@ -151,6 +196,30 @@ export default class HabitService {
         ...logs.map(log =>
           log.prepareUpdate(l => {
             l.synced = true;
+            // Clear retry tracking so a future tombstone/revive on this
+            // row starts from a clean slate.
+            l.retryCount = 0;
+            l.lastAttemptAt = null;
+          }),
+        ),
+      );
+    });
+  }
+
+  // Called when the server returned per-log errors (e.g. "Habit not found").
+  // Records the rejection so getUnsyncedLogs can apply backoff and so logs
+  // that hit MAX_LOG_RETRIES are excluded from future scans entirely.
+  async markLogsRetryFailed(logs: HabitLog[]): Promise<void> {
+    if (logs.length === 0) {
+      return;
+    }
+    const now = Date.now();
+    await this.database.write(async () => {
+      await this.database.batch(
+        ...logs.map(log =>
+          log.prepareUpdate(l => {
+            l.retryCount = (l.retryCount ?? 0) + 1;
+            l.lastAttemptAt = now;
           }),
         ),
       );
@@ -161,6 +230,7 @@ export default class HabitService {
     if (habits.length === 0) {
       return;
     }
+    const habitIds = habits.map(h => h.id);
     await this.database.write(async () => {
       await this.database.batch(
         ...habits.map(habit =>
@@ -170,12 +240,44 @@ export default class HabitService {
         ),
       );
     });
+
+    // The most common cause of per-log "Habit not found" is that the habit
+    // hadn't been pushed yet. Now that the habit is on the server, give its
+    // backlog of logs a fresh chance — reset retry tracking so they aren't
+    // stuck in backoff (or worse, capped out) when they would now succeed.
+    if (habitIds.length > 0) {
+      const candidates = await this.database
+        .get<HabitLog>('habit_logs')
+        .query(
+          Q.where('habit_id', Q.oneOf(habitIds)),
+          Q.where('synced', false),
+          Q.where('retry_count', Q.gt(0)),
+        )
+        .fetch();
+      if (candidates.length > 0) {
+        await this.database.write(async () => {
+          await this.database.batch(
+            ...candidates.map(log =>
+              log.prepareUpdate(l => {
+                l.retryCount = 0;
+                l.lastAttemptAt = null;
+              }),
+            ),
+          );
+        });
+      }
+    }
   }
 
   observeUnsyncedCount(): Observable<number> {
+    // Match getUnsyncedLogs: exclude rows past the permanent-failure cap so
+    // the UI doesn't show a forever-growing "N pending" for dead-end logs.
     const logs$ = this.database
       .get<HabitLog>('habit_logs')
-      .query(Q.where('synced', false))
+      .query(
+        Q.where('synced', false),
+        Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
+      )
       .observe();
     const habits$ = this.database
       .get<Habit>('habits')

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -237,8 +237,16 @@ export default class SyncService {
     const succeeded = logs.filter(
       log => !errorSet.has(`${log.habitId}:${log.completedDate}`),
     );
+    const failed = logs.filter(log =>
+      errorSet.has(`${log.habitId}:${log.completedDate}`),
+    );
 
     await this.habitService.markLogsSynced(succeeded);
+    // Record per-log rejections so HabitService.getUnsyncedLogs can apply
+    // exponential backoff and eventually exclude permanently-failing rows
+    // from the scan. Without this, "Habit not found" rejections grow the
+    // unsynced backlog forever and every sync re-fetches them all.
+    await this.habitService.markLogsRetryFailed(failed);
 
     const errorMessages = (syncErrors || []).map(
       (e: {habit_id: string; completed_date: string; reason: string}) =>


### PR DESCRIPTION
## Summary

Fixes **N-M8**: `getUnsyncedLogs()` did a full table scan of every `synced=false` row on every sync. Combined with N-C2 (logs for never-synced habits never clearing), the scan grew without bound — every "Habit not found" rejection stayed in the queue forever and got re-fetched on every cycle.

This change adds per-log retry tracking that both bounds the scan and stops hammering dead-end rows.

## Changes

- **Schema v3** (`src/models/schema.ts`, `src/models/migrations.ts`): two new columns on `habit_logs` — `retry_count` (indexed) and `last_attempt_at`. Default `retry_count=0` means existing rows are eligible for the next sync immediately, so the migration is behaviorally a no-op for current users.
- **SQL-level cap** (`HabitService.getUnsyncedLogs`, `observeUnsyncedCount`): query filters `retry_count < MAX_LOG_RETRIES` (=10) so permanently-rejected rows drop out of the scan entirely instead of being re-fetched forever.
- **Exponential backoff** (`HabitService.getUnsyncedLogs`): server-rejected logs wait `min(60s · 2^(n-1), 6h)` between attempts. Applied in-memory after the SQL filter, so the filter alone keeps the scan size bounded.
- **`markLogsRetryFailed`** (`HabitService` + `SyncService.pushBatch`): when the server returns per-log errors (e.g. "Habit not found"), the affected logs get their `retry_count` incremented and `last_attempt_at` stamped. Transport-level failures (network / 5xx) still re-attempt the full batch — only per-log rejections advance the counter.
- **Recovery path** (`HabitService.markHabitsSynced`): the most common cause of "Habit not found" is that the habit hadn't been pushed yet. When a habit finally syncs, retry state is cleared for its logs so they get retried on the very next cycle instead of waiting out their backoff (or worse, staying capped).
- **Tombstone/revive consistency** (`HabitService.toggleHabitCompletion`): re-toggling a day is a fresh user action, so it resets retry state.

## Test plan

Added 14 new tests covering the new behavior; full suite (213 tests) passes.

- [x] `getUnsyncedLogs` excludes capped logs at the SQL layer
- [x] `getUnsyncedLogs` honors the exponential backoff window
- [x] `getUnsyncedLogs` returns a log once its backoff has elapsed
- [x] `markLogsRetryFailed` increments `retry_count` and stamps `last_attempt_at`
- [x] A log capped at `MAX_LOG_RETRIES` stops appearing in `getUnsyncedLogs` and `observeUnsyncedCount`
- [x] `backoffMsFor` is exponential with a 6-hour cap
- [x] `markHabitsSynced` clears retry state for logs of newly-synced habits (and only those habits)
- [x] `SyncService.pushBatch` calls `markLogsRetryFailed` only on per-log errors, never on network/5xx whole-batch failures
- [x] `tsc --noEmit` clean
- [x] `eslint` introduces no new warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01G7A4ELEpKoKUz7G98Lf83Y)_