### PR TITLE
Include onToggle in HabitCard areEqual check

### DIFF
--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -29,6 +29,7 @@ function areEqual(prev: HabitCardProps, next: HabitCardProps): boolean {
     prev.name === next.name &&
     prev.completedToday === next.completedToday &&
     prev.streak === next.streak &&
+    prev.onToggle === next.onToggle &&
     prev.onPress === next.onPress
   );
 }


### PR DESCRIPTION
## Summary
- `HabitCard`'s `React.memo` custom `areEqual` was missing `onToggle`, leaving a latent stale-closure bug if its reference ever becomes unstable.
- Added `prev.onToggle === next.onToggle` to the comparison alongside the existing prop checks.

## Test plan
- [ ] Verify `HabitCard` still re-renders when habit data changes
- [ ] Confirm toggling a habit still works in `DashboardScreen`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrcaWzm965dh4hgm2NCq1q)_