### PR TITLE
Serialize toggleHabit calls per habit to avoid streak race

### DIFF
--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -20,6 +20,7 @@ export function useHabits(habitService: HabitService) {
   const todayRef = useRef(getTodayString());
   const [, setDateVersion] = useState(0);
   const rawHabitsRef = useRef<Habit[]>([]);
+  const toggleChainRef = useRef<Map<string, Promise<void>>>(new Map());
   const isMounted = useSubscriptionLeakDetector('useHabits');
 
   const computeDisplayData = useCallback(
@@ -98,58 +99,75 @@ export function useHabits(habitService: HabitService) {
   }, [computeDisplayData]);
 
   const toggleHabit = useCallback(
-    async (habitId: string) => {
+    (habitId: string) => {
       const today = todayRef.current;
       const cache = streakCacheRef.current;
+      const chain = toggleChainRef.current;
 
-      // Optimistic update
-      setHabits(prev =>
-        prev.map(h => {
-          if (h.id !== habitId) {
-            return h;
-          }
-          const nowCompleted = !h.completedToday;
-          const newStreak = nowCompleted ? h.streak + 1 : Math.max(h.streak - 1, 0);
-          cache.set(habitId, newStreak);
-          return {
-            ...h,
-            completedToday: nowCompleted,
-            streak: newStreak,
-          };
-        }),
-      );
-
-      try {
-        await habitService.toggleHabitCompletion(habitId, today);
-        // Recalculate actual streak after successful write
-        const actualStreak = await habitService.calculateStreak(habitId, today);
-        cache.set(habitId, actualStreak);
-        setHabits(prev =>
-          prev.map(h =>
-            h.id === habitId ? {...h, streak: actualStreak} : h,
-          ),
-        );
-      } catch {
-        // Revert optimistic update
+      const run = async () => {
+        // Optimistic update
         setHabits(prev =>
           prev.map(h => {
             if (h.id !== habitId) {
               return h;
             }
-            const reverted = !h.completedToday;
-            const revertedStreak = reverted
+            const nowCompleted = !h.completedToday;
+            const newStreak = nowCompleted
               ? h.streak + 1
               : Math.max(h.streak - 1, 0);
-            cache.set(habitId, revertedStreak);
+            cache.set(habitId, newStreak);
             return {
               ...h,
-              completedToday: reverted,
-              streak: revertedStreak,
+              completedToday: nowCompleted,
+              streak: newStreak,
             };
           }),
         );
-        throw new Error('Could not save. Please try again.');
-      }
+
+        try {
+          await habitService.toggleHabitCompletion(habitId, today);
+          const actualStreak = await habitService.calculateStreak(
+            habitId,
+            today,
+          );
+          cache.set(habitId, actualStreak);
+          setHabits(prev =>
+            prev.map(h =>
+              h.id === habitId ? {...h, streak: actualStreak} : h,
+            ),
+          );
+        } catch {
+          setHabits(prev =>
+            prev.map(h => {
+              if (h.id !== habitId) {
+                return h;
+              }
+              const reverted = !h.completedToday;
+              const revertedStreak = reverted
+                ? h.streak + 1
+                : Math.max(h.streak - 1, 0);
+              cache.set(habitId, revertedStreak);
+              return {
+                ...h,
+                completedToday: reverted,
+                streak: revertedStreak,
+              };
+            }),
+          );
+          throw new Error('Could not save. Please try again.');
+        }
+      };
+
+      const previous = chain.get(habitId) ?? Promise.resolve();
+      const next = previous.catch(() => {}).then(run);
+      chain.set(habitId, next);
+      const cleanup = () => {
+        if (chain.get(habitId) === next) {
+          chain.delete(habitId);
+        }
+      };
+      next.then(cleanup, cleanup);
+      return next;
     },
     [habitService],
   );


### PR DESCRIPTION
## Summary

Fixes a race in `useHabits.toggleHabit` (src/hooks/useHabits.ts:100) when the user double-taps a habit.

Previously, two parallel calls would each issue their own `toggleHabitCompletion` write followed by a `calculateStreak` read. Because the two streak reads could resolve in either order, the later-resolving (but stale) result could overwrite the correct final streak.

## Fix

Added a per-habit promise chain (`toggleChainRef: Map<string, Promise<void>>`). Each call appends its work to the previous in-flight promise for that habit, so the optimistic update, write, and streak recalculation run serially per habit. The map entry is cleared once the tail of the chain settles.

The chain uses `.catch(() => {})` on the previous link so a failed toggle doesn't poison subsequent ones — each call still observes its own rejection.

## Test plan

- [ ] Manual: double-tap a habit; final streak matches the actual post-write state
- [ ] Manual: tap, then before settle tap again; both writes apply in order, streak stays correct
- [ ] Manual: simulate a write failure mid-chain; subsequent taps still work
- [ ] `npm run typecheck` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01E2b7TpcrMeCf8Fx3jxKix7)_