### PR TITLE
Cleanup: lift useHabits to shared HabitsContext (WT6)

### DIFF
--- a/src/hooks/useHabitsContext.tsx
+++ b/src/hooks/useHabitsContext.tsx
@@ -1,0 +1,51 @@
+import React, {createContext, useContext} from 'react';
+import {useHabits} from './useHabits';
+import type HabitService from '../services/HabitService';
+
+type UseHabitsReturn = ReturnType<typeof useHabits>;
+
+const HabitsContext = createContext<UseHabitsReturn | null>(null);
+
+interface HabitsProviderProps {
+  habitService: HabitService;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides a single shared `useHabits` subscription to all descendants.
+ *
+ * The Dashboard, Streaks, and Stats tabs are kept alive simultaneously by
+ * React Navigation, and they all read the same habit list. Without this
+ * provider each tab opens its own WatermelonDB subscription and runs its own
+ * `computeDisplayData` pass on every sync emission, multiplying the cost by
+ * the number of mounted tabs. Lifting the hook here collapses that fan-out to
+ * a single subscription.
+ */
+export const HabitsProvider: React.FC<HabitsProviderProps> = ({
+  habitService,
+  children,
+}) => {
+  const value = useHabits(habitService);
+  return (
+    <HabitsContext.Provider value={value}>{children}</HabitsContext.Provider>
+  );
+};
+
+/**
+ * Reads the shared habits state from `HabitsProvider`.
+ *
+ * Throws if used outside a provider — callers that need an escape hatch
+ * (e.g. screen tests that inject a mock service via props) should call
+ * `useHabits` directly instead.
+ */
+export function useHabitsContext(): UseHabitsReturn {
+  const ctx = useContext(HabitsContext);
+  if (ctx === null) {
+    throw new Error(
+      'useHabitsContext must be used within a HabitsProvider. ' +
+        'Pass a habitService prop to the screen for tests, or wrap the tree ' +
+        'in <HabitsProvider>.',
+    );
+  }
+  return ctx;
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -8,6 +8,11 @@ import StreaksScreen from '../screens/StreaksScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import CreateHabitModal from '../screens/CreateHabitModal';
 import NBTabBar from '../components/atoms/NBTabBar';
+import {HabitsProvider} from '../hooks/useHabitsContext';
+import HabitService from '../services/HabitService';
+import database from '../models';
+
+const sharedHabitService = new HabitService(database);
 
 const HomeStack = createNativeStackNavigator();
 const StatsStack = createNativeStackNavigator();
@@ -40,14 +45,16 @@ const SettingsStackScreen: React.FC = () => (
 );
 
 const AppNavigator: React.FC = () => (
-  <Tab.Navigator
-    screenOptions={{headerShown: false}}
-    tabBar={props => <NBTabBar {...props} />}>
-    <Tab.Screen name="Today" component={HomeStackScreen} />
-    <Tab.Screen name="Streaks" component={StreaksScreen} />
-    <Tab.Screen name="Stats" component={StatsStackScreen} />
-    <Tab.Screen name="Me" component={SettingsStackScreen} />
-  </Tab.Navigator>
+  <HabitsProvider habitService={sharedHabitService}>
+    <Tab.Navigator
+      screenOptions={{headerShown: false}}
+      tabBar={props => <NBTabBar {...props} />}>
+      <Tab.Screen name="Today" component={HomeStackScreen} />
+      <Tab.Screen name="Streaks" component={StreaksScreen} />
+      <Tab.Screen name="Stats" component={StatsStackScreen} />
+      <Tab.Screen name="Me" component={SettingsStackScreen} />
+    </Tab.Navigator>
+  </HabitsProvider>
 );
 
 export default AppNavigator;

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -18,22 +18,59 @@ import NBCard from '../components/atoms/NBCard';
 import NBChip from '../components/atoms/NBChip';
 import {useHabits} from '../hooks/useHabits';
 import type {HabitDisplayData} from '../hooks/useHabits';
+import {useHabitsContext} from '../hooks/useHabitsContext';
 import HabitService from '../services/HabitService';
-import database from '../models';
 
 interface DashboardScreenProps {
   navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
   habitService?: HabitService;
 }
 
-const defaultHabitService = new HabitService(database);
-
 const DashboardScreen: React.FC<DashboardScreenProps> = ({
   navigation,
   habitService,
+}) =>
+  habitService ? (
+    <DashboardScreenWithService
+      navigation={navigation}
+      habitService={habitService}
+    />
+  ) : (
+    <DashboardScreenFromContext navigation={navigation} />
+  );
+
+interface DashboardScreenWithServiceProps {
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  habitService: HabitService;
+}
+
+const DashboardScreenWithService: React.FC<DashboardScreenWithServiceProps> = ({
+  navigation,
+  habitService,
 }) => {
-  const service = habitService ?? defaultHabitService;
-  const {habits, toggleHabit} = useHabits(service);
+  const state = useHabits(habitService);
+  return <DashboardScreenBody navigation={navigation} {...state} />;
+};
+
+const DashboardScreenFromContext: React.FC<{
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+}> = ({navigation}) => {
+  const state = useHabitsContext();
+  return <DashboardScreenBody navigation={navigation} {...state} />;
+};
+
+interface DashboardScreenBodyProps {
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  habits: HabitDisplayData[];
+  toggleHabit: (habitId: string) => Promise<void>;
+  loading: boolean;
+}
+
+const DashboardScreenBody: React.FC<DashboardScreenBodyProps> = ({
+  navigation,
+  habits,
+  toggleHabit,
+}) => {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   const [today, setToday] = useState(() => getFormattedToday());

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -11,23 +11,56 @@ import NBChevron from '../components/atoms/NBChevron';
 import NBFlame from '../components/atoms/NBFlame';
 import {useHabits} from '../hooks/useHabits';
 import type {HabitDisplayData} from '../hooks/useHabits';
+import {useHabitsContext} from '../hooks/useHabitsContext';
 import HabitService from '../services/HabitService';
-import database from '../models';
 
 interface StatsListScreenProps {
   navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
   habitService?: HabitService;
 }
 
-const defaultHabitService = new HabitService(database);
-
 const StatsListScreen: React.FC<StatsListScreenProps> = ({
   navigation,
   habitService,
-}) => {
-  const service = habitService ?? defaultHabitService;
-  const {habits} = useHabits(service);
+}) =>
+  habitService ? (
+    <StatsListScreenWithService
+      navigation={navigation}
+      habitService={habitService}
+    />
+  ) : (
+    <StatsListScreenFromContext navigation={navigation} />
+  );
 
+interface StatsListScreenWithServiceProps {
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  habitService: HabitService;
+}
+
+const StatsListScreenWithService: React.FC<StatsListScreenWithServiceProps> = ({
+  navigation,
+  habitService,
+}) => {
+  const {habits} = useHabits(habitService);
+  return <StatsListScreenBody navigation={navigation} habits={habits} />;
+};
+
+const StatsListScreenFromContext: React.FC<{
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+}> = ({navigation}) => {
+  const {habits} = useHabitsContext();
+  return <StatsListScreenBody navigation={navigation} habits={habits} />;
+};
+
+interface StatsListScreenBodyProps {
+  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  habits: HabitDisplayData[];
+}
+
+const StatsListScreenBody: React.FC<StatsListScreenBodyProps> = ({
+  navigation,
+  habits,
+}) => {
   const handlePress = useCallback(
     (habitId: string) => {
       navigation?.navigate('Stats', {habitId});

--- a/src/screens/StreaksScreen.tsx
+++ b/src/screens/StreaksScreen.tsx
@@ -10,14 +10,12 @@ import NBChip from '../components/atoms/NBChip';
 import NBFlame from '../components/atoms/NBFlame';
 import {useHabits} from '../hooks/useHabits';
 import type {HabitDisplayData} from '../hooks/useHabits';
+import {useHabitsContext} from '../hooks/useHabitsContext';
 import HabitService from '../services/HabitService';
-import database from '../models';
 
 interface StreaksScreenProps {
   habitService?: HabitService;
 }
-
-const defaultHabitService = new HabitService(database);
 
 interface RankStyle {
   fill: string;
@@ -49,10 +47,30 @@ const RANK_STYLES: RankStyle[] = [
 
 const RANK_OFFSETS = [0, 8, -6];
 
-const StreaksScreen: React.FC<StreaksScreenProps> = ({habitService}) => {
-  const service = habitService ?? defaultHabitService;
-  const {habits} = useHabits(service);
+const StreaksScreen: React.FC<StreaksScreenProps> = ({habitService}) =>
+  habitService ? (
+    <StreaksScreenWithService habitService={habitService} />
+  ) : (
+    <StreaksScreenFromContext />
+  );
 
+const StreaksScreenWithService: React.FC<{habitService: HabitService}> = ({
+  habitService,
+}) => {
+  const {habits} = useHabits(habitService);
+  return <StreaksScreenBody habits={habits} />;
+};
+
+const StreaksScreenFromContext: React.FC = () => {
+  const {habits} = useHabitsContext();
+  return <StreaksScreenBody habits={habits} />;
+};
+
+interface StreaksScreenBodyProps {
+  habits: HabitDisplayData[];
+}
+
+const StreaksScreenBody: React.FC<StreaksScreenBodyProps> = ({habits}) => {
   const top3 = useMemo(
     () =>
       [...habits]


### PR DESCRIPTION
## Summary

One architectural cleanup item (Soft Clemson v3 review batch).

- **#80 WT6-01** — Lifted the `useHabits` subscription to a single shared `HabitsContext` so the three tab screens stop running parallel WatermelonDB subscriptions.

## Problem

`DashboardScreen`, `StreaksScreen`, and `StatsListScreen` each called `useHabits(service)` independently. React Navigation keeps every tab mounted, so one sync emission fanned out into **three** WatermelonDB subscriptions and **three** parallel `computeDisplayData` passes (N habits × 3 tabs of per-habit DB fan-out per push).

## Implementation

- **New:** `src/hooks/useHabitsContext.tsx` — `HabitsProvider` (calls `useHabits` once internally) + `useHabitsContext` (consumer hook that throws if used outside a provider, with a message pointing to the prop escape hatch).
- **`src/navigation/AppNavigator.tsx`** — mounts `<HabitsProvider habitService={sharedHabitService}>` around the `Tab.Navigator`, with a module-scope `sharedHabitService = new HabitService(database)` as the single subscription owner.
- **`src/screens/{Dashboard,Streaks,StatsList}Screen.tsx`** — each split into outer / `*WithService` / `*FromContext` / `*Body` components. The outer component decides at mount time whether to call `useHabits(prop)` directly or `useHabitsContext()`, based on whether a `habitService` prop was passed. Strictly Rules-of-Hooks safe — each leaf component calls exactly one hook unconditionally.

## Test compatibility

Every existing screen test passes `habitService` as a prop. The outer-selector pattern routes those calls through the `*WithService` path, which calls `useHabits(prop)` directly and bypasses the context entirely. **No test file was modified.** The escape hatch is preserved and proved by the existing DashboardScreen / StreaksScreen / StatsListScreen tests passing without any provider in the tree.

## Runtime effect

Production now opens **one** `getActiveHabits()` subscription and runs **one** `computeDisplayData` fan-out per sync emission, regardless of how many tabs are mounted.

## Test plan

- [x] `npx jest` — 245/245 pass, 3/3 snapshots pass (no regen needed).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual device check: confirm Today/Streaks/Stats tabs still display correct habit data, and that sync emissions reflect across all three without lag.

Closes #80