### PR TITLE
Fix three SettingsScreen issues: silent sync error, eager service init, misnamed handler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,31 +3,39 @@ import {NavigationContainer} from '@react-navigation/native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AppNavigator from './navigation/AppNavigator';
-import NotificationService from './services/NotificationService';
+import {ServicesProvider, useServices} from './services/ServicesContext';
 
-const notificationService = new NotificationService();
-
-const App: React.FC = () => {
+const NotificationBootstrap: React.FC = () => {
+  const services = useServices();
   // Reschedule notifications on app launch.
   // iOS can clear scheduled notifications on reboot, so we re-register them
   // every time the app starts if the user has notifications enabled.
   useEffect(() => {
+    if (!services) {
+      return;
+    }
     (async () => {
       const enabled = await AsyncStorage.getItem('reminder_enabled');
       if (enabled === 'true') {
         const time = (await AsyncStorage.getItem('reminder_time')) ?? '08:00';
         const [hour, minute] = time.split(':').map(Number);
-        await notificationService.scheduleDailyReminder(hour, minute);
+        await services.notificationService.scheduleDailyReminder(hour, minute);
       }
     })();
-  }, []);
+  }, [services]);
+  return null;
+};
 
+const App: React.FC = () => {
   return (
-    <SafeAreaProvider>
-      <NavigationContainer>
-        <AppNavigator />
-      </NavigationContainer>
-    </SafeAreaProvider>
+    <ServicesProvider>
+      <SafeAreaProvider>
+        <NotificationBootstrap />
+        <NavigationContainer>
+          <AppNavigator />
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </ServicesProvider>
   );
 };
 

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -3,6 +3,7 @@ import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
 import SettingsScreen from '../../screens/SettingsScreen';
 import HabitService from '../../services/HabitService';
 import SyncService from '../../services/SyncService';
+import NotificationService from '../../services/NotificationService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {of} from 'rxjs';
 
@@ -87,6 +88,15 @@ function createMockHabitService(
   } as unknown as jest.Mocked<HabitService>;
 }
 
+function createMockNotificationService() {
+  return {
+    requestPermission: jest.fn().mockResolvedValue(true),
+    scheduleDailyReminder: jest.fn().mockResolvedValue(undefined),
+    cancelDailyReminder: jest.fn().mockResolvedValue(undefined),
+    onNotificationToggle: jest.fn().mockResolvedValue(true),
+  } as unknown as jest.Mocked<NotificationService>;
+}
+
 function createMockSyncService(pendingCount = 0) {
   return {
     pushUnsyncedLogs: jest.fn().mockResolvedValue({pushed: 0, failed: 0}),
@@ -115,9 +125,10 @@ describe('SettingsScreen', () => {
     ];
     const service = createMockHabitService(habits);
     const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
 
     const {getByText, getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
@@ -137,9 +148,10 @@ describe('SettingsScreen', () => {
     ];
     const service = createMockHabitService(habits);
     const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
 
     const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
@@ -156,9 +168,10 @@ describe('SettingsScreen', () => {
   it('displays correct unsynced logs count', async () => {
     const service = createMockHabitService([], 5);
     const syncService = createMockSyncService(5);
+    const notificationService = createMockNotificationService();
 
     const {getByTestId, getByText} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
@@ -172,9 +185,10 @@ describe('SettingsScreen', () => {
   it('displays app version and server URL', async () => {
     const service = createMockHabitService([]);
     const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
 
     const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
@@ -190,9 +204,10 @@ describe('SettingsScreen', () => {
   it('calls pushUnsyncedLogs when Sync Now is pressed', async () => {
     const service = createMockHabitService([]);
     const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
 
     const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
@@ -209,9 +224,10 @@ describe('SettingsScreen', () => {
   it('displays "1 log pending sync" for singular count', async () => {
     const service = createMockHabitService([], 1);
     const syncService = createMockSyncService(1);
+    const notificationService = createMockNotificationService();
 
     const {getByTestId, getByText} = render(
-      <SettingsScreen habitService={service} syncService={syncService} />,
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -19,7 +19,7 @@ import HabitService from '../services/HabitService';
 import SyncService from '../services/SyncService';
 import NotificationService from '../services/NotificationService';
 import {API_BASE_URL} from '../services/api';
-import database from '../models';
+import {useServices} from '../services/ServicesContext';
 import type Habit from '../models/Habit';
 import {useHabitObservable} from '../hooks/useHabitObservable';
 
@@ -34,18 +34,20 @@ interface SettingsScreenProps {
   notificationService?: NotificationService;
 }
 
-const defaultHabitService = new HabitService(database);
-const defaultSyncService = new SyncService(defaultHabitService);
-const defaultNotificationService = new NotificationService();
-
 const SettingsScreen: React.FC<SettingsScreenProps> = ({
   habitService,
   syncService,
   notificationService,
 }) => {
-  const hService = habitService ?? defaultHabitService;
-  const sService = syncService ?? defaultSyncService;
-  const nService = notificationService ?? defaultNotificationService;
+  const ctxServices = useServices();
+  const hService = habitService ?? ctxServices?.habitService;
+  const sService = syncService ?? ctxServices?.syncService;
+  const nService = notificationService ?? ctxServices?.notificationService;
+  if (!hService || !sService || !nService) {
+    throw new Error(
+      'SettingsScreen requires services via props or <ServicesProvider>',
+    );
+  }
 
   const allHabits$ = useMemo(() => hService.getAllHabits(), [hService]);
   const habits = useHabitObservable<Habit[]>(allHabits$, []);
@@ -90,7 +92,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     [hService],
   );
 
-  const handleDelete = useCallback(
+  const handleLongPressDeactivate = useCallback(
     (habitId: string, habitName: string) => {
       Alert.alert(
         'Deactivate Habit',
@@ -149,6 +151,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         await AsyncStorage.setItem(LAST_SYNC_KEY, now);
         setLastSyncTime(now);
       }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      Alert.alert('Sync Failed', message);
     } finally {
       setSyncing(false);
     }
@@ -159,7 +164,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
       <TouchableOpacity
         style={styles.habitRow}
         testID={`habit-row-${item.id}`}
-        onLongPress={() => handleDelete(item.id, item.name)}
+        onLongPress={() => handleLongPressDeactivate(item.id, item.name)}
         accessibilityLabel={`${item.name} habit`}>
         <View style={styles.habitInfo}>
           <Text style={styles.habitName}>{item.name}</Text>
@@ -176,7 +181,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         />
       </TouchableOpacity>
     ),
-    [handleToggleActive, handleDelete],
+    [handleToggleActive, handleLongPressDeactivate],
   );
 
   const hours = Array.from({length: 24}, (_, i) => i);

--- a/src/services/ServicesContext.tsx
+++ b/src/services/ServicesContext.tsx
@@ -1,0 +1,32 @@
+import React, {createContext, useContext, useMemo} from 'react';
+import HabitService from './HabitService';
+import SyncService from './SyncService';
+import NotificationService from './NotificationService';
+import database from '../models';
+
+export interface Services {
+  habitService: HabitService;
+  syncService: SyncService;
+  notificationService: NotificationService;
+}
+
+const ServicesContext = createContext<Services | null>(null);
+
+export const ServicesProvider: React.FC<{children: React.ReactNode}> = ({
+  children,
+}) => {
+  const services = useMemo<Services>(() => {
+    const habitService = new HabitService(database);
+    const syncService = new SyncService(habitService);
+    const notificationService = new NotificationService();
+    return {habitService, syncService, notificationService};
+  }, []);
+
+  return (
+    <ServicesContext.Provider value={services}>
+      {children}
+    </ServicesContext.Provider>
+  );
+};
+
+export const useServices = (): Services | null => useContext(ServicesContext);


### PR DESCRIPTION
## Summary

Three minor fixes to `src/screens/SettingsScreen.tsx`:

- **Silent sync errors** — `handleSyncNow` wrapped `pushUnsyncedLogs` in `try/finally`, so an error inside the push (e.g. an `AsyncStorage` crash) would stop the spinner but never reach the user. Added a `catch` that surfaces the failure via `Alert.alert('Sync Failed', ...)`.
- **Eager service instantiation** — `new HabitService(database)` and `new SyncService(...)` ran at module-import time, firing WatermelonDB initialization even if the user never opened Settings. Lifted into a new `ServicesContext` provided at the App root (`src/services/ServicesContext.tsx`); `App.tsx` now wraps the tree with `<ServicesProvider>`. `SettingsScreen` reads from context, with prop injection preserved as the override path tests use.
- **Misnamed handler** — `handleDelete` was bound to `onLongPress` and called `toggleHabitActive` (matching the "Deactivate Habit" alert title). Renamed to `handleLongPressDeactivate` so the name reflects the behavior.

## Test plan

- [x] `npm test` — all 213 tests pass (existing `SettingsScreen.test.tsx` updated to pass a `notificationService` mock, since the previous module-level default no longer exists)
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `npm run typecheck` — no new errors
- [ ] Manual: trigger Sync Now with the server unreachable and confirm an alert appears
- [ ] Manual: cold-launch app on Home tab and confirm nothing crashes if Settings tab is never opened


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGyzvKuh9hPxaPfg6ZsEk4)_