### PR TITLE
Show full release version (versionName + versionCode) in Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^4.1.0",
         "react": "19.0.0",
         "react-native": "0.78.1",
+        "react-native-device-info": "^14.1.1",
         "react-native-safe-area-context": "^5.7.0",
         "react-native-screens": "~4.18.0",
         "react-native-svg": "^15.8.0",
@@ -11450,6 +11451,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-device-info": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-14.1.1.tgz",
+      "integrity": "sha512-lXFpe6DJmzbQXNLWxlMHP2xuTU5gwrKAvI8dCAZuERhW9eOXSubOQIesk9lIBnsi9pI19GMrcpJEvs4ARPRYmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^4.1.0",
     "react": "19.0.0",
     "react-native": "0.78.1",
+    "react-native-device-info": "^14.1.1",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-screens": "~4.18.0",
     "react-native-svg": "^15.8.0",

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -11,6 +11,14 @@ import {of} from 'rxjs';
 // Mock the database import to avoid SQLite initialization in tests
 jest.mock('../../models', () => ({}));
 
+jest.mock('react-native-device-info', () => ({
+  __esModule: true,
+  default: {
+    getVersion: jest.fn().mockReturnValue('1.2.3'),
+    getBuildNumber: jest.fn().mockReturnValue('456'),
+  },
+}));
+
 // Mock @notifee/react-native (imported transitively via NotificationService)
 jest.mock('@notifee/react-native', () => ({
   __esModule: true,
@@ -196,7 +204,7 @@ describe('SettingsScreen', () => {
       expect(getByTestId('app-version')).toBeTruthy();
     });
 
-    expect(getByTestId('app-version').props.children).toBe('0.0.1');
+    expect(getByTestId('app-version').props.children).toBe('1.2.3-r456');
     expect(getByTestId('server-url').props.children).toBe(
       'https://habit-api.darling.solutions',
     );

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -30,8 +30,9 @@ import NBToggle from '../components/atoms/NBToggle';
 import NBButton from '../components/atoms/NBButton';
 import NBShadow from '../components/atoms/NBShadow';
 import NBSettingsRow from '../components/atoms/NBSettingsRow';
+import {getAppReleaseString} from '../utils/appVersion';
 
-const APP_VERSION = '0.0.1';
+const APP_VERSION = getAppReleaseString();
 const REMINDER_ENABLED_KEY = 'reminder_enabled';
 const REMINDER_TIME_KEY = 'reminder_time';
 const LAST_SYNC_KEY = 'last_sync_timestamp';

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -1,0 +1,5 @@
+import DeviceInfo from 'react-native-device-info';
+
+export function getAppReleaseString(): string {
+  return `${DeviceInfo.getVersion()}-r${DeviceInfo.getBuildNumber()}`;
+}


### PR DESCRIPTION
## Summary

The Settings screen displayed a hardcoded `'0.0.1'` string, so the UI didn't reflect the actual installed build's `versionName` / `versionCode` (which are wired in `android/app/build.gradle` from `VERSION_NAME` / `VERSION_CODE` env vars). That made it impossible to confirm which build was running when triaging user issues.

This PR reads both values at runtime via `react-native-device-info` and displays them as the full release string everywhere the version is shown.

## Changes

- Added `react-native-device-info` (^14.0.4) — Android autolinking picks it up; no native edits needed.
- New `src/utils/appVersion.ts` with a single `getAppReleaseString()` helper that returns `` `${getVersion()}-r${getBuildNumber()}` `` (both getters are natively synchronous).
- `src/screens/SettingsScreen.tsx`: replaced `const APP_VERSION = '0.0.1'` with `getAppReleaseString()`. JSX unchanged — the chip still prepends `v`, the About row doesn't.
- `src/__tests__/screens/SettingsScreen.test.tsx`: mocked `react-native-device-info` (returns `1.2.3` / `456`) and updated the assertion to expect `'1.2.3-r456'`.

## Result

| Location | Before | After (with `VERSION_NAME=0.0.1 VERSION_CODE=134`) |
|---|---|---|
| Header chip | `v0.0.1` | `v0.0.1-r134` |
| About > VERSION row | `0.0.1` | `0.0.1-r134` |

Local dev builds (no env vars set) will show `v dev-r1` / `dev-r1`, falling back through the existing defaults in `build.gradle:85-86`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings from changed files
- [x] `npm test` — 252/252 passing across 13 suites
- [ ] Manual: `VERSION_NAME=0.0.1 VERSION_CODE=134 (cd android && ./gradlew assembleDebug)`, install on device, open Settings, confirm chip reads `v0.0.1-r134` and the About row reads `0.0.1-r134`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FU8Y1vgoP5dW7CXGMyxT8e)_