### PR TITLE
Fix react/jsx-no-comment-textnodes lint errors

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -177,7 +177,7 @@ const DashboardScreenBody: React.FC<DashboardScreenBodyProps> = ({
           </View>
           <View style={styles.progressDots}>
             {habits.length === 0 ? (
-              <Text style={styles.progressEmpty}>// AWAITING HABITS</Text>
+              <Text style={styles.progressEmpty}>{'// AWAITING HABITS'}</Text>
             ) : (
               habits.map(h => (
                 <View

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -47,7 +47,7 @@ const SectionHeader: React.FC<{label: string; count?: string | number}> = ({
   count,
 }) => (
   <View style={styles.sectionHeader}>
-    <Text style={styles.sectionHeaderText}>// {label}</Text>
+    <Text style={styles.sectionHeaderText}>{`// ${label}`}</Text>
     {count !== undefined && (
       <Text style={styles.sectionHeaderText}>{count}</Text>
     )}


### PR DESCRIPTION
## Summary

Two ESLint errors blocking PR #89:

```
src/screens/DashboardScreen.tsx
  180:50  error  Comments inside children section of tag should be placed inside braces  react/jsx-no-comment-textnodes

src/screens/SettingsScreen.tsx
   50:44  error  Comments inside children section of tag should be placed inside braces  react/jsx-no-comment-textnodes
```

## Root cause

The redesign's section headers (`// HABITS`, `// NOTIFICATIONS`, `// SYNC`, `// ABOUT`) and the empty-progress label (`// AWAITING HABITS`) use a decorative `//` prefix to read like terminal section headers. ESLint's `react/jsx-no-comment-textnodes` rule sees `//` at the start of JSX text content and assumes it's an accidentally-unwrapped JS comment.

## Fix

Wrap the `//`-prefixed text in a JSX expression container so the `//` is part of a string literal, not raw JSX text:

```diff
- <Text>// {label}</Text>
+ <Text>{`// ${label}`}</Text>

- <Text>// AWAITING HABITS</Text>
+ <Text>{'// AWAITING HABITS'}</Text>
```

Rendered output is byte-identical.

## Test plan

- [x] `npx eslint src/screens/SettingsScreen.tsx src/screens/DashboardScreen.tsx` — 0 errors (3 pre-existing `curly` warnings in `formatHour` remain; not blocking).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx jest` — 252/252 pass.

## Follow-up note

If the design wants the `//` decoration to stay long-term, this approach (string-literal wrapping) is the right pattern. If the `//` was just placeholder styling, a future cleanup could drop it entirely.