### PR TITLE
Tighten api.ts retry budget, breaker, and token caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@react-navigation/native": "^7.1.33",
         "@react-navigation/native-stack": "^7.14.4",
         "axios": "^1.13.6",
-        "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
         "react": "19.0.0",
         "react-native": "0.78.1",
@@ -4899,18 +4898,6 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -8489,18 +8476,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@react-navigation/native": "^7.1.33",
     "@react-navigation/native-stack": "^7.14.4",
     "axios": "^1.13.6",
-    "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
     "react": "19.0.0",
     "react-native": "0.78.1",

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -19,6 +19,14 @@ jest.mock('../../services/api', () => {
     request: {use: jest.fn(), eject: jest.fn()},
     response: {use: jest.fn(), eject: jest.fn()},
   };
+  class CircuitOpenError extends Error {
+    constructor() {
+      super('Circuit breaker open: skipping request');
+      this.name = 'CircuitOpenError';
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-shadow
+  const AsyncStorage = require('@react-native-async-storage/async-storage');
   return {
     __esModule: true,
     default: {
@@ -26,6 +34,15 @@ jest.mock('../../services/api', () => {
       interceptors: mockInterceptors,
     },
     AUTH_TOKEN_KEY: 'auth_token',
+    CircuitOpenError,
+    isCircuitOpen: jest.fn(() => false),
+    setAuthToken: jest.fn(async (token: string | null) => {
+      if (token === null) {
+        await AsyncStorage.removeItem('auth_token');
+      } else {
+        await AsyncStorage.setItem('auth_token', token);
+      }
+    }),
   };
 });
 

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -16,6 +16,14 @@ jest.mock('../../services/api', () => {
     request: {use: jest.fn(), eject: jest.fn()},
     response: {use: jest.fn(), eject: jest.fn()},
   };
+  class CircuitOpenError extends Error {
+    constructor() {
+      super('Circuit breaker open: skipping request');
+      this.name = 'CircuitOpenError';
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-shadow
+  const AsyncStorage = require('@react-native-async-storage/async-storage');
   return {
     __esModule: true,
     default: {
@@ -23,6 +31,15 @@ jest.mock('../../services/api', () => {
       interceptors: mockInterceptors,
     },
     AUTH_TOKEN_KEY: 'auth_token',
+    CircuitOpenError,
+    isCircuitOpen: jest.fn(() => false),
+    setAuthToken: jest.fn(async (token: string | null) => {
+      if (token === null) {
+        await AsyncStorage.removeItem('auth_token');
+      } else {
+        await AsyncStorage.setItem('auth_token', token);
+      }
+    }),
   };
 });
 

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -1,7 +1,12 @@
 import {AppState} from 'react-native';
 import type {AppStateStatus} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import apiClient, {AUTH_TOKEN_KEY} from './api';
+import apiClient, {
+  AUTH_TOKEN_KEY,
+  CircuitOpenError,
+  isCircuitOpen,
+  setAuthToken,
+} from './api';
 import type HabitService from './HabitService';
 
 export const SYNC_SECRET_KEY = 'sync_secret';
@@ -83,7 +88,7 @@ export default class SyncService {
     try {
       const response = await apiClient.post('/auth/token', {secret});
       const {access_token} = response.data;
-      await AsyncStorage.setItem(AUTH_TOKEN_KEY, access_token);
+      await setAuthToken(access_token);
       await AsyncStorage.setItem(SYNC_SECRET_KEY, secret);
       await AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY);
     } catch (error: unknown) {
@@ -270,6 +275,11 @@ export default class SyncService {
       if (result.errors) {
         allErrors.push(...result.errors);
       }
+      // If repeated transient failures tripped the circuit breaker, stop now —
+      // every remaining batch would be rejected by the request interceptor.
+      if (isCircuitOpen()) {
+        break;
+      }
     }
 
     return {
@@ -280,6 +290,10 @@ export default class SyncService {
   }
 
   private handleSyncError(error: SyncError): SyncResult {
+    if (error instanceof CircuitOpenError) {
+      console.warn('Sync skipped: circuit breaker open');
+      return {pushed: 0, failed: 0};
+    }
     if (isNetworkError(error) || is5xxError(error)) {
       console.warn('Sync failed (will retry later):', error.message || 'Unknown error');
       return {pushed: 0, failed: 0};
@@ -299,7 +313,7 @@ export default class SyncService {
     try {
       const response = await apiClient.post('/auth/token', {secret});
       const {access_token} = response.data;
-      await AsyncStorage.setItem(AUTH_TOKEN_KEY, access_token);
+      await setAuthToken(access_token);
       await AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY);
       return true;
     } catch (e) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,32 +1,125 @@
-// TODO: axios + axios-retry add ~15-30KB gzipped to the bundle.
-// Consider replacing with native fetch + a small retry wrapper (~2KB)
-// to reduce bundle size. The app only uses basic GET/POST with retry logic.
+// TODO: axios adds ~15KB gzipped to the bundle. Consider replacing with
+// native fetch + a small retry wrapper (~2KB) to reduce bundle size. The
+// app only uses basic GET/POST with retry logic.
 import axios from 'axios';
-import axiosRetry from 'axios-retry';
+import type {AxiosError, InternalAxiosRequestConfig} from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const API_BASE_URL = 'https://habit-tracker.tunnel.example.com';
 export const AUTH_TOKEN_KEY = 'auth_token';
+
+// Per-request retry budget. axios-retry's default 3 retries with exponential
+// backoff stalls pushInBatches for ~28s per failing chunk; one quick retry is
+// enough to ride out a transient blip without holding the whole loop hostage.
+const MAX_RETRIES = 1;
+const RETRY_DELAY_MS = 500;
+
+// Circuit breaker. After this many consecutive failures we stop hitting the
+// network for COOLDOWN_MS so the rest of pushInBatches can fail fast instead
+// of paying the timeout + retry cost on every batch.
+const BREAKER_THRESHOLD = 3;
+const BREAKER_COOLDOWN_MS = 30_000;
+
+export class CircuitOpenError extends Error {
+  constructor() {
+    super('Circuit breaker open: skipping request');
+    this.name = 'CircuitOpenError';
+  }
+}
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
   timeout: 10000,
 });
 
+let cachedToken: string | null = null;
+let tokenHydrated = false;
+
+async function hydrateToken(): Promise<void> {
+  if (tokenHydrated) {
+    return;
+  }
+  cachedToken = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
+  tokenHydrated = true;
+}
+
+export async function setAuthToken(token: string | null): Promise<void> {
+  cachedToken = token;
+  tokenHydrated = true;
+  if (token === null) {
+    await AsyncStorage.removeItem(AUTH_TOKEN_KEY);
+  } else {
+    await AsyncStorage.setItem(AUTH_TOKEN_KEY, token);
+  }
+}
+
+let consecutiveFailures = 0;
+let breakerOpenedAt = 0;
+
+function breakerIsOpen(): boolean {
+  if (consecutiveFailures < BREAKER_THRESHOLD) {
+    return false;
+  }
+  if (Date.now() - breakerOpenedAt < BREAKER_COOLDOWN_MS) {
+    return true;
+  }
+  // Cooldown elapsed: half-open — allow the next attempt to probe.
+  consecutiveFailures = 0;
+  return false;
+}
+
+export function isCircuitOpen(): boolean {
+  return breakerIsOpen();
+}
+
+function isRetryableError(error: AxiosError): boolean {
+  if (!error.response) {
+    return true;
+  }
+  return error.response.status >= 500;
+}
+
 apiClient.interceptors.request.use(async config => {
-  const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  if (breakerIsOpen()) {
+    throw new CircuitOpenError();
+  }
+  await hydrateToken();
+  if (cachedToken) {
+    config.headers.Authorization = `Bearer ${cachedToken}`;
   }
   return config;
 });
 
-axiosRetry(apiClient, {
-  retries: 3,
-  retryDelay: (retryCount: number) => Math.pow(2, retryCount - 1) * 1000,
-  retryCondition: error =>
-    axiosRetry.isNetworkError(error) ||
-    (error.response != null && error.response.status >= 500),
-});
+type RetryableConfig = InternalAxiosRequestConfig & {__retryCount?: number};
+
+apiClient.interceptors.response.use(
+  response => {
+    consecutiveFailures = 0;
+    return response;
+  },
+  async (error: AxiosError) => {
+    if (error instanceof CircuitOpenError) {
+      return Promise.reject(error);
+    }
+
+    const config = error.config as RetryableConfig | undefined;
+    const attempts = config?.__retryCount ?? 0;
+    if (config && attempts < MAX_RETRIES && isRetryableError(error)) {
+      config.__retryCount = attempts + 1;
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+      return apiClient.request(config);
+    }
+
+    // Only count transient failures against the breaker — 4xx is a client
+    // problem the breaker can't help with.
+    if (isRetryableError(error)) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures === BREAKER_THRESHOLD) {
+        breakerOpenedAt = Date.now();
+      }
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default apiClient;


### PR DESCRIPTION
## Summary

Addresses two of the three `api.ts` review items. The third — hardcoded `API_BASE_URL` — needs `react-native-config` + native wiring and is left for a separate branch.

### 1. Retry / circuit breaker (`api.ts:24-30`)
`axios-retry`'s default 3 retries with exponential backoff (1s + 2s + 4s) × 10s timeout meant one failing chunk could stall `SyncService.pushInBatches` for ~28s, and every subsequent chunk paid the same cost.

- Drop `axios-retry` (and its dep entry).
- Per-request budget: 1 retry, 500ms delay, only on network errors / 5xx.
- Circuit breaker: trips after 3 consecutive transient failures, stays open 30s. While open, the request interceptor rejects with `CircuitOpenError` synchronously.
- `pushInBatches` checks `isCircuitOpen()` after each batch and bails, so a failing chunk no longer dooms the rest of the loop.

### 2. Token caching (`api.ts:16-22`)
Interceptor used to read `AsyncStorage` on every request.

- Module-scope `cachedToken`, hydrated lazily on first request.
- New `setAuthToken(token | null)` keeps cache + storage in sync; called from `SyncService.authenticate` and `attemptReauth`.

### Not in this PR
- `API_BASE_URL` build-config gating — needs `react-native-config` + Android/iOS native config; will be a separate branch.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 213/213 pass (incl. 62 SyncService tests; updated mocks to expose `CircuitOpenError`, `isCircuitOpen`, `setAuthToken`)
- [x] `npm run lint` — 0 new errors (only pre-existing warnings remain)
- [ ] Manual: force backend 5xx, confirm `pushInBatches` exits after ~3 batches instead of grinding through all 50
- [ ] Manual: verify `AsyncStorage.getItem` is called once per app launch, not per request

---
_Generated by [Claude Code](https://claude.ai/code/session_01FitwjRS2vYHCoWXBdZKJXd)_