### PR TITLE
Memoize weeks array in MonthCalendar

### DIFF
--- a/src/components/MonthCalendar.tsx
+++ b/src/components/MonthCalendar.tsx
@@ -87,12 +87,14 @@ const MonthCalendar: React.FC<MonthCalendarProps> = ({
     return days;
   }, [year, month, prevMonthDays.length, currentMonthDays.length]);
 
-  const allDays = [...prevMonthDays, ...currentMonthDays, ...nextMonthDays];
-
-  const weeks: typeof allDays[] = [];
-  for (let i = 0; i < allDays.length; i += 7) {
-    weeks.push(allDays.slice(i, i + 7));
-  }
+  const weeks = useMemo(() => {
+    const allDays = [...prevMonthDays, ...currentMonthDays, ...nextMonthDays];
+    const result: (typeof allDays)[] = [];
+    for (let i = 0; i < allDays.length; i += 7) {
+      result.push(allDays.slice(i, i + 7));
+    }
+    return result;
+  }, [prevMonthDays, currentMonthDays, nextMonthDays]);
 
   const handlePrevMonth = () => {
     if (month === 0) {


### PR DESCRIPTION
## Summary
- Wraps the `weeks` computation in `MonthCalendar.tsx` in `useMemo` for consistency with the surrounding memoized day arrays (`prevMonthDays`, `currentMonthDays`, `nextMonthDays`).
- Cost is negligible (6 array slices); change is purely for stylistic uniformity.

## Test plan
- [ ] Verify the calendar renders correctly and weeks display unchanged.
- [ ] Confirm month navigation still works.

https://claude.ai/code/session_01Br917XshstGirr5ZGKL8ou

---
_Generated by [Claude Code](https://claude.ai/code/session_01Br917XshstGirr5ZGKL8ou)_