### PR TITLE
Cleanup: theme tokens (WT1)

### DIFF
--- a/src/__tests__/theme.test.ts
+++ b/src/__tests__/theme.test.ts
@@ -58,8 +58,6 @@ describe('theme design system', () => {
       'body',
       'mono',
       'heading',
-      'headingFallback',
-      'bodyFallback',
     ];
 
     it.each(expectedFontKeys)(
@@ -78,11 +76,9 @@ describe('theme design system', () => {
       'display02',
       'display03',
       'label',
-      'h1',
       'h2',
       'body',
       'caption',
-      'streak',
     ];
 
     it.each(expectedScaleKeys)(

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,9 +1,9 @@
-// Soft Clemson v3 — Pixel 10a habit tracker palette.
-// No black: text-only ink. Two-tier tiger + two-tier regalia do the
-// contrast work that black used to.
+// App color tokens. Warm "tiger + regalia" palette; no pure black — the
+// two-tier tiger and two-tier regalia ramps do the contrast work that
+// black used to.
 
 export const colors = Object.freeze({
-  // Soft Clemson core
+  // Core surfaces and ink
   paper: '#F2EBDC',
   card: '#FAF5EA',
   text: '#2E2A26',
@@ -28,16 +28,18 @@ export const colors = Object.freeze({
 
   // Legacy keys retained for backward compatibility with consumers that
   // still import them, remapped onto the new palette.
-  background: '#F2EBDC',
-  surface: '#FAF5EA',
-  clemsonOrange: '#C7754A',
-  regaliaPurple: '#6A5A86',
-  textPrimary: '#2E2A26',
-  textSecondary: '#5B544B',
-  success: '#C7754A',
-  streakGold: '#C7754A',
-  error: '#8E4F2E',
-  border: '#6A5A86',
+  background: '#F2EBDC', // alias of paper — primary screen background
+  surface: '#FAF5EA', // alias of card — raised surfaces
+  clemsonOrange: '#C7754A', // alias of tiger — kept for older imports
+  regaliaPurple: '#6A5A86', // alias of regalia — kept for older imports
+  textPrimary: '#2E2A26', // alias of text
+  textSecondary: '#5B544B', // alias of textSoft
+  // Semantic status colors, tuned to sit alongside the warm palette while
+  // staying visually distinct from tiger (orange) and tigerDeep (shadow).
+  success: '#5C7A4E', // muted olive-green — reads as "ok/done" without clashing
+  streakGold: '#C8A24B', // warm gold — distinct from tiger orange
+  error: '#8C2F36', // burgundy red — clearly different from tigerDeep shadow
+  border: '#6A5A86', // alias of line
 });
 
 export type Colors = typeof colors;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,4 +1,4 @@
-// Soft Clemson v3 — Archivo Black / Space Grotesk / Space Mono.
+// Type tokens and font family mapping.
 // Font files must be present in /assets/fonts and linked via
 // `npx react-native-asset` for the custom families to resolve; until
 // then RN falls back to the system font automatically.
@@ -9,26 +9,23 @@ export const fontFamily = {
   body: 'Space Grotesk',
   mono: 'Space Mono',
 
-  // Legacy keys retained so existing consumers (and theme.test.ts) keep
-  // compiling. heading/body map onto the new display/body fonts.
+  // deprecated: use display
   heading: 'Archivo Black',
-  headingFallback: 'sans-serif',
-  bodyFallback: 'sans-serif',
 } as const;
 
 export const typeScale = {
-  // Soft Clemson v3 display scale
+  // Display scale
   display01: {fontSize: 86, lineHeight: 71}, // TODAY headline
   display02: {fontSize: 60, lineHeight: 51},
   display03: {fontSize: 28, lineHeight: 28},
   label: {fontSize: 13, lineHeight: 16},
 
-  // Legacy keys retained
-  h1: {fontSize: 32, lineHeight: 40},
+  // deprecated: use display02 or display03
   h2: {fontSize: 24, lineHeight: 32},
+  // deprecated: use label
   body: {fontSize: 16, lineHeight: 24},
+  // deprecated: use label
   caption: {fontSize: 12, lineHeight: 16},
-  streak: {fontSize: 48, lineHeight: 56},
 } as const;
 
 export type FontFamily = typeof fontFamily;


### PR DESCRIPTION
## Summary

Theme-only cleanup pass (Soft Clemson v3 review batch).

- **#59 WT1-01** — Fixed the legacy compat block in `src/theme/colors.ts`. Previously `success`, `streakGold`, and `error` all aliased to `tiger` / `tigerDeep` (orange and shadow color), so any consumer using `colors.success` rendered an orange checkmark instead of a "success" green. Re-aliased to visually distinct values that still fit the warm palette: `success` → muted olive `#5C7A4E`, `streakGold` → warm gold `#C8A24B`, `error` → burgundy `#8C2F36`. Each surviving alias gets a one-line comment explaining its mapping.
- **#60 WT1-02** — Stripped "Soft Clemson v3 / Pixel 10a" sprint branding from the headers of `colors.ts` and `typography.ts`. Replaced with brief, evergreen descriptions.
- **#61 WT1-03** — Removed fully-orphaned `typeScale.h1`, `typeScale.streak`, `fontFamily.headingFallback`, `fontFamily.bodyFallback`. Marked `h2` / `body` / `caption` / `heading` as `// deprecated: use <newKey>` because MonthCalendar, DashboardScreen, and ErrorBoundary still consume them — migrating those callsites is out of scope here. Updated `theme.test.ts` `expectedFontKeys` / `expectedScaleKeys` accordingly.

## Test plan

- [x] `npx jest` — 245/245 pass, 3 snapshots pass. (Drop of 4 vs baseline = 4 fewer `it.each` cases for the removed keys.)
- [ ] Manual check: confirm new success/error/streakGold values look right in any UI that eventually adopts them (currently no live consumers — they're defined for forward use).

## Follow-ups (out of scope)

- Migrate `MonthCalendar`, `DashboardScreen`, `ErrorBoundary` off the deprecated `typeScale.h2/body/caption` and `fontFamily.heading` keys.
- If no UI ever adopts the legacy semantic aliases (success / streakGold / error), a follow-up could delete them outright and drop them from the test.

Closes #59
Closes #60
Closes #61