### PR TITLE
Fix jest.config.js typo: setupFilesAfterSetup → setupFilesAfterEnv

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  setupFilesAfterSetup: [],
+  setupFilesAfterEnv: [],
   moduleNameMapper: {
     '^@nozbe/watermelondb$': '<rootDir>/node_modules/@nozbe/watermelondb',
     '^@nozbe/watermelondb/(.*)$': '<rootDir>/node_modules/@nozbe/watermelondb/$1',


### PR DESCRIPTION
## Summary
- `jest.config.js:4` had `setupFilesAfterSetup: []`, which is not a recognized Jest config key and was silently ignored.
- Renamed to the correct key `setupFilesAfterEnv` per the [Jest docs](https://jestjs.io/docs/configuration#setupfilesafterenv-array) so any setup files added later actually run.

## Test plan
- [ ] `npx jest --showConfig` lists `setupFilesAfterEnv` (no warning about unknown options)
- [ ] `npm test` continues to pass

https://claude.ai/code/session_01V9WXR9FUC65KxsmUMjDuvM

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9WXR9FUC65KxsmUMjDuvM)_