### PR TITLE
fix(useHabits): drop inaccurate optimistic streak math

### DIFF
--- a/src/__tests__/screens/DashboardScreen.test.tsx
+++ b/src/__tests__/screens/DashboardScreen.test.tsx
@@ -160,7 +160,7 @@ describe('DashboardScreen', () => {
     ];
     const service = createMockServiceWithStreaks(habits);
 
-    const {getByTestId, getByText} = render(
+    const {getByTestId, queryByTestId, getByText} = render(
       <DashboardScreen habitService={service} />,
     );
 
@@ -168,22 +168,27 @@ describe('DashboardScreen', () => {
       expect(getByTestId('habit-card-1')).toBeTruthy();
     });
 
-    // Initially streak is 0
     expect(getByText('🔥 0 days')).toBeTruthy();
+    expect(queryByTestId('checkmark-1')).toBeNull();
 
-    // Now make toggle hang so we can observe the optimistic state
+    // Make toggle hang so we can observe the optimistic state.
     service.toggleHabitCompletion = jest.fn(
-      () => new Promise(() => {}), // Never resolves
+      () => new Promise(() => {}),
     ) as unknown as typeof service.toggleHabitCompletion;
 
     await act(async () => {
       fireEvent.press(getByTestId('toggle-1'));
     });
 
-    // The toggle was called but hasn't resolved - yet UI should already show streak of 1
+    // completedToday flips immediately so the checkmark renders, but the
+    // streak is not optimistically incremented — the real value arrives
+    // from calculateStreak after the write resolves. Showing the old
+    // streak is preferable to flashing an arithmetic guess that ignores
+    // yesterday's completion state.
     await waitFor(() => {
-      expect(getByText('🔥 1 day')).toBeTruthy();
+      expect(getByTestId('checkmark-1')).toBeTruthy();
     });
+    expect(getByText('🔥 0 days')).toBeTruthy();
   });
 
   // ─── Streak display ────────────────────────────────────────────────

--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -102,26 +102,19 @@ export function useHabits(habitService: HabitService) {
       const today = todayRef.current;
       const cache = streakCacheRef.current;
 
-      // Optimistic update
+      // Optimistically toggle completedToday only. The streak depends on
+      // whether yesterday (and earlier days) were completed, which we don't
+      // know here, so any local arithmetic on h.streak can show a wrong
+      // value for a frame. Leave streak unchanged until calculateStreak
+      // returns the authoritative value below.
       setHabits(prev =>
-        prev.map(h => {
-          if (h.id !== habitId) {
-            return h;
-          }
-          const nowCompleted = !h.completedToday;
-          const newStreak = nowCompleted ? h.streak + 1 : Math.max(h.streak - 1, 0);
-          cache.set(habitId, newStreak);
-          return {
-            ...h,
-            completedToday: nowCompleted,
-            streak: newStreak,
-          };
-        }),
+        prev.map(h =>
+          h.id === habitId ? {...h, completedToday: !h.completedToday} : h,
+        ),
       );
 
       try {
         await habitService.toggleHabitCompletion(habitId, today);
-        // Recalculate actual streak after successful write
         const actualStreak = await habitService.calculateStreak(habitId, today);
         cache.set(habitId, actualStreak);
         setHabits(prev =>
@@ -130,23 +123,12 @@ export function useHabits(habitService: HabitService) {
           ),
         );
       } catch {
-        // Revert optimistic update
         setHabits(prev =>
-          prev.map(h => {
-            if (h.id !== habitId) {
-              return h;
-            }
-            const reverted = !h.completedToday;
-            const revertedStreak = reverted
-              ? h.streak + 1
-              : Math.max(h.streak - 1, 0);
-            cache.set(habitId, revertedStreak);
-            return {
-              ...h,
-              completedToday: reverted,
-              streak: revertedStreak,
-            };
-          }),
+          prev.map(h =>
+            h.id === habitId
+              ? {...h, completedToday: !h.completedToday}
+              : h,
+          ),
         );
         throw new Error('Could not save. Please try again.');
       }


### PR DESCRIPTION
## Summary

- `useHabits.toggleHabit` was applying `h.streak ± 1` as an optimistic streak update. That math doesn't have the information needed to be correct — the post-toggle streak depends on whether yesterday (and earlier days) were completed, not just today. `calculateStreak` corrected the value afterwards, but the user saw a flash of a wrong streak in between.
- The fix keeps the optimistic flip of `completedToday` (so the checkmark still updates immediately) and leaves `streak` unchanged until `calculateStreak` returns the authoritative value. Showing the prior streak briefly is strictly preferable to flashing an arithmetic guess.
- Cleaned up the error-path revert, which previously re-derived a (still wrong) streak; now it just flips `completedToday` back.

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npx jest` — 213/213 pass.
- [x] Updated `DashboardScreen.test.tsx` "applies optimistic UI update immediately on toggle" to assert the checkmark appears immediately while the streak stays at the prior value until the calculation resolves.
- [ ] Manual smoke: toggle a habit and confirm the streak no longer flickers to an incorrect value before settling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEAXwpgzaPiF7P1wPktCib)_