### PR TITLE
fix(modal): reset creating state in finally block

### DIFF
--- a/src/screens/CreateHabitModal.tsx
+++ b/src/screens/CreateHabitModal.tsx
@@ -42,6 +42,8 @@ const CreateHabitModal: React.FC<CreateHabitModalProps> = ({
       await service.createHabit(trimmedName);
       navigation?.goBack();
     } catch {
+      // ignore; user can retry
+    } finally {
       setCreating(false);
     }
   }, [isValid, creating, service, trimmedName, navigation]);


### PR DESCRIPTION
## Summary

Move `setCreating(false)` in `CreateHabitModal` into a `finally` clause so the flag is cleared on both success and error paths.

Previously the success branch called `navigation?.goBack()` but never reset `creating`. In the current navigator the component unmounts, so the leak is invisible — but if the modal is ever reused or hosted inside a non-unmounting navigator (e.g. switched to a sheet), the Create button would stay stuck in its disabled/in-flight state on the next open.

## Changes

- `src/screens/CreateHabitModal.tsx`: empty `catch`, reset `creating` in `finally`.

## Test plan

- [x] `npx jest src/__tests__/screens/CreateHabitModal.test.tsx` — all 8 tests pass.
- [ ] Manually verify: open modal → create habit → reopen → button is enabled (only relevant under a non-unmounting host).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFj7PvqkmQNqtwkkjy5VAJ)_