### PR TITLE
Pass componentName to useHabitObservable instead of stack-sniffing

### DIFF
--- a/src/hooks/useHabitObservable.ts
+++ b/src/hooks/useHabitObservable.ts
@@ -8,28 +8,16 @@ import type {Observable} from 'rxjs';
  *
  * @param observable$ - An RxJS observable (e.g. from WatermelonDB .observe())
  * @param initialValue - The initial value before the first emission
+ * @param componentName - Caller name used in dev-mode leak warnings
  * @returns The latest emitted value
  */
 export function useHabitObservable<T>(
   observable$: Observable<T> | null | undefined,
   initialValue: T,
+  componentName: string,
 ): T {
   const [value, setValue] = useState<T>(initialValue);
   const mountedRef = useRef(true);
-  const componentNameRef = useRef<string>('');
-
-  // Capture the component name for dev-mode warnings (via stack trace)
-  useEffect(() => {
-    if (__DEV__) {
-      try {
-        throw new Error('useHabitObservable caller');
-      } catch (e: unknown) {
-        const stack = (e as Error).stack ?? '';
-        const callerLine = stack.split('\n')[2] ?? '';
-        componentNameRef.current = callerLine.trim();
-      }
-    }
-  }, []);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -46,7 +34,7 @@ export function useHabitObservable<T>(
           console.warn(
             '[useHabitObservable] Subscription fired after unmount. ' +
               'This indicates a potential memory leak. ' +
-              `Source: ${componentNameRef.current}`,
+              `Source: ${componentName}`,
           );
         }
       },
@@ -56,7 +44,7 @@ export function useHabitObservable<T>(
       mountedRef.current = false;
       subscription.unsubscribe();
     };
-  }, [observable$]);
+  }, [observable$, componentName]);
 
   return value;
 }

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -48,9 +48,9 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   const nService = notificationService ?? defaultNotificationService;
 
   const allHabits$ = useMemo(() => hService.getAllHabits(), [hService]);
-  const habits = useHabitObservable<Habit[]>(allHabits$, []);
+  const habits = useHabitObservable<Habit[]>(allHabits$, [], 'SettingsScreen');
   const unsyncedCount$ = useMemo(() => hService.observeUnsyncedCount(), [hService]);
-  const unsyncedCount = useHabitObservable<number>(unsyncedCount$, 0);
+  const unsyncedCount = useHabitObservable<number>(unsyncedCount$, 0, 'SettingsScreen');
   const [reminderEnabled, setReminderEnabled] = useState(false);
   const [reminderTime, setReminderTime] = useState('08:00');
   const [syncStatus, setSyncStatus] = useState<'online' | 'offline' | 'auth_failed'>('online');


### PR DESCRIPTION
## Summary
- Replaces `new Error().stack` introspection in `useHabitObservable` with an explicit `componentName` parameter, matching the pattern used by `useSubscriptionLeakDetector`.
- Drops the forced throw on every mount and the brittle dependency on Hermes' stack format.
- Updates the two call sites in `SettingsScreen.tsx` to pass `'SettingsScreen'`.

## Test plan
- [ ] `npm run typecheck`
- [ ] Manual: mount/unmount Settings screen in dev; confirm leak warnings still identify `SettingsScreen` as the source if a subscription fires after unmount.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb3Y9PfPxwBBVxfSy9qV7d)_