### PR TITLE
Gate sync error warns with __DEV__ and drop response! assertion

### DIFF
--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -1,6 +1,7 @@
 import {AppState} from 'react-native';
 import type {AppStateStatus} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import type {AxiosResponse} from 'axios';
 import apiClient, {AUTH_TOKEN_KEY} from './api';
 import type HabitService from './HabitService';
 
@@ -157,7 +158,7 @@ export default class SyncService {
       })),
     };
 
-    let response;
+    let response: AxiosResponse | undefined;
     try {
       response = await apiClient.post('/habits/sync', payload);
     } catch (error: unknown) {
@@ -178,7 +179,11 @@ export default class SyncService {
       }
     }
 
-    const syncedIds: string[] = response!.data?.synced_ids ?? [];
+    if (!response) {
+      return false;
+    }
+
+    const syncedIds: string[] = response.data?.synced_ids ?? [];
     const syncedSet = new Set(syncedIds);
     const syncedHabits = unsyncedHabits.filter(habit => syncedSet.has(habit.id));
     await this.habitService.markHabitsSynced(syncedHabits);
@@ -280,12 +285,14 @@ export default class SyncService {
   }
 
   private handleSyncError(error: SyncError): SyncResult {
-    if (isNetworkError(error) || is5xxError(error)) {
-      console.warn('Sync failed (will retry later):', error.message || 'Unknown error');
-      return {pushed: 0, failed: 0};
+    if (__DEV__) {
+      if (isNetworkError(error) || is5xxError(error)) {
+        console.warn('Sync failed (will retry later):', error.message || 'Unknown error');
+      } else {
+        // For unexpected errors, also fail silently
+        console.warn('Sync failed with unexpected error:', error.message || 'Unknown error');
+      }
     }
-    // For unexpected errors, also fail silently
-    console.warn('Sync failed with unexpected error:', error.message || 'Unknown error');
     return {pushed: 0, failed: 0};
   }
 


### PR DESCRIPTION
## Summary
- Gate the two `console.warn` calls in `SyncService.handleSyncError` behind `__DEV__`. Axios error messages can include the request URL (e.g. `Request failed with status code 500 ...`), and some network-layer errors embed system-level paths — fine in development, but no reason to surface them in production logs.
- Replace the `response!` non-null assertion in `SyncService.pushUnsyncedHabits` with an explicit `let response: AxiosResponse | undefined` plus an early-return guard. The control flow already guarantees `response` is set whenever execution reaches the read, but typing it as `undefined`-able and checking it makes that obvious to readers and to TypeScript without the bang.

## Test plan
- [ ] `npm run typecheck` passes (verified locally; only pre-existing tsconfig deprecation warnings remain).
- [ ] Manual: trigger a sync failure in dev — warnings still log. Confirm no warnings emitted in a release build.
- [ ] Manual: trigger an authenticated `/habits/sync` 401 → re-auth → retry path and confirm habits still get marked synced.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fhaBRT3nM32RQ3k5YMnmm)_