### PR TITLE
Count yesterday's streak when today isn't logged yet

### DIFF
--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -250,7 +250,7 @@ describe('HabitService', () => {
       expect(streak).toBe(1);
     });
 
-    it('returns 0 if today is not logged but yesterday was', async () => {
+    it('returns 1 if today is not logged but yesterday was', async () => {
       const habit = await createTestHabit(database);
       const today = '2026-03-07';
       const yesterday = '2026-03-06';
@@ -258,6 +258,27 @@ describe('HabitService', () => {
       await createTestLog(database, habit.id, yesterday);
 
       const streak = await service.calculateStreak(habit.id, today);
+      expect(streak).toBe(1);
+    });
+
+    it('returns N for an N-day streak ending yesterday when today is not yet logged', async () => {
+      const habit = await createTestHabit(database);
+      await createTestLog(database, habit.id, '2026-03-03');
+      await createTestLog(database, habit.id, '2026-03-04');
+      await createTestLog(database, habit.id, '2026-03-05');
+      await createTestLog(database, habit.id, '2026-03-06'); // yesterday
+      // today (2026-03-07) deliberately not logged
+
+      const streak = await service.calculateStreak(habit.id, '2026-03-07');
+      expect(streak).toBe(4);
+    });
+
+    it('returns 0 when neither today nor yesterday is logged', async () => {
+      const habit = await createTestHabit(database);
+      // Older log exists, but the streak is broken by the missing yesterday
+      await createTestLog(database, habit.id, '2026-03-04');
+
+      const streak = await service.calculateStreak(habit.id, '2026-03-07');
       expect(streak).toBe(0);
     });
 

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -315,6 +315,16 @@ export default class HabitService {
 
     const dateSet = new Set(logs.map(log => log.completedDate));
 
+    // A streak is still alive if yesterday was logged — the user has
+    // until end of day to complete today. Walk from yesterday when
+    // today has no log so the count reflects the streak being protected.
+    if (!dateSet.has(currentDate)) {
+      currentDate = format(
+        subDays(new Date(currentDate + 'T00:00:00'), 1),
+        'yyyy-MM-dd',
+      );
+    }
+
     while (dateSet.has(currentDate)) {
       streak++;
       currentDate = format(


### PR DESCRIPTION
## Summary

`HabitService.calculateStreak(habitId, today)` returned `0` whenever today had no log, so the Today screen, Top Streaks tab, and Stats screen all showed `0` until the user completed today — even when they had a live multi-day streak going into today. The counter should reflect the streak the user is *protecting*, not just reward them once they've logged today.

**Fix:** before walking, if today is not in the log set, step `currentDate` back one day. The existing walk then counts from yesterday, and naturally returns `0` if yesterday is also missing.

```ts
// In calculateStreak, after building dateSet:
if (!dateSet.has(currentDate)) {
  currentDate = format(
    subDays(new Date(currentDate + 'T00:00:00'), 1),
    'yyyy-MM-dd',
  );
}
// ...existing while loop unchanged
```

Behavior:
- Today logged → walks from today (unchanged).
- Today missing, yesterday logged → walks from yesterday.
- Today missing, yesterday missing → returns `0` (streak truly broken).
- Tombstoned today → filtered out of query; treated as "today missing", which is correct.

No changes needed in `useHabits.ts`, `StatsScreen.tsx`, or the dashboard mocks — the service fix propagates to all three call sites.

## Tests

- Renamed `"returns 0 if today is not logged but yesterday was"` → `"returns 1 if today is not logged but yesterday was"` and updated the expectation.
- Added `"returns N for an N-day streak ending yesterday when today is not yet logged"` (4 logged days ending yesterday → 4).
- Added `"returns 0 when neither today nor yesterday is logged"` (genuine break).
- All other streak tests left untouched (no-logs, only-today, 5-consecutive, gap-breaks, 100-day perf, Feb 28→Mar 1, Jan 30→Feb 1, Dec 31→Jan 1, tombstoned-middle-day).

## Test plan

- [x] `npm test -- HabitService.test.ts` — 48/48 pass (including the 3 changed/added streak tests and the unchanged tombstone/boundary tests).
- [x] `npm test` (full suite) — 254/254 pass across 13 suites; no dashboard mock changes needed.
- [x] `npm run typecheck` — clean.
- [ ] Manual smoke (dev build): log a habit yesterday, leave today empty → all three screens show `🔥 1 day`; tap today → ticks to `🔥 2 days`; skip a full day → resets to `0`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbx9sJ7K6wwvYpN57H2vEi)_