### PR TITLE
Cleanup: atom perf + radii split (WT2)

### DIFF
--- a/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
@@ -45,13 +45,17 @@ exports[`DashboardScreen matches snapshot 1`] = `
               {
                 "alignSelf": "flex-start",
                 "borderRadius": 999,
+                "borderWidth": 2,
                 "paddingHorizontal": 10,
                 "paddingVertical": 4,
               },
               {
                 "backgroundColor": "#FAF5EA",
                 "borderColor": "#6A5A86",
-                "borderWidth": 2,
+              },
+              {
+                "backgroundColor": "#FAF5EA",
+                "borderColor": "#6A5A86",
               },
               undefined,
             ]
@@ -71,6 +75,7 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 {
                   "color": "#2E2A26",
                 },
+                null,
                 undefined,
               ]
             }
@@ -118,13 +123,17 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 {
                   "alignSelf": "flex-start",
                   "borderRadius": 999,
+                  "borderWidth": 2,
                   "paddingHorizontal": 10,
                   "paddingVertical": 4,
                 },
                 {
+                  "backgroundColor": "#FAF5EA",
+                  "borderColor": "#6A5A86",
+                },
+                {
                   "backgroundColor": "#C7754A",
                   "borderColor": "#8E4F2E",
-                  "borderWidth": 2,
                 },
                 undefined,
               ]
@@ -144,6 +153,7 @@ exports[`DashboardScreen matches snapshot 1`] = `
                   {
                     "color": "#2E2A26",
                   },
+                  null,
                   undefined,
                 ]
               }
@@ -215,6 +225,7 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 "borderRadius": 22,
                 "borderWidth": 2.5,
               },
+              null,
               {
                 "marginTop": 16,
               },

--- a/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
@@ -2017,13 +2017,17 @@ exports[`StatsScreen matches snapshot 1`] = `
                   {
                     "alignSelf": "flex-start",
                     "borderRadius": 999,
+                    "borderWidth": 2,
                     "paddingHorizontal": 10,
                     "paddingVertical": 4,
                   },
                   {
                     "backgroundColor": "#FAF5EA",
                     "borderColor": "#6A5A86",
-                    "borderWidth": 2,
+                  },
+                  {
+                    "backgroundColor": "#FAF5EA",
+                    "borderColor": "#6A5A86",
                   },
                   undefined,
                 ]
@@ -2043,6 +2047,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                     {
                       "color": "#2E2A26",
                     },
+                    null,
                     undefined,
                   ]
                 }
@@ -2057,13 +2062,17 @@ exports[`StatsScreen matches snapshot 1`] = `
                 {
                   "alignSelf": "flex-start",
                   "borderRadius": 999,
+                  "borderWidth": 2,
                   "paddingHorizontal": 10,
                   "paddingVertical": 4,
                 },
                 {
+                  "backgroundColor": "#FAF5EA",
+                  "borderColor": "#6A5A86",
+                },
+                {
                   "backgroundColor": "#C7754A",
                   "borderColor": "#8E4F2E",
-                  "borderWidth": 2,
                 },
                 undefined,
               ]
@@ -2083,6 +2092,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   {
                     "color": "#2E2A26",
                   },
+                  null,
                   undefined,
                 ]
               }
@@ -2156,6 +2166,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   "borderRadius": 22,
                   "borderWidth": 2.5,
                 },
+                null,
                 {
                   "marginBottom": 16,
                 },
@@ -2288,6 +2299,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   "borderRadius": 22,
                   "borderWidth": 2.5,
                 },
+                null,
                 {
                   "marginBottom": 16,
                 },
@@ -4268,6 +4280,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   "borderRadius": 22,
                   "borderWidth": 2.5,
                 },
+                null,
                 {
                   "marginBottom": 16,
                 },

--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -10,7 +10,7 @@ import Svg, {Path} from 'react-native-svg';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders, shadowOffsets} from '../theme/radii';
+import {radii, borders, shadowOffsets} from '../theme';
 import NBShadow from './atoms/NBShadow';
 
 export const HABIT_ROW_HEIGHT = 72;

--- a/src/components/MonthCalendar.tsx
+++ b/src/components/MonthCalendar.tsx
@@ -11,7 +11,7 @@ import {getTodayString} from '../utils/dateUtils';
 import {colors} from '../theme/colors';
 import {fontFamily, typeScale} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {borders} from '../theme/radii';
+import {borders} from '../theme';
 
 interface MonthCalendarProps {
   year: number;

--- a/src/components/atoms/NBButton.tsx
+++ b/src/components/atoms/NBButton.tsx
@@ -3,7 +3,7 @@ import {Pressable, Text, ActivityIndicator, View, StyleSheet} from 'react-native
 import type {ViewStyle, StyleProp, TextStyle} from 'react-native';
 import {colors} from '../../theme/colors';
 import {fontFamily} from '../../theme/typography';
-import {radii, borders, shadowOffsets} from '../../theme/radii';
+import {radii, borders, shadowOffsets} from '../../theme';
 import NBShadow from './NBShadow';
 
 type NBButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
@@ -35,8 +35,8 @@ const NBButton: React.FC<NBButtonProps> = ({
 
   return (
     <NBShadow
-      offsetX={shadowOffsets.xs + 2}
-      offsetY={shadowOffsets.xs + 2}
+      offsetX={shadowOffsets.sm}
+      offsetY={shadowOffsets.sm}
       color={styling.shadowColor}
       borderRadius={radii.pill}
       style={[styles.wrapper, disabled && styles.disabled, style]}>

--- a/src/components/atoms/NBCard.tsx
+++ b/src/components/atoms/NBCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import type {ViewStyle, StyleProp} from 'react-native';
 import {colors} from '../../theme/colors';
-import {radii, borders, shadowOffsets} from '../../theme/radii';
+import {radii, borders, shadowOffsets} from '../../theme';
 import NBShadow from './NBShadow';
 
 interface NBCardProps {
@@ -17,35 +17,50 @@ interface NBCardProps {
   children: React.ReactNode;
 }
 
+const DEFAULT_BORDER_COLOR = colors.line;
+const DEFAULT_BACKGROUND = colors.card;
+const DEFAULT_BORDER_RADIUS = radii.card;
+const DEFAULT_BORDER_WIDTH = borders.thick;
+const DEFAULT_SHADOW_COLOR = colors.shadow;
+const DEFAULT_SHADOW_OFFSET = shadowOffsets.md;
+
 const NBCard: React.FC<NBCardProps> = ({
-  borderColor = colors.line,
-  shadowColor = colors.shadow,
-  shadowOffset = shadowOffsets.md,
-  background = colors.card,
-  borderRadius = radii.card,
-  borderWidth = borders.thick,
+  borderColor,
+  shadowColor = DEFAULT_SHADOW_COLOR,
+  shadowOffset = DEFAULT_SHADOW_OFFSET,
+  background,
+  borderRadius,
+  borderWidth,
   style,
   testID,
   children,
 }) => {
+  // Only allocate an override object when a caller supplied at least one
+  // visual prop; the common no-override path uses the stable `defaultStyle`.
+  const hasOverride =
+    background !== undefined ||
+    borderColor !== undefined ||
+    borderRadius !== undefined ||
+    borderWidth !== undefined;
+
+  const overrideStyle: ViewStyle | null = hasOverride
+    ? {
+        backgroundColor: background ?? DEFAULT_BACKGROUND,
+        borderColor: borderColor ?? DEFAULT_BORDER_COLOR,
+        borderRadius: borderRadius ?? DEFAULT_BORDER_RADIUS,
+        borderWidth: borderWidth ?? DEFAULT_BORDER_WIDTH,
+      }
+    : null;
+
   return (
     <NBShadow
       offsetX={shadowOffset}
       offsetY={shadowOffset}
       color={shadowColor}
-      borderRadius={borderRadius}>
+      borderRadius={borderRadius ?? DEFAULT_BORDER_RADIUS}>
       <View
         testID={testID}
-        style={[
-          styles.card,
-          {
-            backgroundColor: background,
-            borderColor,
-            borderRadius,
-            borderWidth,
-          },
-          style,
-        ]}>
+        style={[styles.card, styles.defaultStyle, overrideStyle, style]}>
         {children}
       </View>
     </NBShadow>
@@ -55,6 +70,12 @@ const NBCard: React.FC<NBCardProps> = ({
 const styles = StyleSheet.create({
   card: {
     overflow: 'hidden',
+  },
+  defaultStyle: {
+    backgroundColor: DEFAULT_BACKGROUND,
+    borderColor: DEFAULT_BORDER_COLOR,
+    borderRadius: DEFAULT_BORDER_RADIUS,
+    borderWidth: DEFAULT_BORDER_WIDTH,
   },
 });
 

--- a/src/components/atoms/NBChip.tsx
+++ b/src/components/atoms/NBChip.tsx
@@ -3,7 +3,7 @@ import {View, Text, StyleSheet} from 'react-native';
 import type {ViewStyle, StyleProp, TextStyle} from 'react-native';
 import {colors} from '../../theme/colors';
 import {fontFamily} from '../../theme/typography';
-import {radii, borders} from '../../theme/radii';
+import {radii, borders} from '../../theme';
 
 interface NBChipProps {
   background?: string;
@@ -15,28 +15,39 @@ interface NBChipProps {
   children: React.ReactNode;
 }
 
+const DEFAULT_BACKGROUND = colors.card;
+const DEFAULT_BORDER_COLOR = colors.line;
+const DEFAULT_TEXT_COLOR = colors.text;
+
 const NBChip: React.FC<NBChipProps> = ({
-  background = colors.card,
-  color = colors.text,
-  borderColor = colors.line,
+  background,
+  color,
+  borderColor,
   style,
   textStyle,
   testID,
   children,
 }) => {
+  // Allocate the override object only when a caller supplied at least one
+  // color override; the default path uses the stable `defaultStyle`.
+  const hasContainerOverride =
+    background !== undefined || borderColor !== undefined;
+  const containerOverride: ViewStyle | null = hasContainerOverride
+    ? {
+        backgroundColor: background ?? DEFAULT_BACKGROUND,
+        borderColor: borderColor ?? DEFAULT_BORDER_COLOR,
+      }
+    : null;
+  const textOverride: TextStyle | null =
+    color !== undefined ? {color} : null;
+
   return (
     <View
       testID={testID}
-      style={[
-        styles.chip,
-        {
-          backgroundColor: background,
-          borderColor,
-          borderWidth: borders.base,
-        },
-        style,
-      ]}>
-      <Text style={[styles.text, {color}, textStyle]}>{children}</Text>
+      style={[styles.chip, styles.defaultContainer, containerOverride, style]}>
+      <Text style={[styles.text, styles.defaultText, textOverride, textStyle]}>
+        {children}
+      </Text>
     </View>
   );
 };
@@ -47,6 +58,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 4,
     borderRadius: radii.pill,
+    borderWidth: borders.base,
+  },
+  defaultContainer: {
+    backgroundColor: DEFAULT_BACKGROUND,
+    borderColor: DEFAULT_BORDER_COLOR,
   },
   text: {
     fontFamily: fontFamily.mono,
@@ -55,6 +71,9 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
     textTransform: 'uppercase',
     lineHeight: 14,
+  },
+  defaultText: {
+    color: DEFAULT_TEXT_COLOR,
   },
 });
 

--- a/src/components/atoms/NBCircle.tsx
+++ b/src/components/atoms/NBCircle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import Svg, {Path} from 'react-native-svg';
 import {colors} from '../../theme/colors';
-import {borders, shadowOffsets} from '../../theme/radii';
+import {borders, shadowOffsets} from '../../theme';
 import NBShadow from './NBShadow';
 
 interface NBCircleProps {

--- a/src/components/atoms/NBSettingsRow.tsx
+++ b/src/components/atoms/NBSettingsRow.tsx
@@ -3,7 +3,7 @@ import {View, Text, StyleSheet} from 'react-native';
 import type {ViewStyle, StyleProp} from 'react-native';
 import {colors} from '../../theme/colors';
 import {fontFamily} from '../../theme/typography';
-import {borders} from '../../theme/radii';
+import {borders} from '../../theme';
 
 interface NBSettingsRowProps {
   label: string;

--- a/src/components/atoms/NBShadow.tsx
+++ b/src/components/atoms/NBShadow.tsx
@@ -13,8 +13,8 @@ interface NBShadowProps {
 }
 
 // Hard-edge offset shadow done with a translated colored View behind the child.
-// RN's boxShadow is unreliable across versions and Android elevation blurs;
-// this matches the Soft Clemson v3 design exactly.
+// RN's boxShadow is unreliable across versions and Android elevation blurs the
+// edges; this primitive renders a crisp offset block instead.
 const NBShadow: React.FC<NBShadowProps> = ({
   offsetX = 5,
   offsetY = 5,

--- a/src/components/atoms/NBTabBar.tsx
+++ b/src/components/atoms/NBTabBar.tsx
@@ -4,7 +4,7 @@ import type {BottomTabBarProps} from '@react-navigation/bottom-tabs';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {colors} from '../../theme/colors';
 import {fontFamily} from '../../theme/typography';
-import {radii, borders, shadowOffsets} from '../../theme/radii';
+import {radii, borders, shadowOffsets} from '../../theme';
 import NBShadow from './NBShadow';
 
 // route.name -> bottom-tab UI metadata. Keeping the testID lookup inside the
@@ -25,8 +25,8 @@ const NBTabBar: React.FC<BottomTabBarProps> = ({state, navigation}) => {
       pointerEvents="box-none"
       style={[styles.outer, {paddingBottom: Math.max(insets.bottom, 0) + 16}]}>
       <NBShadow
-        offsetX={shadowOffsets.xs + 2}
-        offsetY={shadowOffsets.xs + 2}
+        offsetX={shadowOffsets.sm}
+        offsetY={shadowOffsets.sm}
         color={colors.tigerDeep}
         borderRadius={radii.pill}
         style={styles.shadowWrap}>
@@ -58,25 +58,17 @@ const NBTabBar: React.FC<BottomTabBarProps> = ({state, navigation}) => {
                 accessibilityLabel={meta.label}
                 onPress={onPress}
                 android_ripple={{color: colors.regalia, borderless: false}}
-                style={[
-                  styles.tab,
-                  isActive && styles.tabActive,
-                  index === 0 && styles.tabFirst,
-                  index === state.routes.length - 1 && styles.tabLast,
-                ]}>
+                style={[styles.tab, isActive && styles.tabActive]}>
                 <View
                   style={[
                     styles.dot,
-                    {
-                      borderColor: isActive ? colors.text : colors.regaliaSoft,
-                      backgroundColor: isActive ? colors.text : 'transparent',
-                    },
+                    isActive ? styles.dotActive : styles.dotInactive,
                   ]}
                 />
                 <Text
                   style={[
                     styles.label,
-                    {color: isActive ? colors.text : colors.regaliaSoft},
+                    isActive ? styles.labelActive : styles.labelInactive,
                   ]}>
                   {meta.label}
                 </Text>
@@ -117,19 +109,19 @@ const styles = StyleSheet.create({
   tabActive: {
     backgroundColor: colors.tiger,
   },
-  tabFirst: {
-    borderTopLeftRadius: radii.pill,
-    borderBottomLeftRadius: radii.pill,
-  },
-  tabLast: {
-    borderTopRightRadius: radii.pill,
-    borderBottomRightRadius: radii.pill,
-  },
   dot: {
     width: 14,
     height: 14,
     borderRadius: 7,
     borderWidth: borders.base,
+  },
+  dotActive: {
+    borderColor: colors.text,
+    backgroundColor: colors.text,
+  },
+  dotInactive: {
+    borderColor: colors.regaliaSoft,
+    backgroundColor: 'transparent',
   },
   label: {
     fontFamily: fontFamily.mono,
@@ -137,6 +129,20 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: 0.8,
   },
+  labelActive: {
+    color: colors.text,
+  },
+  labelInactive: {
+    color: colors.regaliaSoft,
+  },
 });
 
-export default NBTabBar;
+export default React.memo(NBTabBar, (prev, next) => {
+  // React Navigation reuses the same state.routes reference between renders
+  // when the route list is unchanged; only state.index differs on tab change.
+  // Skip re-render when both are referentially equal.
+  return (
+    prev.state.index === next.state.index &&
+    prev.state.routes === next.state.routes
+  );
+});

--- a/src/components/atoms/NBToggle.tsx
+++ b/src/components/atoms/NBToggle.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {View, Pressable, StyleSheet} from 'react-native';
 import {colors} from '../../theme/colors';
-import {radii, borders, shadowOffsets} from '../../theme/radii';
+import {radii, borders, shadowOffsets} from '../../theme';
 import NBShadow from './NBShadow';
 
 interface NBToggleProps {
@@ -10,7 +10,7 @@ interface NBToggleProps {
   color?: string;
   testID?: string;
   accessibilityLabel?: string;
-  // Accept-and-ignore Switch-API niceties so existing callsites compile.
+  // Switch-compatible color overrides; defaults preserve existing visuals.
   trackColor?: {false?: string; true?: string};
   thumbColor?: string;
   disabled?: boolean;
@@ -26,6 +26,8 @@ const NBToggle: React.FC<NBToggleProps> = ({
   color = colors.tiger,
   testID,
   accessibilityLabel,
+  trackColor,
+  thumbColor,
   disabled,
 }) => {
   const handlePress = useCallback(() => {
@@ -34,6 +36,11 @@ const NBToggle: React.FC<NBToggleProps> = ({
     }
     onValueChange?.(!value);
   }, [disabled, onValueChange, value]);
+
+  const trackBackground = value
+    ? trackColor?.true ?? color
+    : trackColor?.false ?? colors.card;
+  const thumbBackground = thumbColor ?? colors.card;
 
   return (
     <NBShadow
@@ -48,27 +55,33 @@ const NBToggle: React.FC<NBToggleProps> = ({
         accessibilityLabel={accessibilityLabel}
         accessibilityState={{checked: value, disabled: !!disabled}}
         onPress={handlePress}
-        // eslint-disable-next-line react-native/no-inline-styles
         style={[
           styles.track,
+          // eslint-disable-next-line react-native/no-inline-styles
           {
-            backgroundColor: value ? color : colors.card,
-            borderColor: colors.line,
+            backgroundColor: trackBackground,
             opacity: disabled ? 0.5 : 1,
           },
         ]}>
         <View
           style={[
-            styles.thumb,
-            {
-              left: value ? TOGGLE_WIDTH - THUMB_SIZE - borders.thick : -borders.thick,
-              borderColor: colors.line,
-            },
+            value ? styles.thumbOn : styles.thumbOff,
+            {backgroundColor: thumbBackground},
           ]}
         />
       </Pressable>
     </NBShadow>
   );
+};
+
+const thumbBase = {
+  position: 'absolute' as const,
+  top: -borders.thick,
+  width: THUMB_SIZE,
+  height: THUMB_SIZE + borders.thick * 2,
+  borderRadius: THUMB_SIZE / 2,
+  borderWidth: borders.thick,
+  borderColor: colors.line,
 };
 
 const styles = StyleSheet.create({
@@ -80,16 +93,16 @@ const styles = StyleSheet.create({
     height: TOGGLE_HEIGHT,
     borderRadius: radii.pill,
     borderWidth: borders.thick,
+    borderColor: colors.line,
     position: 'relative',
   },
-  thumb: {
-    position: 'absolute',
-    top: -borders.thick,
-    width: THUMB_SIZE,
-    height: THUMB_SIZE + borders.thick * 2,
-    borderRadius: THUMB_SIZE / 2,
-    backgroundColor: colors.card,
-    borderWidth: borders.thick,
+  thumbOn: {
+    ...thumbBase,
+    left: TOGGLE_WIDTH - THUMB_SIZE - borders.thick,
+  },
+  thumbOff: {
+    ...thumbBase,
+    left: -borders.thick,
   },
 });
 

--- a/src/screens/CreateHabitModal.tsx
+++ b/src/screens/CreateHabitModal.tsx
@@ -9,7 +9,7 @@ import {
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders, shadowOffsets} from '../theme/radii';
+import {radii, borders, shadowOffsets} from '../theme';
 import NBCard from '../components/atoms/NBCard';
 import NBButton from '../components/atoms/NBButton';
 import NBShadow from '../components/atoms/NBShadow';

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -11,7 +11,7 @@ import {colors} from '../theme/colors';
 import {getFormattedToday} from '../utils/dateUtils';
 import {fontFamily, typeScale} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders} from '../theme/radii';
+import {radii, borders} from '../theme';
 import HabitCard, {HABIT_ROW_HEIGHT} from '../components/HabitCard';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -15,7 +15,7 @@ import {format} from 'date-fns';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders, shadowOffsets} from '../theme/radii';
+import {radii, borders, shadowOffsets} from '../theme';
 import HabitService from '../services/HabitService';
 import SyncService, {AuthenticationError} from '../services/SyncService';
 import NotificationService from '../services/NotificationService';

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -3,7 +3,7 @@ import {View, Text, Pressable, FlatList, StyleSheet} from 'react-native';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {borders} from '../theme/radii';
+import {borders} from '../theme';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';
 import NBChip from '../components/atoms/NBChip';

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -12,7 +12,7 @@ import {getTodayString} from '../utils/dateUtils';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders} from '../theme/radii';
+import {radii, borders} from '../theme';
 import MonthCalendar from '../components/MonthCalendar';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';

--- a/src/screens/StreaksScreen.tsx
+++ b/src/screens/StreaksScreen.tsx
@@ -3,7 +3,7 @@ import {View, Text, StyleSheet, ScrollView} from 'react-native';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {borders} from '../theme/radii';
+import {borders} from '../theme';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';
 import NBChip from '../components/atoms/NBChip';

--- a/src/theme/borders.ts
+++ b/src/theme/borders.ts
@@ -1,0 +1,7 @@
+export const borders = {
+  thin: 1.5,
+  base: 2,
+  thick: 2.5,
+} as const;
+
+export type Borders = typeof borders;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -7,13 +7,21 @@ export type {FontFamily, TypeScale} from './typography';
 export {spacing} from './spacing';
 export type {Spacing} from './spacing';
 
-export {radii, borders, shadowOffsets} from './radii';
-export type {Radii, Borders, ShadowOffsets} from './radii';
+export {radii} from './radii';
+export type {Radii} from './radii';
+
+export {borders} from './borders';
+export type {Borders} from './borders';
+
+export {shadowOffsets} from './shadowOffsets';
+export type {ShadowOffsets} from './shadowOffsets';
 
 import {colors} from './colors';
 import {fontFamily, typeScale} from './typography';
 import {spacing} from './spacing';
-import {radii, borders, shadowOffsets} from './radii';
+import {radii} from './radii';
+import {borders} from './borders';
+import {shadowOffsets} from './shadowOffsets';
 
 export const theme = {
   colors,

--- a/src/theme/radii.ts
+++ b/src/theme/radii.ts
@@ -5,18 +5,4 @@ export const radii = {
   pill: 999,
 } as const;
 
-export const borders = {
-  thin: 1.5,
-  base: 2,
-  thick: 2.5,
-} as const;
-
-export const shadowOffsets = {
-  xs: 2,
-  md: 5,
-  lg: 8,
-} as const;
-
 export type Radii = typeof radii;
-export type Borders = typeof borders;
-export type ShadowOffsets = typeof shadowOffsets;

--- a/src/theme/shadowOffsets.ts
+++ b/src/theme/shadowOffsets.ts
@@ -1,0 +1,8 @@
+export const shadowOffsets = {
+  xs: 2,
+  sm: 4,
+  md: 5,
+  lg: 8,
+} as const;
+
+export type ShadowOffsets = typeof shadowOffsets;


### PR DESCRIPTION
## Summary

Seven cleanup items across the NB* atoms layer and the theme tokens (Soft Clemson v3 review batch).

- **#62 WT2-01** — Split `src/theme/radii.ts` into three single-purpose files: `radii.ts` (corner radii), `borders.ts` (border widths), `shadowOffsets.ts` (shadow offset distances). `src/theme/index.ts` re-exports all three. Atom and screen imports converted to the barrel path `'../../theme'` for one canonical import going forward.
- **#63 WT2-02** — Added `shadowOffsets.sm = 4`. `NBButton` now uses `shadowOffsets.sm` directly instead of the magic `shadowOffsets.xs + 2` arithmetic on a token.
- **#64 WT2-03** — `NBTabBar`: hoisted per-tab inline color objects into `dotActive` / `dotInactive` / `labelActive` / `labelInactive` `StyleSheet.create` entries; removed the redundant `tabFirst` / `tabLast` border-radius styles (parent already clips with `overflow: 'hidden'` + `borderRadius: pill`); wrapped the export in `React.memo`.
- **#65 WT2-04** — `NBToggle` now honors `trackColor` and `thumbColor` props (previously accept-and-ignore). Thumb position moved into static `thumbOn` / `thumbOff` `StyleSheet` entries (no more inline `{left}`). Existing callers that don't pass overrides render identically.
- **#66 WT2-05** — `NBCard` / `NBChip` default-case styling reorganized so the default branch yields a stable `StyleSheet` reference instead of a fresh object per render. Override branch still works.
- **#67 WT2-06** — Stripped "Soft Clemson v3" branding from the `NBShadow.tsx` comment.

## Test plan

- [x] `npx jest` — 249/249 pass.
- [x] 2 snapshots regenerated (`DashboardScreen`, `StatsScreen`) for the NBChip restructure — diff is pure style-array reshuffling, visually identical.
- [ ] Manual device run-through: confirm tab bar, toggles, chips, and cards still look right.

Closes #62
Closes #63
Closes #64
Closes #65
Closes #66
Closes #67