### PR TITLE
Unstick Daily Reminder toggle when notifee cleanup rejects

### DIFF
--- a/MANUAL_QA.md
+++ b/MANUAL_QA.md
@@ -1,5 +1,32 @@
 # Manual QA Scenarios
 
+## Notification Toggles (Android)
+
+The interaction between the global DAILY REMINDER and per-habit NOTIFY
+toggles can desync on real devices if a notifee call (e.g.
+`getTriggerNotifications`) transiently rejects. Verify on a real Android
+device after touching the Settings notification section.
+
+### Steps
+
+1. **Toggle Daily Reminder ON → OFF → ON**
+   - Open Settings. Toggle DAILY REMINDER on, then off, then on again.
+   - If any `Per-Habit Reminders` alert appears about a cleanup failure,
+     the DAILY REMINDER toggle must remain visibly **ON** afterwards.
+   - DAILY REMINDER must not snap back to OFF after a successful ON tap.
+
+2. **Per-habit toggles enable when Daily Reminder is OFF**
+   - With DAILY REMINDER ON, all per-habit NOTIFY toggles must be
+     grayed out (disabled).
+   - Toggle DAILY REMINDER OFF. Every per-habit NOTIFY toggle on an
+     active habit must become tappable immediately (no app restart, no
+     navigation away and back).
+
+3. **Per-habit ON/OFF cycle**
+   - With DAILY REMINDER OFF, tap a per-habit NOTIFY to ON, then OFF,
+     then ON again. The toggle must reflect each tap and the per-habit
+     time picker must appear when ON.
+
 ## 5. Multi-day Streak (Time Travel)
 
 Detox does not natively support mocking the system date on iOS simulators.

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -675,6 +675,50 @@ describe('SettingsScreen', () => {
     );
   });
 
+  it('commits the global ON state even when cancelAllHabitReminders rejects', async () => {
+    // Real-device failure mode: notifee.getTriggerNotifications (called
+    // inside cancelAllHabitReminders) rejects on some Android OEM builds
+    // or after a transient bridge hiccup. The daily reminder itself was
+    // scheduled successfully — the toggle must commit ON so the user is
+    // not stuck unable to re-enable the daily reminder.
+    const habits = [{id: 'h1', name: 'Exercise', isActive: true}];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+    (
+      notificationService.cancelAllHabitReminders as jest.Mock
+    ).mockRejectedValueOnce(new Error('getTriggerNotifications failed'));
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('reminder-toggle')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('reminder-toggle'), 'valueChange', true);
+    });
+
+    expect(notificationService.scheduleDailyReminder).toHaveBeenCalled();
+    expect(
+      getByTestId('reminder-toggle').props.accessibilityState.checked,
+    ).toBe(true);
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'reminder_enabled',
+      'true',
+    );
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Per-Habit Reminders',
+      expect.stringContaining('cleaning up per-habit reminders failed'),
+    );
+  });
+
   it('surfaces a schedule failure as an Alert and leaves the global toggle off', async () => {
     const habits = [{id: 'h1', name: 'Exercise', isActive: true}];
     const service = createMockHabitService(habits);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
   View,
   Text,
-  FlatList,
   TextInput,
   Pressable,
   StyleSheet,
@@ -195,7 +194,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         }
         try {
           await nService.scheduleDailyReminder(hour, minute);
-          await nService.cancelAllHabitReminders();
         } catch (err) {
           Alert.alert(
             'Notification Error',
@@ -203,8 +201,22 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           );
           return;
         }
+        // Commit ON state as soon as the daily reminder is actually scheduled,
+        // so the toggle and AsyncStorage always reflect notifee's actual state.
+        // The per-habit cleanup below is a best-effort secondary step with its
+        // own Alert — if it fails the daily reminder is still active and the
+        // user is not stuck on the global toggle.
         setReminderEnabled(true);
         await AsyncStorage.setItem(REMINDER_ENABLED_KEY, 'true');
+
+        try {
+          await nService.cancelAllHabitReminders();
+        } catch (err) {
+          Alert.alert(
+            'Per-Habit Reminders',
+            `Daily reminder is on, but cleaning up per-habit reminders failed: ${errMessage(err, 'unknown error')}. They may still fire alongside the daily reminder.`,
+          );
+        }
       } else {
         // Commit OFF state as soon as the daily reminder is actually cancelled,
         // so the toggle and AsyncStorage always reflect notifee's actual state.
@@ -386,107 +398,91 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
 
   const hours = useMemo(() => Array.from({length: 24}, (_, i) => i), []);
 
-  const renderHabitRow = useCallback(
-    ({item, index}: {item: Habit; index: number}) => {
-      const isLast = index === habits.length - 1;
-      const showPicker =
-        item.notificationsEnabled && !reminderEnabled && item.isActive;
-      const habitTime = item.notificationTime || '08:00';
-      return (
-        <View>
-          <Pressable
-            testID={`habit-row-${item.id}`}
-            onLongPress={() => handleLongPressDeactivate(item)}
-            accessibilityLabel={`${item.name} habit`}>
-            <NBSettingsRow
-              label={item.name}
-              hint={`CREATED ${format(new Date(item.createdAt), 'MMM d, yyyy').toUpperCase()}`}
-              right={
-                <View style={styles.habitToggleGroup}>
-                  <View style={styles.habitToggleCol}>
-                    <Text style={styles.habitToggleLabel}>ACTIVE</Text>
-                    <NBToggle
-                      testID={`toggle-active-${item.id}`}
-                      value={item.isActive}
-                      onValueChange={() => handleToggleActive(item)}
-                      color={colors.tiger}
-                    />
-                  </View>
-                  <View style={styles.habitToggleCol}>
-                    <Text style={styles.habitToggleLabel}>NOTIFY</Text>
-                    <NBToggle
-                      testID={`toggle-notify-${item.id}`}
-                      value={item.notificationsEnabled}
-                      onValueChange={v =>
-                        handleHabitNotificationToggle(item, v)
-                      }
-                      disabled={reminderEnabled || !item.isActive}
-                      color={colors.tiger}
-                    />
-                  </View>
+  const renderHabitRow = (item: Habit, index: number) => {
+    const isLast = index === habits.length - 1;
+    const showPicker =
+      item.notificationsEnabled && !reminderEnabled && item.isActive;
+    const habitTime = item.notificationTime || '08:00';
+    return (
+      <View key={item.id}>
+        <Pressable
+          testID={`habit-row-${item.id}`}
+          onLongPress={() => handleLongPressDeactivate(item)}
+          accessibilityLabel={`${item.name} habit`}>
+          <NBSettingsRow
+            label={item.name}
+            hint={`CREATED ${format(new Date(item.createdAt), 'MMM d, yyyy').toUpperCase()}`}
+            right={
+              <View style={styles.habitToggleGroup}>
+                <View style={styles.habitToggleCol}>
+                  <Text style={styles.habitToggleLabel}>ACTIVE</Text>
+                  <NBToggle
+                    testID={`toggle-active-${item.id}`}
+                    value={item.isActive}
+                    onValueChange={() => handleToggleActive(item)}
+                    color={colors.tiger}
+                  />
                 </View>
-              }
-              isLast={isLast && !showPicker}
-            />
-          </Pressable>
-          {showPicker && (
-            <View
-              style={[
-                styles.timePickerContainer,
-                !isLast && styles.habitPickerDivider,
-              ]}
-              testID={`habit-time-picker-${item.id}`}>
-              <Text style={styles.rowLabel}>REMINDER TIME</Text>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                style={styles.timePicker}>
-                {hours.map(hour => {
-                  const selected =
-                    habitTime === `${String(hour).padStart(2, '0')}:00`;
-                  return (
-                    <Pressable
-                      key={hour}
-                      testID={`habit-time-option-${item.id}-${hour}`}
-                      style={[
-                        styles.timeOption,
-                        {
-                          backgroundColor: selected
-                            ? colors.tiger
-                            : colors.card,
-                          borderColor: selected
-                            ? colors.tigerDeep
-                            : colors.line,
-                        },
-                      ]}
-                      onPress={() => handleHabitTimeChange(item, hour)}>
-                      <Text style={styles.timeOptionText}>
-                        {formatHour(hour)}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </ScrollView>
-            </View>
-          )}
-        </View>
-      );
-    },
-    [
-      // Depend on `habits` (not `habits.length`) so the callback identity
-      // flips on every WatermelonDB emission. Habit models mutate in place,
-      // so without this the FlatList CellRenderer (PureComponent) keeps a
-      // stale render of item.isActive / item.notificationsEnabled even
-      // after toggleHabitActive or setHabitNotification.
-      habits,
-      reminderEnabled,
-      handleToggleActive,
-      handleLongPressDeactivate,
-      handleHabitNotificationToggle,
-      handleHabitTimeChange,
-      hours,
-    ],
-  );
+                <View style={styles.habitToggleCol}>
+                  <Text style={styles.habitToggleLabel}>NOTIFY</Text>
+                  <NBToggle
+                    testID={`toggle-notify-${item.id}`}
+                    value={item.notificationsEnabled}
+                    onValueChange={v =>
+                      handleHabitNotificationToggle(item, v)
+                    }
+                    disabled={reminderEnabled || !item.isActive}
+                    color={colors.tiger}
+                  />
+                </View>
+              </View>
+            }
+            isLast={isLast && !showPicker}
+          />
+        </Pressable>
+        {showPicker && (
+          <View
+            style={[
+              styles.timePickerContainer,
+              !isLast && styles.habitPickerDivider,
+            ]}
+            testID={`habit-time-picker-${item.id}`}>
+            <Text style={styles.rowLabel}>REMINDER TIME</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.timePicker}>
+              {hours.map(hour => {
+                const selected =
+                  habitTime === `${String(hour).padStart(2, '0')}:00`;
+                return (
+                  <Pressable
+                    key={hour}
+                    testID={`habit-time-option-${item.id}-${hour}`}
+                    style={[
+                      styles.timeOption,
+                      {
+                        backgroundColor: selected
+                          ? colors.tiger
+                          : colors.card,
+                        borderColor: selected
+                          ? colors.tigerDeep
+                          : colors.line,
+                      },
+                    ]}
+                    onPress={() => handleHabitTimeChange(item, hour)}>
+                    <Text style={styles.timeOptionText}>
+                      {formatHour(hour)}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+        )}
+      </View>
+    );
+  };
 
   return (
     <NBSurface testID="settings-screen">
@@ -506,14 +502,12 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           {habits.length === 0 ? (
             <Text style={styles.emptyText}>No habits yet.</Text>
           ) : (
-            <FlatList
-              data={habits}
-              renderItem={renderHabitRow}
-              keyExtractor={item => item.id}
-              extraData={reminderEnabled}
-              scrollEnabled={false}
-              testID="habits-list"
-            />
+            // Render with .map (not FlatList) — scrollEnabled would be false
+            // inside this parent ScrollView so virtualization is off either
+            // way, and plain .map sidesteps FlatList CellRenderer caching
+            // when WatermelonDB row instances mutate in place across
+            // observable emissions. Do not "optimize" this back to FlatList.
+            <View testID="habits-list">{habits.map(renderHabitRow)}</View>
           )}
         </NBCard>
 


### PR DESCRIPTION
## Summary

Third attempt at the Settings notification-toggle bug ("user disables Daily Reminder → per-habit NOTIFY toggles remain disabled → can't re-enable anything"). Prior attempts ([#95](https://github.com/domicy/daily-habit-tracker/pull/95), [#96](https://github.com/domicy/daily-habit-tracker/pull/96), [#97](https://github.com/domicy/daily-habit-tracker/pull/97)) addressed adjacent issues without resolving the symptom.

### Primary fix (high-confidence, regression test included)

`handleReminderToggle` ON-path coupled `scheduleDailyReminder` and `cancelAllHabitReminders` in the same `try/catch`. If `cancelAllHabitReminders` rejected (notifee's `getTriggerNotifications` can fail transiently on some Android OEM builds — even after the daily reminder itself was successfully scheduled), the catch block bailed out before `setReminderEnabled(true)` and the AsyncStorage write ran. The controlled `NBToggle` snapped back to OFF and the user could not re-enable the daily reminder. On the next tap the same failure path re-ran. **User stuck.**

Fix: schedule the daily reminder, commit state to React + AsyncStorage immediately, then run `cancelAllHabitReminders` as a best-effort secondary step with its own Alert. This mirrors the existing OFF-path design where `cancelDailyReminder` is the critical step and the per-habit fan-out is best-effort.

New test `commits the global ON state even when cancelAllHabitReminders rejects` fails on the prior code and passes after the fix.

### Defense-in-depth + cleanup (medium-confidence, no new test)

Replaced the `<FlatList>` around the habits list with `habits.map(...)` wrapped in `<View testID="habits-list">`. `scrollEnabled={false}` inside a parent `<ScrollView>` meant FlatList wasn't virtualizing anyway, and its `CellRenderer` PureComponent caching is the suspected reason per-habit NOTIFY toggles can read stale `disabled=true` even after `reminderEnabled` flips (the prior `extraData` fix in #95 passes its Jest test but the symptom persists on device, suggesting the test renderer doesn't fully model the production CellRenderer). This is **not reproduced** in Jest — we cannot prove it's a second live bug — but the swap strictly simplifies the code (drops `useCallback` + `extraData` + `keyExtractor` + the renderHabitRow identity-flip dance) and eliminates a class of WatermelonDB-mutate-in-place vs PureComponent mismatches. Inline comment added so the next contributor doesn't "optimize" `.map` back to `FlatList`.

### Files

- `src/screens/SettingsScreen.tsx` — ON-path restructure, FlatList → map, dropped FlatList import
- `src/__tests__/screens/SettingsScreen.test.tsx` — new regression test for the ON-path desync
- `MANUAL_QA.md` — added Android device-QA section for the toggle ON/OFF/ON cycle

## Test plan

- [x] `npx jest src/__tests__/screens/SettingsScreen.test.tsx` — 27/27 pass (new test included)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/screens/SettingsScreen.tsx src/__tests__/screens/SettingsScreen.test.tsx` — no new warnings (3 pre-existing `if/return` one-liner warnings in unrelated code)
- [ ] **Device QA (the actual user-facing validation)**: install on Android. Tap DAILY REMINDER on, then off, then on again. If a `Per-Habit Reminders` alert appears about a cleanup failure, the toggle must still visibly be ON afterwards (primary fix). Toggle DAILY REMINDER OFF and verify all per-habit NOTIFY toggles on active habits become tappable immediately (secondary fix).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN8F6879BbcbvmZDsdpM13)_