### PR TITLE
Make Sync Secret entry resilient to O/0 confusion and keyboard overlap

### DIFF
--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import {Alert} from 'react-native';
 import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
 import SettingsScreen from '../../screens/SettingsScreen';
 import HabitService from '../../services/HabitService';
-import SyncService from '../../services/SyncService';
+import SyncService, {AuthenticationError} from '../../services/SyncService';
 import NotificationService from '../../services/NotificationService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {of} from 'rxjs';
@@ -236,5 +237,176 @@ describe('SettingsScreen', () => {
 
     expect(getByTestId('pending-sync-count').props.children).toBe(1);
     expect(getByText(/1.*log.*pending sync/)).toBeTruthy();
+  });
+
+  it('authenticates and shows success alert when Connect is tapped with a secret', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('sync-secret-input'), 'my-secret');
+    await act(async () => {
+      fireEvent.press(getByTestId('connect-button'));
+    });
+
+    expect(syncService.authenticate).toHaveBeenCalledWith('my-secret');
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Connected',
+      expect.stringContaining('Sync is now enabled'),
+    );
+  });
+
+  it('trims whitespace from the secret before calling authenticate', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('sync-secret-input'), '  padded-secret  ');
+    await act(async () => {
+      fireEvent.press(getByTestId('connect-button'));
+    });
+
+    expect(syncService.authenticate).toHaveBeenCalledWith('padded-secret');
+  });
+
+  it('shows an error alert when authenticate rejects with AuthenticationError', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    (syncService.authenticate as jest.Mock).mockRejectedValueOnce(
+      new AuthenticationError('Invalid secret'),
+    );
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('sync-secret-input'), 'wrong');
+    await act(async () => {
+      fireEvent.press(getByTestId('connect-button'));
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith('Connection failed', 'Invalid secret');
+  });
+
+  it('shows a generic error message when authenticate rejects with a non-Authentication error', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    (syncService.authenticate as jest.Mock).mockRejectedValueOnce(
+      new Error('boom'),
+    );
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    fireEvent.changeText(getByTestId('sync-secret-input'), 'anything');
+    await act(async () => {
+      fireEvent.press(getByTestId('connect-button'));
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Connection failed',
+      expect.stringContaining('Could not reach the server'),
+    );
+  });
+
+  it('does not call authenticate when the input is empty', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('connect-button')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('connect-button'));
+    });
+
+    expect(syncService.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('toggles secureTextEntry when the Show/Hide control is tapped', async () => {
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(true);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('toggle-secret-visibility'));
+    });
+
+    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(false);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('toggle-secret-visibility'));
+    });
+
+    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(true);
+  });
+
+  it('does not crash when the secret input gains focus (scroll-to-end handler)', async () => {
+    jest.useFakeTimers();
+    const service = createMockHabitService([]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('sync-secret-input')).toBeTruthy();
+    });
+
+    // The handler schedules scrollRef.current?.scrollToEnd inside a 50ms
+    // setTimeout. We can't hook the ScrollView ref from outside the
+    // component, but firing focus + advancing timers exercises the path
+    // and asserts it doesn't throw on a null/undefined ref.
+    expect(() => {
+      fireEvent(getByTestId('sync-secret-input'), 'focus');
+      jest.advanceTimersByTime(60);
+    }).not.toThrow();
+
+    jest.useRealTimers();
   });
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
   View,
   Text,
@@ -61,6 +61,8 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   const [syncing, setSyncing] = useState(false);
   const [secretInput, setSecretInput] = useState('');
   const [connecting, setConnecting] = useState(false);
+  const [showSecret, setShowSecret] = useState(false);
+  const scrollRef = useRef<ScrollView>(null);
 
   // Load notification preferences
   useEffect(() => {
@@ -215,8 +217,10 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
 
   return (
     <ScrollView
+      ref={scrollRef}
       style={styles.screen}
       contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
       testID="settings-screen">
       {/* Your Habits */}
       <Text style={styles.sectionTitle}>Your Habits</Text>
@@ -321,7 +325,16 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         )}
 
         <View style={styles.connectBlock}>
-          <Text style={styles.connectLabel}>Sync Secret</Text>
+          <View style={styles.connectLabelRow}>
+            <Text style={styles.connectLabel}>Sync Secret</Text>
+            <TouchableOpacity
+              onPress={() => setShowSecret(s => !s)}
+              testID="toggle-secret-visibility">
+              <Text style={styles.connectToggle}>
+                {showSecret ? 'Hide' : 'Show'}
+              </Text>
+            </TouchableOpacity>
+          </View>
           <TextInput
             testID="sync-secret-input"
             style={styles.connectInput}
@@ -331,8 +344,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
             placeholderTextColor={colors.textSecondary}
             autoCapitalize="none"
             autoCorrect={false}
-            secureTextEntry
+            secureTextEntry={!showSecret}
             editable={!connecting}
+            // Android's adjustResize shrinks the window but doesn't scroll the
+            // ScrollView. Without this, the focused input sits behind the
+            // keyboard on tall keyboards (e.g. Pixel 10a).
+            onFocus={() => {
+              // Delay one tick so layout settles after the keyboard appears.
+              setTimeout(() => scrollRef.current?.scrollToEnd({animated: true}), 50);
+            }}
           />
           <TouchableOpacity
             style={[
@@ -497,11 +517,23 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: colors.border,
   },
+  connectLabelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
   connectLabel: {
     fontFamily: fontFamily.body,
     ...typeScale.body,
     color: colors.textPrimary,
-    marginBottom: spacing.sm,
+  },
+  connectToggle: {
+    fontFamily: fontFamily.body,
+    ...typeScale.caption,
+    color: colors.clemsonOrange,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
   },
   connectInput: {
     fontFamily: fontFamily.body,


### PR DESCRIPTION
## Summary
After PR #57 landed and the Pixel was set up, two papercuts blocked actually connecting:

1. The base64url-style JWT secret had both `0` (zero) and `O` (capital O) in it, the input is `secureTextEntry`, and the server returns a flat "Invalid secret" — so an O→0 paste/transcription error was invisible to the user. Server-side diagnostic instrumentation (since reverted) confirmed the phone was sending `0` at index 51 where the server expected `O`.
2. Android's `adjustResize` shrank the window but didn't scroll the ScrollView, so the focused Sync Secret field sat behind the soft keyboard on the Pixel 10a.

## Changes
- Add a "Show / Hide" toggle next to the Sync Secret label that flips `secureTextEntry`. The user can verify the pasted value before tapping Connect, instead of guessing at what got into the field.
- On TextInput focus, `scrollRef.current?.scrollToEnd({animated: true})` after a 50 ms delay so layout settles after the keyboard appears.
- Add `keyboardShouldPersistTaps="handled"` so the Connect button is still tappable while the keyboard is up.

The server-side JWT secret was also rotated out-of-band to a 48-char alphabet that excludes `0/O/1/I/l/i/o` so future entry is unambiguous.

## Test plan
- [ ] CI passes (lint, jest, signed release).
- [ ] On the Pixel: tap the Sync Secret field → focused input scrolls into view above the keyboard.
- [ ] Tap "Show" → secret characters become visible; tap "Hide" → masked again.
- [ ] Paste new secret → "Connected" alert → status flips to online → "Sync Now" pushes any pending logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)