### PR TITLE
Cleanup: render-hot-path perf fixes in tab screens (WT5)

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -147,14 +147,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({
                   key={h.id}
                   style={[
                     styles.progressDot,
-                    {
-                      backgroundColor: h.completedToday
-                        ? colors.tiger
-                        : colors.card,
-                      borderColor: h.completedToday
-                        ? colors.tigerDeep
-                        : colors.mute,
-                    },
+                    h.completedToday ? styles.dotFilled : styles.dotEmpty,
                   ]}
                 />
               ))
@@ -237,6 +230,14 @@ const styles = StyleSheet.create({
     height: 22,
     borderRadius: 11,
     borderWidth: borders.thick,
+  },
+  dotFilled: {
+    backgroundColor: colors.tiger,
+    borderColor: colors.tigerDeep,
+  },
+  dotEmpty: {
+    backgroundColor: colors.card,
+    borderColor: colors.mute,
   },
   progressEmpty: {
     fontFamily: fontFamily.mono,

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -6,7 +6,6 @@ import {spacing} from '../theme/spacing';
 import {borders} from '../theme';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';
-import NBChip from '../components/atoms/NBChip';
 import NBChevron from '../components/atoms/NBChevron';
 import NBFlame from '../components/atoms/NBFlame';
 import {useHabits} from '../hooks/useHabits';
@@ -36,14 +35,11 @@ const StatsListScreen: React.FC<StatsListScreenProps> = ({
   );
 
   const renderItem = useCallback(
-    ({item, index}: {item: HabitDisplayData; index: number}) => (
+    ({item}: {item: HabitDisplayData}) => (
       <Pressable
         testID={`stats-row-${item.id}`}
         onPress={() => handlePress(item.id)}
-        style={[
-          styles.row,
-          index === habits.length - 1 && styles.rowLast,
-        ]}>
+        style={styles.row}>
         <View style={styles.rowText}>
           <Text style={styles.rowLabel}>{item.name.toUpperCase()}</Text>
           <View style={styles.streakRow}>
@@ -57,13 +53,17 @@ const StatsListScreen: React.FC<StatsListScreenProps> = ({
         <NBChevron color={colors.regalia} />
       </Pressable>
     ),
-    [habits.length, handlePress],
+    [handlePress],
+  );
+
+  const renderSeparator = useCallback(
+    () => <View style={styles.separator} />,
+    [],
   );
 
   return (
     <NBSurface testID="stats-list-screen">
       <View style={styles.header}>
-        <NBChip>STATS</NBChip>
         <Text style={styles.title}>STATS</Text>
         <Text style={styles.subtitle}>
           PICK A HABIT TO SEE THE CALENDAR
@@ -80,6 +80,7 @@ const StatsListScreen: React.FC<StatsListScreenProps> = ({
             data={habits}
             renderItem={renderItem}
             keyExtractor={item => item.id}
+            ItemSeparatorComponent={renderSeparator}
             scrollEnabled={false}
             testID="stats-habit-list"
           />
@@ -119,13 +120,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: 16,
     paddingVertical: 14,
-    borderBottomWidth: borders.thin,
-    borderBottomColor: colors.regaliaSoft,
     backgroundColor: colors.card,
     gap: 12,
   },
-  rowLast: {
-    borderBottomWidth: 0,
+  separator: {
+    height: borders.thin,
+    backgroundColor: colors.regaliaSoft,
   },
   rowText: {
     flex: 1,

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -39,11 +39,14 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
   const [habitName, setHabitName] = useState('');
   const [streak, setStreak] = useState(0);
   const [completedDates, setCompletedDates] = useState<Set<string>>(new Set());
-  const [calendarYear, setCalendarYear] = useState(
-    new Date().getFullYear(),
+  // Single Date observation so year and month can't straddle a midnight/month
+  // boundary (two separate `new Date()` calls could observe different values).
+  const initialNow = useRef(new Date()).current;
+  const [calendarYear, setCalendarYear] = useState(() =>
+    initialNow.getFullYear(),
   );
-  const [calendarMonth, setCalendarMonth] = useState(
-    new Date().getMonth(),
+  const [calendarMonth, setCalendarMonth] = useState(() =>
+    initialNow.getMonth(),
   );
 
   const animatedStreak = useRef(new Animated.Value(0)).current;

--- a/src/screens/StreaksScreen.tsx
+++ b/src/screens/StreaksScreen.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 import {View, Text, StyleSheet, ScrollView} from 'react-native';
+import {format, getISOWeek, getISOWeekYear} from 'date-fns';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
@@ -53,6 +54,16 @@ const StreaksScreen: React.FC<StreaksScreenProps> = ({habitService}) => {
   const service = habitService ?? defaultHabitService;
   const {habits} = useHabits(service);
 
+  // Compute date labels once at mount — they don't change more than once per day.
+  // Avoids running `new Date()` and date arithmetic on every render.
+  const [weekText, monthDayText] = useMemo(() => {
+    const now = new Date();
+    return [
+      `WK ${getISOWeek(now)} / ${getISOWeekYear(now)}`,
+      format(now, 'LLL · EEE').toUpperCase(),
+    ];
+  }, []);
+
   const top3 = useMemo(
     () =>
       [...habits]
@@ -71,9 +82,9 @@ const StreaksScreen: React.FC<StreaksScreenProps> = ({habitService}) => {
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.headerRow}>
           <NBChip background={colors.darkBg} color={colors.darkBgText} borderColor={colors.regaliaDeep}>
-            {weekLabel()}
+            {weekText}
           </NBChip>
-          <NBChip>{monthDayLabel()}</NBChip>
+          <NBChip>{monthDayText}</NBChip>
         </View>
         <Text style={styles.title}>TOP{'\n'}STREAKS</Text>
 
@@ -162,36 +173,6 @@ const RankCard: React.FC<RankCardProps> = ({rank, habit, style, offset}) => {
     </View>
   );
 };
-
-function weekLabel(): string {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), 0, 1);
-  const dayOfYear = Math.floor(
-    (now.getTime() - start.getTime()) / 86_400_000,
-  );
-  const week = Math.ceil((dayOfYear + start.getDay() + 1) / 7);
-  return `WK ${week} / ${now.getFullYear()}`;
-}
-
-function monthDayLabel(): string {
-  const now = new Date();
-  const months = [
-    'JAN',
-    'FEB',
-    'MAR',
-    'APR',
-    'MAY',
-    'JUN',
-    'JUL',
-    'AUG',
-    'SEP',
-    'OCT',
-    'NOV',
-    'DEC',
-  ];
-  const days = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-  return `${months[now.getMonth()]} · ${days[now.getDay()]}`;
-}
 
 const styles = StyleSheet.create({
   content: {


### PR DESCRIPTION
## Summary

Five render-perf cleanup items in the tab screens (Soft Clemson v3 review batch). One sixth item (#77) is intentionally deferred — see below.

- **#74 WT5-01** — `StreaksScreen`: replaced inline `weekLabel()` / `monthDayLabel()` JSX calls with `weekText` / `monthDayText` derived once via `useMemo`. Switched the hand-rolled (and ISO-incorrect) week-number math to `date-fns` `getISOWeek` / `getISOWeekYear`, and month/day to `format(now, 'LLL · EEE')`.
- **#75 WT5-02** — `DashboardScreen`: added `dotFilled` / `dotEmpty` to `StyleSheet.create`. The progress-card dots map now picks a stable style reference instead of constructing a fresh `{backgroundColor, borderColor}` per dot per render.
- **#76 WT5-03** — `StatsListScreen`: moved last-row border treatment to an `ItemSeparatorComponent`. `renderItem` no longer takes `index` and no longer depends on `habits.length`, so FlatList recycling is no longer invalidated on add/remove.
- **#78 WT5-05** — `StatsListScreen`: removed the redundant `<NBChip>STATS</NBChip>` from the header (the title text immediately below already says STATS). Dropped the now-unused `NBChip` import.
- **#79 WT5-06** — `StatsScreen`: captured a single `Date` via `useRef` and used it in both `useState(() => ...)` initializers, eliminating the midnight-boundary inconsistency risk between `calendarYear` and `calendarMonth`.

## Deferred (NOT closed by this PR)

- **#77 WT5-04** — Converting the streak number to `Animated.createAnimatedComponent(Text)` would change `streak-count`'s `props.children` from a plain number to an Animated node object. That breaks both the explicit `getByTestId('streak-count').props.children).toBe(N)` assertions in `StatsScreen.test.tsx` and the snapshot at line 2236. The agent followed the "don't half-do it" guidance — this needs a coupled test rewrite. Perf cost is bounded (300ms one-shot animation on data load), so it's safe to ship the rest now and revisit #77 separately.

## Test plan

- [x] `npx jest` — 245/245 pass, 3/3 snapshots pass (no regen needed).
- [ ] Manual device check: Streaks header chips show correct ISO week + month-day, Today progress dots fill correctly, Stats list scrolls smoothly when adding/removing habits.

Closes #74
Closes #75
Closes #76
Closes #78
Closes #79