### PR TITLE
fix(test): make batch chunking test reflect real per-batch sync counts

### DIFF
--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -593,9 +593,9 @@ describe('SyncService Hardening', () => {
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      (apiClient.post as jest.Mock).mockImplementation(() =>
+      (apiClient.post as jest.Mock).mockImplementation((_url: string, payload: {logs: {habit_id: string; completed_date: string}[]}) =>
         Promise.resolve({
-          data: {synced: 100, errors: []},
+          data: {synced: payload.logs.length, errors: []},
         }),
       );
 
@@ -603,7 +603,7 @@ describe('SyncService Hardening', () => {
 
       // 6 API calls (550 / 100 = 5 full + 1 partial)
       expect(apiClient.post).toHaveBeenCalledTimes(6);
-      expect(result.pushed).toBe(600); // 6 * 100 from mock
+      expect(result.pushed).toBe(550);
     }, 30000);
 
     it('each batch contains at most 100 logs', async () => {


### PR DESCRIPTION
## Summary

The `chunks into batches of 100 when count > 500` hardening test used a mock that returned `synced: 100` for every call regardless of payload size. As N-M9 points out, this masks real bugs: the test would still pass if the final 50-log batch only synced 1 row, or if every batch silently dropped logs. It also produced the misleading `pushed: 600` assertion for 550 input logs, which the comment (`6 * 100 from mock`) acknowledged.

Mirror the approach already used by the very next test (`each batch contains at most 100 logs`): return `synced: payload.logs.length` from the mock and assert `result.pushed === 550`. The call-count assertion (`6`) still proves chunking; the new `pushed` assertion now also proves each batch's reported count matches what was sent.

## Test plan
- [x] `npm test -- src/__tests__/services/SyncService.hardening.test.ts -t "chunks into batches of 100"` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_012EiNaGSdEAj6WLq3pcmgV6)_