### PR TITLE
Mock CircuitOpenError in SyncService.untoggle test

### DIFF
--- a/src/__tests__/services/SyncService.untoggle.test.ts
+++ b/src/__tests__/services/SyncService.untoggle.test.ts
@@ -27,6 +27,15 @@ jest.mock('../../services/api', () => {
     request: {use: jest.fn(), eject: jest.fn()},
     response: {use: jest.fn(), eject: jest.fn()},
   };
+  // SyncService.handleSyncError does `error instanceof CircuitOpenError`,
+  // so the mock has to expose the class or the runtime check throws
+  // "Right-hand side of 'instanceof' is not an object".
+  class CircuitOpenError extends Error {
+    constructor(message: string = 'Circuit breaker open') {
+      super(message);
+      this.name = 'CircuitOpenError';
+    }
+  }
   return {
     __esModule: true,
     default: {
@@ -34,6 +43,7 @@ jest.mock('../../services/api', () => {
       interceptors: mockInterceptors,
     },
     AUTH_TOKEN_KEY: 'auth_token',
+    CircuitOpenError,
   };
 });
 


### PR DESCRIPTION
## Summary
- `src/__tests__/services/SyncService.untoggle.test.ts` mocks `../../services/api` but only exposes `default` and `AUTH_TOKEN_KEY` — `CircuitOpenError` is missing from the factory.
- `SyncService.handleSyncError` does `if (error instanceof CircuitOpenError)`, so the first test that actually triggers an error path (`a network failure during the push leaves the tombstone pending for retry`) throws `TypeError: Right-hand side of 'instanceof' is not an object`.
- The two sibling test files (`SyncService.test.ts`, `SyncService.hardening.test.ts`) already declare a mock `CircuitOpenError` class inside their factory for this exact reason — copy the same pattern here.

## Test plan
- [x] `npx jest src/__tests__/services/SyncService.untoggle.test.ts` — 6/6 pass locally (previously 5/6).

## Context
Discovered while investigating CI on #55 — the failure pre-existed that PR and is unrelated to it.

https://claude.ai/code/session_01AfJi7hjHN85MhQSDPSaofx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQvQH1LXvKTxxkyhu9sGAv)_