### PR TITLE
Drop 1s inter-batch sleep in SyncService chunking

### DIFF
--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -8,7 +8,6 @@ export const SYNC_SECRET_KEY = 'sync_secret';
 export const SYNC_AUTH_FAILED_KEY = 'sync_auth_failed';
 
 const BATCH_SIZE = 100;
-const BATCH_PAUSE_MS = 1000;
 const MAX_UNBATCHED = 500;
 
 export class AuthenticationError extends Error {
@@ -68,10 +67,6 @@ function is5xxError(error: SyncError): boolean {
 
 function is401Error(error: SyncError): boolean {
   return error?.response?.status === 401;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export default class SyncService {
@@ -274,11 +269,6 @@ export default class SyncService {
       totalFailed += result.failed;
       if (result.errors) {
         allErrors.push(...result.errors);
-      }
-
-      // Pause between batches (skip after last batch)
-      if (i + BATCH_SIZE < allLogs.length) {
-        await sleep(BATCH_PAUSE_MS);
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes N-M10: `SyncService.pushInBatches` slept 1s between every batch, so a foreground "Sync Now" with 600 unsynced logs spun the spinner for an extra ~5s on top of HTTP latency with no UI feedback.

- Removed the `await sleep(BATCH_PAUSE_MS)` between batches in `pushInBatches`
- Removed the now-unused `BATCH_PAUSE_MS` constant and `sleep` helper

HTTP request timing already serializes the batches, so the extra pause served no purpose — it was pure dead time. Chunking, batch size (100), and the >500 threshold are unchanged.

## Test plan

- [x] `npx jest src/__tests__/services/SyncService.hardening.test.ts` — 37/37 pass (including the Scenario 5 large-backlog/chunking cases)
- [x] `npx jest src/__tests__/services/SyncService.test.ts` — 25/25 pass
- [ ] Manual: tap "Sync Now" with >500 pending logs and confirm the spinner clears as soon as HTTP requests finish

---
_Generated by [Claude Code](https://claude.ai/code/session_01JF2AuLfsQ9guFVNyNxqGZM)_