### PR TITLE
Clearer startup error for missing DATABASE_URL/JWT_SECRET

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import ValidationError
 from pydantic_settings import BaseSettings
 
 
@@ -12,4 +13,21 @@ class Settings(BaseSettings):
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 
-settings = Settings()
+try:
+    settings = Settings()
+except ValidationError as exc:
+    missing = sorted(
+        {
+            str(err["loc"][0]).upper()
+            for err in exc.errors()
+            if err.get("type") == "missing" and err.get("loc")
+        }
+    )
+    if not missing:
+        raise
+    raise RuntimeError(
+        "Missing required environment variable(s): "
+        + ", ".join(missing)
+        + ". Set them in the process environment or a .env file "
+        "(see backend/.env.example)."
+    ) from exc

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,25 @@
+import importlib
+
+import pytest
+
+
+def test_missing_env_vars_raises_clear_error(monkeypatch, tmp_path):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    # pydantic-settings reads a sibling .env if present; chdir to an
+    # empty tmp dir so the test doesn't pick up a developer's local one.
+    monkeypatch.chdir(tmp_path)
+
+    import app.config
+
+    with pytest.raises(RuntimeError) as exc_info:
+        importlib.reload(app.config)
+
+    message = str(exc_info.value)
+    assert "DATABASE_URL" in message
+    assert "JWT_SECRET" in message
+    assert ".env.example" in message
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    importlib.reload(app.config)


### PR DESCRIPTION
## Summary
- PR #49 removed the defaults from `database_url` / `jwt_secret` in `backend/app/config.py`. Deployments that weren't already exporting those env vars (or loading `backend/.env.example` via docker-compose) started crashing at import time with a raw Pydantic `ValidationError`, which made the failure hard to attribute on the deploy side.
- Wrap `Settings()` to catch the missing-field validation error and re-raise a `RuntimeError` that names the variables and points at `backend/.env.example`.
- Secrets remain required — no fallback to hardcoded defaults.

## Test plan
- [x] Manually verified: with both env vars set, `from app.config import settings` succeeds; with them unset, the new `RuntimeError` is raised with `DATABASE_URL`, `JWT_SECRET`, and `.env.example` mentioned in the message.
- [x] New `backend/tests/test_config.py` covers the missing-vars path via `importlib.reload`.
- [ ] CI backend-tests job (will run on push).

## Notes
- The full pytest suite couldn't be executed locally in the sandbox due to an unrelated `cryptography` / `pyo3` panic in the container; CI should run cleanly.

https://claude.ai/code/session_01AfJi7hjHN85MhQSDPSaofx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQvQH1LXvKTxxkyhu9sGAv)_