### PR TITLE
Wire up real sync: production API URL, secret input, background sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ android/.kotlin/
 # Android signing properties (real values; example template is checked in)
 android/keystore.properties
 
+# Backend secrets (real values; .env.example template is checked in)
+backend/.env
+.env
+
 # Bundle artifacts
 *.jsbundle
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       MARIADB_ROOT_PASSWORD: secret
       MARIADB_DATABASE: habits
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:
@@ -13,16 +13,18 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    restart: unless-stopped
 
   api:
     build: .
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     env_file:
-      - .env.example
+      - .env
     depends_on:
       db:
         condition: service_healthy
+    restart: unless-stopped
 
   tunnel:
     image: cloudflare/cloudflared:latest

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,13 @@ import {NavigationContainer} from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AppNavigator from './navigation/AppNavigator';
 import NotificationService from './services/NotificationService';
+import HabitService from './services/HabitService';
+import SyncService from './services/SyncService';
+import database from './models';
 
 const notificationService = new NotificationService();
+const habitService = new HabitService(database);
+const syncService = new SyncService(habitService);
 
 const App: React.FC = () => {
   // Reschedule notifications on app launch.
@@ -19,6 +24,14 @@ const App: React.FC = () => {
         await notificationService.scheduleDailyReminder(hour, minute);
       }
     })();
+  }, []);
+
+  // Push unsynced logs once at launch, then again whenever the app
+  // returns to the foreground.
+  useEffect(() => {
+    syncService.pushUnsyncedLogs();
+    syncService.startBackgroundSync();
+    return () => syncService.stopBackgroundSync();
   }, []);
 
   return (

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -182,7 +182,7 @@ describe('SettingsScreen', () => {
 
     expect(getByTestId('app-version').props.children).toBe('0.0.1');
     expect(getByTestId('server-url').props.children).toBe(
-      'https://habit-tracker.tunnel.example.com',
+      'https://habit-api.darling.solutions',
     );
   });
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   Switch,
   FlatList,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   Alert,
@@ -16,7 +17,7 @@ import {colors} from '../theme/colors';
 import {fontFamily, typeScale} from '../theme/typography';
 import {spacing} from '../theme/spacing';
 import HabitService from '../services/HabitService';
-import SyncService from '../services/SyncService';
+import SyncService, {AuthenticationError} from '../services/SyncService';
 import NotificationService from '../services/NotificationService';
 import {API_BASE_URL} from '../services/api';
 import database from '../models';
@@ -55,6 +56,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   const [syncStatus, setSyncStatus] = useState<'online' | 'offline' | 'auth_failed'>('online');
   const [lastSyncTime, setLastSyncTime] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
+  const [secretInput, setSecretInput] = useState('');
+  const [connecting, setConnecting] = useState(false);
 
   // Load notification preferences
   useEffect(() => {
@@ -152,6 +155,30 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
       setSyncing(false);
     }
   }, [sService]);
+
+  const handleConnect = useCallback(async () => {
+    const secret = secretInput.trim();
+    if (!secret) {
+      return;
+    }
+    setConnecting(true);
+    try {
+      await sService.authenticate(secret);
+      setSecretInput('');
+      const status = await sService.getSyncStatus();
+      setSyncStatus(status.status);
+      setUnsyncedCount(status.pendingCount);
+      Alert.alert('Connected', 'Sync is now enabled on this device.');
+    } catch (err: unknown) {
+      const message =
+        err instanceof AuthenticationError
+          ? err.message
+          : 'Could not reach the server. Check your connection and try again.';
+      Alert.alert('Connection failed', message);
+    } finally {
+      setConnecting(false);
+    }
+  }, [sService, secretInput]);
 
   const renderHabitRow = useCallback(
     ({item}: {item: Habit}) => (
@@ -286,6 +313,36 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
             Last sync: {format(new Date(lastSyncTime), 'MMM d, yyyy h:mm a')}
           </Text>
         )}
+
+        <View style={styles.connectBlock}>
+          <Text style={styles.connectLabel}>Sync Secret</Text>
+          <TextInput
+            testID="sync-secret-input"
+            style={styles.connectInput}
+            value={secretInput}
+            onChangeText={setSecretInput}
+            placeholder="Paste your server secret"
+            placeholderTextColor={colors.textSecondary}
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry
+            editable={!connecting}
+          />
+          <TouchableOpacity
+            style={[
+              styles.connectButton,
+              (connecting || secretInput.trim().length === 0) && styles.connectButtonDisabled,
+            ]}
+            onPress={handleConnect}
+            disabled={connecting || secretInput.trim().length === 0}
+            testID="connect-button">
+            {connecting ? (
+              <ActivityIndicator color={colors.textPrimary} testID="connect-spinner" />
+            ) : (
+              <Text style={styles.connectButtonText}>Connect</Text>
+            )}
+          </TouchableOpacity>
+        </View>
       </View>
 
       {/* About */}
@@ -427,6 +484,44 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.body,
     ...typeScale.caption,
     color: colors.textSecondary,
+  },
+  connectBlock: {
+    marginTop: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  connectLabel: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+    marginBottom: spacing.sm,
+  },
+  connectInput: {
+    fontFamily: fontFamily.body,
+    ...typeScale.body,
+    color: colors.textPrimary,
+    backgroundColor: colors.background,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  connectButton: {
+    backgroundColor: colors.clemsonOrange,
+    borderRadius: 8,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+  },
+  connectButtonDisabled: {
+    opacity: 0.5,
+  },
+  connectButtonText: {
+    fontFamily: fontFamily.heading,
+    ...typeScale.body,
+    color: colors.textPrimary,
   },
 });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 import axiosRetry from 'axios-retry';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export const API_BASE_URL = 'https://habit-tracker.tunnel.example.com';
+export const API_BASE_URL = 'https://habit-api.darling.solutions';
 export const AUTH_TOKEN_KEY = 'auth_token';
 
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- The deployed APK pointed at the placeholder `habit-tracker.tunnel.example.com`, had no UI to enter the auth secret, and never registered the foreground sync listener. Result: logs accumulated on-device and never synced.
- This change wires `API_BASE_URL` to `https://habit-api.darling.solutions`, adds a Sync Secret input + Connect button in Settings, and starts background sync (plus a one-shot push) on app launch.
- Backend hardening: bind container ports to `127.0.0.1` only so cloudflared is the sole ingress, load `.env` instead of the committed `.env.example` template, gitignore `backend/.env`, and add `restart: unless-stopped` so the backend survives reboot.

## Server side (already done out-of-band)
- Backend brought up via `docker compose up -d` (FastAPI on `127.0.0.1:8000`, MariaDB on `127.0.0.1:3306`).
- Alembic migration `001` applied.
- Added `habit-api.darling.solutions` ingress rule to the existing shared cloudflared tunnel (`/etc/cloudflared/config.yml`), created the DNS CNAME via `cloudflared tunnel route dns`, restarted cloudflared.
- Verified: `GET https://habit-api.darling.solutions/health` → `200 {"status":"ok"}`; `POST /auth/token` with the right secret → JWT; wrong secret → 401. The existing `sports.darling.solutions` tunnel still serves.

## Test plan
- [ ] CI passes (lint, jest, signed release build).
- [ ] Install the new APK on the Pixel (via Obtainium notification).
- [ ] Open Settings → "About" → confirm Server URL reads `https://habit-api.darling.solutions`.
- [ ] In Settings → Sync, paste the JWT secret into "Sync Secret" → tap Connect → alert says "Connected".
- [ ] Sync status flips to "online" (or "0 logs pending sync" if no pending).
- [ ] Log a habit completion → tap "Sync Now" → confirm "Last sync" updates.
- [ ] Background test: force-stop the app, log nothing, foreground it again → confirm `pushUnsyncedLogs` runs (no UI signal — verify by querying `/logs` or by checking the next sync status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)