### PR TITLE
Surface notification toggle failures in Settings

### DIFF
--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -119,7 +119,6 @@ function createMockNotificationService() {
     requestPermission: jest.fn().mockResolvedValue(true),
     scheduleDailyReminder: jest.fn().mockResolvedValue(undefined),
     cancelDailyReminder: jest.fn().mockResolvedValue(undefined),
-    onNotificationToggle: jest.fn().mockResolvedValue(true),
     scheduleHabitReminder: jest.fn().mockResolvedValue(undefined),
     cancelHabitReminder: jest.fn().mockResolvedValue(undefined),
     cancelAllHabitReminders: jest.fn().mockResolvedValue(undefined),
@@ -649,9 +648,6 @@ describe('SettingsScreen', () => {
     const service = createMockHabitService(habits);
     const syncService = createMockSyncService();
     const notificationService = createMockNotificationService();
-    (notificationService.onNotificationToggle as jest.Mock).mockResolvedValueOnce(
-      true,
-    );
 
     const {getByTestId} = render(
       <SettingsScreen
@@ -669,8 +665,150 @@ describe('SettingsScreen', () => {
       fireEvent(getByTestId('reminder-toggle'), 'valueChange', true);
     });
 
+    expect(notificationService.requestPermission).toHaveBeenCalled();
+    expect(notificationService.scheduleDailyReminder).toHaveBeenCalled();
     expect(notificationService.cancelAllHabitReminders).toHaveBeenCalled();
     expect(notificationService.scheduleHabitReminder).not.toHaveBeenCalled();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'reminder_enabled',
+      'true',
+    );
+  });
+
+  it('surfaces a schedule failure as an Alert and leaves the global toggle off', async () => {
+    const habits = [{id: 'h1', name: 'Exercise', isActive: true}];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+    (
+      notificationService.scheduleDailyReminder as jest.Mock
+    ).mockRejectedValueOnce(new Error('exact alarm denied'));
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('reminder-toggle')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('reminder-toggle'), 'valueChange', true);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Notification Error',
+      expect.stringContaining('exact alarm denied'),
+    );
+    expect(
+      getByTestId('reminder-toggle').props.accessibilityState.checked,
+    ).toBe(false);
+    // The initial-load useEffect may legitimately call setItem with other
+    // arguments — narrow the negative assertion to the specific call.
+    expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+      'reminder_enabled',
+      'true',
+    );
+  });
+
+  it('rolls back the DB write when a per-habit schedule throws', async () => {
+    const habits = [
+      {
+        id: 'h1',
+        name: 'Exercise',
+        isActive: true,
+        notificationsEnabled: false,
+        notificationTime: '08:00',
+      },
+    ];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+    (
+      notificationService.scheduleHabitReminder as jest.Mock
+    ).mockRejectedValueOnce(new Error('trigger failed'));
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('toggle-notify-h1')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('toggle-notify-h1'), 'valueChange', true);
+    });
+
+    expect(service.setHabitNotification).toHaveBeenCalledWith(
+      'h1',
+      true,
+      '08:00',
+    );
+    // Rollback: re-write with the previous value.
+    expect(service.setHabitNotification).toHaveBeenCalledWith(
+      'h1',
+      false,
+      '08:00',
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Notification Error',
+      expect.stringContaining('trigger failed'),
+    );
+    expect(
+      getByTestId('toggle-notify-h1').props.accessibilityState.checked,
+    ).toBe(false);
+  });
+
+  it('does not call scheduleHabitReminder when the per-habit DB write throws', async () => {
+    const habits = [
+      {
+        id: 'h1',
+        name: 'Exercise',
+        isActive: true,
+        notificationsEnabled: false,
+        notificationTime: '08:00',
+      },
+    ];
+    const service = createMockHabitService(habits);
+    (service.setHabitNotification as jest.Mock).mockRejectedValueOnce(
+      new Error('db write failed'),
+    );
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('toggle-notify-h1')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('toggle-notify-h1'), 'valueChange', true);
+    });
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Habit Update Failed',
+      expect.stringContaining('db write failed'),
+    );
+    expect(notificationService.scheduleHabitReminder).not.toHaveBeenCalled();
+    expect(
+      getByTestId('toggle-notify-h1').props.accessibilityState.checked,
+    ).toBe(false);
   });
 
   it('reschedules each enabled habit reminder when the global reminder is toggled OFF', async () => {

--- a/src/__tests__/services/NotificationService.test.ts
+++ b/src/__tests__/services/NotificationService.test.ts
@@ -1,4 +1,3 @@
-import {Alert} from 'react-native';
 import notifee from '@notifee/react-native';
 import NotificationService from '../../services/NotificationService';
 
@@ -29,9 +28,6 @@ const mockNotifee = notifee as any as {
   cancelTriggerNotification: jest.Mock;
   getTriggerNotifications: jest.Mock;
 };
-
-// Mock Alert
-jest.spyOn(Alert, 'alert').mockImplementation(() => {});
 
 describe('NotificationService', () => {
   let service: NotificationService;
@@ -132,56 +128,6 @@ describe('NotificationService', () => {
 
       expect(mockNotifee.cancelTriggerNotification).toHaveBeenCalledWith(
         'daily-habit-reminder',
-      );
-    });
-  });
-
-  describe('onNotificationToggle', () => {
-    it('cancels notification and does not schedule when disabled', async () => {
-      const result = await service.onNotificationToggle(false, 8, 0);
-
-      expect(result).toBe(false);
-      expect(mockNotifee.cancelTriggerNotification).toHaveBeenCalledWith(
-        'daily-habit-reminder',
-      );
-      expect(mockNotifee.createTriggerNotification).not.toHaveBeenCalled();
-      expect(mockNotifee.requestPermission).not.toHaveBeenCalled();
-    });
-
-    it('requests permission and schedules when enabled and granted', async () => {
-      mockNotifee.requestPermission.mockResolvedValue({
-        authorizationStatus: 1, // AUTHORIZED
-      });
-
-      const result = await service.onNotificationToggle(true, 9, 30);
-
-      expect(result).toBe(true);
-      expect(mockNotifee.requestPermission).toHaveBeenCalled();
-      expect(mockNotifee.createTriggerNotification).toHaveBeenCalled();
-    });
-
-    it('does not schedule when permission is denied', async () => {
-      mockNotifee.requestPermission.mockResolvedValue({
-        authorizationStatus: 0, // DENIED
-      });
-
-      const result = await service.onNotificationToggle(true, 9, 0);
-
-      expect(result).toBe(false);
-      expect(mockNotifee.requestPermission).toHaveBeenCalled();
-      expect(mockNotifee.createTriggerNotification).not.toHaveBeenCalled();
-    });
-
-    it('shows an alert directing to Settings when permission is denied', async () => {
-      mockNotifee.requestPermission.mockResolvedValue({
-        authorizationStatus: 0, // DENIED
-      });
-
-      await service.onNotificationToggle(true, 9, 0);
-
-      expect(Alert.alert).toHaveBeenCalledWith(
-        'Notifications Disabled',
-        'Please enable notifications for Daily Habit Tracker in your device Settings.',
       );
     });
   });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -38,6 +38,10 @@ const REMINDER_ENABLED_KEY = 'reminder_enabled';
 const REMINDER_TIME_KEY = 'reminder_time';
 const LAST_SYNC_KEY = 'last_sync_timestamp';
 
+function errMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
 interface SettingsScreenProps {
   habitService?: HabitService;
   syncService?: SyncService;
@@ -170,28 +174,70 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     async (value: boolean) => {
       const hour = parseInt(reminderTime.split(':')[0], 10);
       const minute = parseInt(reminderTime.split(':')[1], 10);
-      const granted = await nService.onNotificationToggle(value, hour, minute);
 
-      const finalValue = value ? granted : false;
-      setReminderEnabled(finalValue);
-      await AsyncStorage.setItem(REMINDER_ENABLED_KEY, String(finalValue));
-
-      if (finalValue) {
-        // Global mode took over — drop any per-habit reminders. DB rows
-        // keep their values so toggling global OFF later restores them.
-        await nService.cancelAllHabitReminders();
+      if (value) {
+        let granted: boolean;
+        try {
+          granted = await nService.requestPermission();
+        } catch (err) {
+          Alert.alert(
+            'Notifications',
+            errMessage(err, 'Failed to request notification permission.'),
+          );
+          return;
+        }
+        if (!granted) {
+          Alert.alert(
+            'Notifications Disabled',
+            'Please enable notifications for Daily Habit Tracker in your device Settings.',
+          );
+          return;
+        }
+        try {
+          await nService.scheduleDailyReminder(hour, minute);
+          await nService.cancelAllHabitReminders();
+        } catch (err) {
+          Alert.alert(
+            'Notification Error',
+            errMessage(err, 'Failed to schedule daily reminder.'),
+          );
+          return;
+        }
+        setReminderEnabled(true);
+        await AsyncStorage.setItem(REMINDER_ENABLED_KEY, 'true');
       } else {
-        // Global mode off → reinstate each enabled habit's reminder.
-        // Concurrent dispatch avoids stutter on the Notifee bridge.
-        const enabledHabits = await hService.getHabitsWithNotifications();
-        await Promise.all(
-          enabledHabits.map(habit => {
-            const [h, m] = (habit.notificationTime || '08:00')
-              .split(':')
-              .map(Number);
-            return nService.scheduleHabitReminder(habit.id, habit.name, h, m);
-          }),
-        );
+        // Commit OFF state as soon as the daily reminder is actually cancelled,
+        // so the toggle and AsyncStorage always reflect notifee's actual state.
+        // The per-habit fan-out below is a best-effort secondary step with its
+        // own Alert.
+        try {
+          await nService.cancelDailyReminder();
+        } catch (err) {
+          Alert.alert(
+            'Notification Error',
+            errMessage(err, 'Failed to disable daily reminder.'),
+          );
+          return;
+        }
+        setReminderEnabled(false);
+        await AsyncStorage.setItem(REMINDER_ENABLED_KEY, 'false');
+
+        try {
+          const enabledHabits = await hService.getHabitsWithNotifications();
+          await Promise.all(
+            enabledHabits.map(habit => {
+              const [h, m] = (habit.notificationTime || '08:00')
+                .split(':')
+                .map(Number);
+              return nService.scheduleHabitReminder(habit.id, habit.name, h, m);
+            }),
+          );
+        } catch (err) {
+          Alert.alert(
+            'Per-Habit Reminders',
+            `Daily reminder is off, but resuming per-habit reminders failed: ${errMessage(err, 'unknown error')}. Toggle individual habits to retry.`,
+          );
+        }
       }
     },
     [nService, hService, reminderTime],
@@ -204,7 +250,14 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
       await AsyncStorage.setItem(REMINDER_TIME_KEY, timeStr);
 
       if (reminderEnabled) {
-        await nService.scheduleDailyReminder(hour, 0);
+        try {
+          await nService.scheduleDailyReminder(hour, 0);
+        } catch (err) {
+          Alert.alert(
+            'Notification Error',
+            errMessage(err, 'Failed to update reminder time.'),
+          );
+        }
       }
     },
     [nService, reminderEnabled],
@@ -212,11 +265,17 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
 
   const handleHabitNotificationToggle = useCallback(
     async (habit: Habit, value: boolean) => {
-      if (reminderEnabled) {
-        return; // Defensive — UI also marks the toggle disabled.
-      }
       if (value) {
-        const granted = await nService.requestPermission();
+        let granted: boolean;
+        try {
+          granted = await nService.requestPermission();
+        } catch (err) {
+          Alert.alert(
+            'Notifications',
+            errMessage(err, 'Failed to request notification permission.'),
+          );
+          return;
+        }
         if (!granted) {
           Alert.alert(
             'Notifications Disabled',
@@ -225,24 +284,59 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           return;
         }
       }
+
       const time = habit.notificationTime || '08:00';
-      await hService.setHabitNotification(habit.id, value, time);
-      if (value) {
-        const [h, m] = time.split(':').map(Number);
-        await nService.scheduleHabitReminder(habit.id, habit.name, h, m);
-      } else {
-        await nService.cancelHabitReminder(habit.id);
+      const prevEnabled = habit.notificationsEnabled;
+
+      try {
+        await hService.setHabitNotification(habit.id, value, time);
+      } catch (err) {
+        Alert.alert(
+          'Habit Update Failed',
+          errMessage(err, 'Could not save the notification preference.'),
+        );
+        return;
+      }
+
+      try {
+        if (value) {
+          const [h, m] = time.split(':').map(Number);
+          await nService.scheduleHabitReminder(habit.id, habit.name, h, m);
+        } else {
+          await nService.cancelHabitReminder(habit.id);
+        }
+      } catch (err) {
+        // Roll back the DB write so the toggle reflects what's actually
+        // scheduled. If the rollback itself fails, the toggle will desync
+        // from notifee until the user retries — surface the original error
+        // either way.
+        try {
+          await hService.setHabitNotification(habit.id, prevEnabled, time);
+        } catch {
+          // best-effort rollback
+        }
+        Alert.alert(
+          'Notification Error',
+          errMessage(err, 'Failed to schedule reminder.'),
+        );
       }
     },
-    [hService, nService, reminderEnabled],
+    [hService, nService],
   );
 
   const handleHabitTimeChange = useCallback(
     async (habit: Habit, hour: number) => {
       const time = `${String(hour).padStart(2, '0')}:00`;
-      await hService.setHabitNotification(habit.id, true, time);
-      if (!reminderEnabled) {
-        await nService.scheduleHabitReminder(habit.id, habit.name, hour, 0);
+      try {
+        await hService.setHabitNotification(habit.id, true, time);
+        if (!reminderEnabled) {
+          await nService.scheduleHabitReminder(habit.id, habit.name, hour, 0);
+        }
+      } catch (err) {
+        Alert.alert(
+          'Notification Error',
+          errMessage(err, 'Failed to update reminder time.'),
+        );
       }
     },
     [hService, nService, reminderEnabled],

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -6,7 +6,6 @@ import notifee, {
   TimestampTrigger,
   TriggerType,
 } from '@notifee/react-native';
-import {Alert} from 'react-native';
 
 const NOTIFICATION_ID = 'daily-habit-reminder';
 const CHANNEL_ID = 'daily-reminders';
@@ -66,34 +65,6 @@ class NotificationService {
    */
   async cancelDailyReminder(): Promise<void> {
     await notifee.cancelTriggerNotification(NOTIFICATION_ID);
-  }
-
-  /**
-   * Convenience method called from Settings.
-   * If enabled, requests permission then schedules. If disabled, cancels.
-   */
-  async onNotificationToggle(
-    enabled: boolean,
-    hour: number,
-    minute: number,
-  ): Promise<boolean> {
-    if (!enabled) {
-      await this.cancelDailyReminder();
-      return false;
-    }
-
-    const granted = await this.requestPermission();
-    if (!granted) {
-      // User previously denied — direct them to device Settings
-      Alert.alert(
-        'Notifications Disabled',
-        'Please enable notifications for Daily Habit Tracker in your device Settings.',
-      );
-      return false;
-    }
-
-    await this.scheduleDailyReminder(hour, minute);
-    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary

Both the global DAILY REMINDER toggle and the per-habit NOTIFY toggles were reported as silently no-op'ing after PR #95 — taps did nothing, no Alert appeared, and the toggles snapped back to their prior position. The most likely cause is an unhandled rejection inside the async `onValueChange` handlers: both `await` notifee / DB calls without a `try/catch`, so a throw aborts the handler before the controlled `setReminderEnabled` or the WatermelonDB write runs, the controlled `NBToggle` reverts to its prior `value`, and no Alert ever fires.

This PR is framed as a guardrail + diagnostic, not a confirmed root-cause fix. If the rejection hypothesis is right, the user now sees an Alert naming the failing call. If not, the symptom changes shape (toggle moves, or a different Alert), which tells us where to look next.

### Behaviour changes

- **Global toggle ON:** request permission → schedule daily reminder → only on success commit `setReminderEnabled(true)` + AsyncStorage. Any error surfaces via Alert; toggle stays off.
- **Global toggle OFF:** cancel daily reminder → commit OFF state + AsyncStorage immediately (so the toggle always reflects notifee's actual state, even if the secondary fan-out fails) → best-effort fan-out to re-arm per-habit reminders with its own Alert.
- **Per-habit NOTIFY ON/OFF:** request permission (ON only) → DB write → schedule (or cancel). If the schedule throws, the DB write is rolled back so the observable-driven toggle flips back to its real state.
- **Time-picker handlers:** wrapped in `try/catch` so a notifee throw during a picker change can't silently no-op either.

### Cleanup

- Deleted `NotificationService.onNotificationToggle` (its only caller was inlined here so the `try/catch` boundary can be drawn precisely) and its now-unused `Alert` import.
- Removed the dead `if (reminderEnabled) return` early-return in the per-habit handler — `NBToggle.handlePress` already short-circuits on `disabled`, so the guard was unreachable and was the same silent-no-op shape this PR is trying to eliminate elsewhere.

## Test plan

- [x] `npm test` — 274/274 pass, including 3 new SettingsScreen tests for the failure paths (global schedule throws → toggle stays off, AsyncStorage not written to `'true'`; per-habit schedule throws → DB write rolled back, toggle stays off; per-habit DB write throws → `scheduleHabitReminder` is **not** called, toggle stays off).
- [x] `npm run typecheck` — clean (existing tsconfig deprecation warnings unrelated).
- [ ] Manual on device. Tap DAILY REMINDER ON with permission granted. One of three mutually exclusive outcomes:
  1. Toggle flips on and stays on — no error path was hit; original bug not reproducing in this build/session.
  2. Alert with a specific error message — rejection hypothesis confirmed; message names the culprit.
  3. Toggle still doesn't move and no Alert — rejection hypothesis is wrong; investigate the observable wiring / `useServices` / `NBToggle` `value` prop next.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JzFdvKPaUf7GMSA3X8MWMJ)_