### PR TITLE
Simplify completedCount to use completedDates.size

### DIFF
--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -117,18 +117,7 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
     );
     const total = isCurrentMonth ? now.getDate() : daysInMonth;
 
-    let completed = 0;
-    completedDates.forEach(dateStr => {
-      const date = new Date(dateStr + 'T00:00:00');
-      if (
-        date.getFullYear() === calendarYear &&
-        date.getMonth() === calendarMonth
-      ) {
-        completed++;
-      }
-    });
-
-    return {completedCount: completed, totalDays: total};
+    return {completedCount: completedDates.size, totalDays: total};
   }, [completedDates, calendarYear, calendarMonth]);
 
   const progressPercent =


### PR DESCRIPTION
## Summary
- `completedDates` is already fetched for only the selected month (see `getLogsForHabit` call at `StatsScreen.tsx:93` using `startDate`/`endDate` derived from `calendarYear`/`calendarMonth`).
- The year/month filter inside the `useMemo` at `StatsScreen.tsx:111-132` was dead code; replaced with `completedDates.size`.

## Test plan
- [ ] Open stats screen, verify monthly completed count matches calendar
- [ ] Switch months and confirm count updates correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpTWCheQqQnf6QtZ7sqata)_