### PR TITLE
Fix notification toggles stuck after first OFF on Android

### DIFF
--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -904,7 +904,10 @@ describe('SettingsScreen', () => {
     expect(notificationService.cancelAllHabitReminders).not.toHaveBeenCalled();
   });
 
-  it('re-enables habit NOTIFY toggles after the global reminder is turned OFF', async () => {
+  it('keeps per-habit NOTIFY toggles enabled regardless of the global reminder state', async () => {
+    // Per-habit toggle `disabled` is decoupled from `reminderEnabled` so the
+    // Android Pressable + accessibilityState.disabled responder bug cannot
+    // strand the native View in a non-tappable state across a global toggle.
     (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
       if (key === 'reminder_enabled') return Promise.resolve('true');
       if (key === 'reminder_time') return Promise.resolve('09:00');
@@ -928,19 +931,20 @@ describe('SettingsScreen', () => {
     await waitFor(() => {
       expect(getByTestId('toggle-notify-h1')).toBeTruthy();
     });
+    // Even with the global reminder ON, the per-habit toggle must not be
+    // visually/structurally disabled — only the !isActive case disables it.
     expect(
       getByTestId('toggle-notify-h1').props.accessibilityState.disabled,
-    ).toBe(true);
+    ).toBe(false);
 
     await act(async () => {
       fireEvent(getByTestId('reminder-toggle'), 'valueChange', false);
     });
 
-    await waitFor(() => {
-      expect(
-        getByTestId('toggle-notify-h1').props.accessibilityState.disabled,
-      ).toBe(false);
-    });
+    // Still enabled after the global flips off.
+    expect(
+      getByTestId('toggle-notify-h1').props.accessibilityState.disabled,
+    ).toBe(false);
 
     await act(async () => {
       fireEvent(getByTestId('toggle-notify-h1'), 'valueChange', false);
@@ -949,6 +953,91 @@ describe('SettingsScreen', () => {
       'h1',
       false,
       '08:00',
+    );
+  });
+
+  it('persists per-habit NOTIFY preference without scheduling notifee while the global reminder is ON', async () => {
+    // When the global Daily Reminder is on, the per-habit handler must save
+    // the preference to the DB but NOT call scheduleHabitReminder / requestPermission
+    // — the global trigger already covers the habit, scheduling a per-habit
+    // one would be redundant noise.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'reminder_enabled') return Promise.resolve('true');
+      if (key === 'reminder_time') return Promise.resolve('09:00');
+      return Promise.resolve(null);
+    });
+    const habits = [
+      {id: 'h1', name: 'Exercise', isActive: true, notificationsEnabled: false},
+    ];
+    const service = createMockHabitService(habits);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('toggle-notify-h1')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('toggle-notify-h1'), 'valueChange', true);
+    });
+
+    expect(service.setHabitNotification).toHaveBeenCalledWith(
+      'h1',
+      true,
+      '08:00',
+    );
+    expect(notificationService.scheduleHabitReminder).not.toHaveBeenCalled();
+    expect(notificationService.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('activates per-habit preferences via the OFF fan-out after the global reminder is turned off', async () => {
+    // The OFF path's existing fan-out (getHabitsWithNotifications →
+    // scheduleHabitReminder) is the mechanism that picks up the preferences
+    // saved while the global reminder was on.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'reminder_enabled') return Promise.resolve('true');
+      if (key === 'reminder_time') return Promise.resolve('09:00');
+      return Promise.resolve(null);
+    });
+    const habits = [
+      {id: 'h1', name: 'Exercise', isActive: true, notificationsEnabled: true},
+    ];
+    const service = createMockHabitService(habits);
+    (service.getHabitsWithNotifications as jest.Mock).mockResolvedValue([
+      {id: 'h1', name: 'Exercise', notificationTime: '07:30'},
+    ]);
+    const syncService = createMockSyncService();
+    const notificationService = createMockNotificationService();
+
+    const {getByTestId} = render(
+      <SettingsScreen
+        habitService={service}
+        syncService={syncService}
+        notificationService={notificationService}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('reminder-toggle')).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent(getByTestId('reminder-toggle'), 'valueChange', false);
+    });
+
+    expect(notificationService.scheduleHabitReminder).toHaveBeenCalledWith(
+      'h1',
+      'Exercise',
+      7,
+      30,
     );
   });
 

--- a/src/__tests__/services/NotificationService.test.ts
+++ b/src/__tests__/services/NotificationService.test.ts
@@ -218,4 +218,71 @@ describe('NotificationService', () => {
       expect(mockNotifee.cancelTriggerNotification).not.toHaveBeenCalled();
     });
   });
+
+  describe('withTimeout (notifee bridge hang protection)', () => {
+    // Each test that fakes timers must also restore real timers afterwards
+    // so other tests in the suite aren't poisoned.
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('rejects requestPermission with a labelled error when notifee never resolves', async () => {
+      jest.useFakeTimers();
+      // Forever-pending promise simulates the silent Android bridge hang.
+      mockNotifee.requestPermission.mockReturnValue(new Promise(() => {}));
+
+      const pending = service.requestPermission();
+      // Catch the rejection up front so the unhandled-rejection tracker
+      // doesn't flag it before the assertion below runs.
+      const settled = pending.catch(err => err);
+      // advanceTimersByTimeAsync both fires the 5s timer AND flushes the
+      // microtasks needed for the rejection to propagate through
+      // Promise.race -> .finally -> await.
+      await jest.advanceTimersByTimeAsync(5000);
+      const err = await settled;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/notifee\.requestPermission/);
+      expect((err as Error).message).toMatch(/5000ms/);
+    });
+
+    it('rejects scheduleDailyReminder when notifee.createTriggerNotification never resolves', async () => {
+      jest.useFakeTimers();
+      // cancel + createChannel succeed; createTriggerNotification hangs.
+      mockNotifee.cancelTriggerNotification.mockResolvedValue(undefined);
+      mockNotifee.createChannel.mockResolvedValue('');
+      mockNotifee.createTriggerNotification.mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      const pending = service.scheduleDailyReminder(9, 0);
+      const settled = pending.catch(err => err);
+      // scheduleDailyReminder has three sequential withTimeout calls. The
+      // first two settle as microtasks (mockResolvedValue) but each one
+      // needs the prior to flush before its timer is registered/cleared.
+      // advanceTimersByTimeAsync interleaves microtask flushes with timer
+      // advancement, so a single call past the hanging-call's timeout
+      // window settles the entire chain.
+      await jest.advanceTimersByTimeAsync(5000);
+      const err = await settled;
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(
+        /notifee\.createTriggerNotification\(daily\)/,
+      );
+    });
+
+    it('does not leave a pending timer after a successful resolution', async () => {
+      jest.useFakeTimers();
+      mockNotifee.requestPermission.mockResolvedValue({
+        authorizationStatus: 1, // AUTHORIZED
+      });
+
+      const result = await service.requestPermission();
+      expect(result).toBe(true);
+      // If the timer wasn't cleared in .finally, jest would see one
+      // pending; we assert zero so withTimeout doesn't leak.
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -37,10 +37,6 @@ const REMINDER_ENABLED_KEY = 'reminder_enabled';
 const REMINDER_TIME_KEY = 'reminder_time';
 const LAST_SYNC_KEY = 'last_sync_timestamp';
 
-function errMessage(err: unknown, fallback: string): string {
-  return err instanceof Error && err.message ? err.message : fallback;
-}
-
 interface SettingsScreenProps {
   habitService?: HabitService;
   syncService?: SyncService;
@@ -100,6 +96,38 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   // Clear the system status bar so the first row ("Your Habits") and any
   // content the user scrolls to (e.g. the Version row) don't slide under it.
   const contentPaddingTop = Math.max(insets.top + spacing.md, spacing.xl);
+
+  // notifee bridge calls are now timeout-capped (5s) at the service layer.
+  // If a call hangs and the user has navigated away before it surfaces,
+  // late Alert/state updates would warn. Gate diagnostic side effects on
+  // mount state.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const reportError = useCallback(
+    (where: string, err: unknown, title: string, context: string) => {
+      // Always log so adb logcat captures the cause even when the user
+      // has dismissed or never sees the alert.
+      console.error(`[SettingsScreen] ${where}:`, err);
+      if (mountedRef.current) {
+        // Always show the contextual message; append the underlying error
+        // detail when available so the user sees both "what we tried to
+        // do" and "what actually failed". This is critical for diagnosing
+        // the timeout-wrapped notifee labels (e.g. "Timed out waiting for
+        // notifee.createTriggerNotification(daily) (5000ms)").
+        const detail =
+          err instanceof Error && err.message ? err.message : '';
+        const body = detail ? `${context}\n\n${detail}` : context;
+        Alert.alert(title, body);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     (async () => {
@@ -179,25 +207,31 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         try {
           granted = await nService.requestPermission();
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleReminderToggle.requestPermission',
+            err,
             'Notifications',
-            errMessage(err, 'Failed to request notification permission.'),
+            'Failed to request notification permission.',
           );
           return;
         }
         if (!granted) {
-          Alert.alert(
-            'Notifications Disabled',
-            'Please enable notifications for Daily Habit Tracker in your device Settings.',
-          );
+          if (mountedRef.current) {
+            Alert.alert(
+              'Notifications Disabled',
+              'Please enable notifications for Daily Habit Tracker in your device Settings.',
+            );
+          }
           return;
         }
         try {
           await nService.scheduleDailyReminder(hour, minute);
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleReminderToggle.scheduleDailyReminder',
+            err,
             'Notification Error',
-            errMessage(err, 'Failed to schedule daily reminder.'),
+            'Failed to schedule daily reminder.',
           );
           return;
         }
@@ -206,15 +240,20 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         // The per-habit cleanup below is a best-effort secondary step with its
         // own Alert — if it fails the daily reminder is still active and the
         // user is not stuck on the global toggle.
+        if (!mountedRef.current) {
+          return;
+        }
         setReminderEnabled(true);
         await AsyncStorage.setItem(REMINDER_ENABLED_KEY, 'true');
 
         try {
           await nService.cancelAllHabitReminders();
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleReminderToggle.cancelAllHabitReminders',
+            err,
             'Per-Habit Reminders',
-            `Daily reminder is on, but cleaning up per-habit reminders failed: ${errMessage(err, 'unknown error')}. They may still fire alongside the daily reminder.`,
+            'Daily reminder is on, but cleaning up per-habit reminders failed. They may still fire alongside the daily reminder.',
           );
         }
       } else {
@@ -225,10 +264,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         try {
           await nService.cancelDailyReminder();
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleReminderToggle.cancelDailyReminder',
+            err,
             'Notification Error',
-            errMessage(err, 'Failed to disable daily reminder.'),
+            'Failed to disable daily reminder.',
           );
+          return;
+        }
+        if (!mountedRef.current) {
           return;
         }
         setReminderEnabled(false);
@@ -245,14 +289,16 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
             }),
           );
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleReminderToggle.scheduleHabitReminder(fanout)',
+            err,
             'Per-Habit Reminders',
-            `Daily reminder is off, but resuming per-habit reminders failed: ${errMessage(err, 'unknown error')}. Toggle individual habits to retry.`,
+            'Daily reminder is off, but resuming per-habit reminders failed. Toggle individual habits to retry.',
           );
         }
       }
     },
-    [nService, hService, reminderTime],
+    [nService, hService, reminderTime, reportError],
   );
 
   const handleTimeChange = useCallback(
@@ -265,34 +311,48 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         try {
           await nService.scheduleDailyReminder(hour, 0);
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleTimeChange.scheduleDailyReminder',
+            err,
             'Notification Error',
-            errMessage(err, 'Failed to update reminder time.'),
+            'Failed to update reminder time.',
           );
         }
       }
     },
-    [nService, reminderEnabled],
+    [nService, reminderEnabled, reportError],
   );
 
   const handleHabitNotificationToggle = useCallback(
     async (habit: Habit, value: boolean) => {
-      if (value) {
+      // Only prompt for permission when we're about to actually schedule
+      // something. When the global Daily Reminder is on, the per-habit
+      // preference is persisted but no per-habit notifee trigger is created
+      // (the global trigger already covers the user — a per-habit one would
+      // be redundant noise). The preference is picked up by
+      // getHabitsWithNotifications when the user later turns the global
+      // reminder off.
+      const willSchedule = value && !reminderEnabled;
+      if (willSchedule) {
         let granted: boolean;
         try {
           granted = await nService.requestPermission();
         } catch (err) {
-          Alert.alert(
+          reportError(
+            'handleHabitNotificationToggle.requestPermission',
+            err,
             'Notifications',
-            errMessage(err, 'Failed to request notification permission.'),
+            'Failed to request notification permission.',
           );
           return;
         }
         if (!granted) {
-          Alert.alert(
-            'Notifications Disabled',
-            'Please enable notifications for Daily Habit Tracker in your device Settings.',
-          );
+          if (mountedRef.current) {
+            Alert.alert(
+              'Notifications Disabled',
+              'Please enable notifications for Daily Habit Tracker in your device Settings.',
+            );
+          }
           return;
         }
       }
@@ -303,10 +363,19 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
       try {
         await hService.setHabitNotification(habit.id, value, time);
       } catch (err) {
-        Alert.alert(
+        reportError(
+          'handleHabitNotificationToggle.setHabitNotification',
+          err,
           'Habit Update Failed',
-          errMessage(err, 'Could not save the notification preference.'),
+          'Could not save the notification preference.',
         );
+        return;
+      }
+
+      // When the global reminder is on, we deliberately skip per-habit
+      // notifee scheduling — the preference is saved and will activate
+      // the next time the global reminder is turned off.
+      if (reminderEnabled) {
         return;
       }
 
@@ -327,13 +396,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
         } catch {
           // best-effort rollback
         }
-        Alert.alert(
+        reportError(
+          'handleHabitNotificationToggle.scheduleHabitReminder',
+          err,
           'Notification Error',
-          errMessage(err, 'Failed to schedule reminder.'),
+          'Failed to schedule reminder.',
         );
       }
     },
-    [hService, nService],
+    [hService, nService, reminderEnabled, reportError],
   );
 
   const handleHabitTimeChange = useCallback(
@@ -345,13 +416,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
           await nService.scheduleHabitReminder(habit.id, habit.name, hour, 0);
         }
       } catch (err) {
-        Alert.alert(
+        reportError(
+          'handleHabitTimeChange',
+          err,
           'Notification Error',
-          errMessage(err, 'Failed to update reminder time.'),
+          'Failed to update reminder time.',
         );
       }
     },
-    [hService, nService, reminderEnabled],
+    [hService, nService, reminderEnabled, reportError],
   );
 
   const handleSyncNow = useCallback(async () => {
@@ -431,7 +504,15 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
                     onValueChange={v =>
                       handleHabitNotificationToggle(item, v)
                     }
-                    disabled={reminderEnabled || !item.isActive}
+                    // Intentionally NOT gated on reminderEnabled. Toggling
+                    // disabled true->false on a Pressable on Android can
+                    // leave the native View's touch responder stuck — taps
+                    // stop firing even after disabled flips back to false.
+                    // Decouple: the per-habit toggle just reflects the
+                    // user's preference. When the global Daily Reminder is
+                    // on, the per-habit handler persists the preference but
+                    // skips per-habit notifee scheduling (global covers it).
+                    disabled={!item.isActive}
                     color={colors.tiger}
                   />
                 </View>

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -11,6 +11,33 @@ const NOTIFICATION_ID = 'daily-habit-reminder';
 const CHANNEL_ID = 'daily-reminders';
 const HABIT_NOTIFICATION_PREFIX = 'habit-reminder-';
 
+// notifee bridge calls on Android can silently never resolve in some failure
+// modes (SCHEDULE_EXACT_ALARM denial, bridge race, OEM-specific issues),
+// leaving handler awaits hanging forever with no alert. Cap each call so a
+// hang surfaces as a labelled rejection that the caller's try/catch can
+// report instead of disappearing.
+const NOTIFEE_CALL_TIMEOUT_MS = 5000;
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  ms: number = NOTIFEE_CALL_TIMEOUT_MS,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label} (${ms}ms)`));
+    }, ms);
+  });
+  // Clear the timer once the race settles so a successful resolve doesn't
+  // leak a pending timer into the event loop.
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  });
+}
+
 class NotificationService {
   /**
    * Request notification permission.
@@ -18,7 +45,10 @@ class NotificationService {
    * On older Android this is a no-op (granted at install).
    */
   async requestPermission(): Promise<boolean> {
-    const settings = await notifee.requestPermission();
+    const settings = await withTimeout(
+      notifee.requestPermission(),
+      'notifee.requestPermission',
+    );
     return (
       settings.authorizationStatus === AuthorizationStatus.AUTHORIZED ||
       settings.authorizationStatus === AuthorizationStatus.PROVISIONAL
@@ -30,13 +60,19 @@ class NotificationService {
    * daily local notification at the given hour and minute.
    */
   async scheduleDailyReminder(hour: number, minute: number): Promise<void> {
-    await this.cancelDailyReminder();
+    await withTimeout(
+      notifee.cancelTriggerNotification(NOTIFICATION_ID),
+      'notifee.cancelTriggerNotification(daily)',
+    );
 
     // Ensure notification channel exists.
-    await notifee.createChannel({
-      id: CHANNEL_ID,
-      name: 'Daily Reminders',
-    });
+    await withTimeout(
+      notifee.createChannel({
+        id: CHANNEL_ID,
+        name: 'Daily Reminders',
+      }),
+      'notifee.createChannel(daily)',
+    );
 
     // Build a timestamp trigger for the next occurrence of the given time
     const now = new Date();
@@ -46,17 +82,20 @@ class NotificationService {
       repeatFrequency: RepeatFrequency.DAILY,
     };
 
-    await notifee.createTriggerNotification(
-      {
-        id: NOTIFICATION_ID,
-        title: 'Daily Habits',
-        body: 'Time to check in on your habits!',
-        android: {
-          channelId: CHANNEL_ID,
-          pressAction: {id: 'default'},
+    await withTimeout(
+      notifee.createTriggerNotification(
+        {
+          id: NOTIFICATION_ID,
+          title: 'Daily Habits',
+          body: 'Time to check in on your habits!',
+          android: {
+            channelId: CHANNEL_ID,
+            pressAction: {id: 'default'},
+          },
         },
-      },
-      trigger,
+        trigger,
+      ),
+      'notifee.createTriggerNotification(daily)',
     );
   }
 
@@ -64,7 +103,10 @@ class NotificationService {
    * Cancel the scheduled daily reminder notification.
    */
   async cancelDailyReminder(): Promise<void> {
-    await notifee.cancelTriggerNotification(NOTIFICATION_ID);
+    await withTimeout(
+      notifee.cancelTriggerNotification(NOTIFICATION_ID),
+      'notifee.cancelTriggerNotification(daily)',
+    );
   }
 
   /**
@@ -103,12 +145,18 @@ class NotificationService {
     minute: number,
   ): Promise<void> {
     const id = this.habitNotificationId(habitId);
-    await notifee.cancelTriggerNotification(id);
+    await withTimeout(
+      notifee.cancelTriggerNotification(id),
+      `notifee.cancelTriggerNotification(${id})`,
+    );
 
-    await notifee.createChannel({
-      id: CHANNEL_ID,
-      name: 'Daily Reminders',
-    });
+    await withTimeout(
+      notifee.createChannel({
+        id: CHANNEL_ID,
+        name: 'Daily Reminders',
+      }),
+      'notifee.createChannel(habit)',
+    );
 
     const trigger: TimestampTrigger = {
       type: TriggerType.TIMESTAMP,
@@ -116,22 +164,29 @@ class NotificationService {
       repeatFrequency: RepeatFrequency.DAILY,
     };
 
-    await notifee.createTriggerNotification(
-      {
-        id,
-        title: habitName,
-        body: "Don't forget your habit today.",
-        android: {
-          channelId: CHANNEL_ID,
-          pressAction: {id: 'default'},
+    await withTimeout(
+      notifee.createTriggerNotification(
+        {
+          id,
+          title: habitName,
+          body: "Don't forget your habit today.",
+          android: {
+            channelId: CHANNEL_ID,
+            pressAction: {id: 'default'},
+          },
         },
-      },
-      trigger,
+        trigger,
+      ),
+      `notifee.createTriggerNotification(${id})`,
     );
   }
 
   async cancelHabitReminder(habitId: string): Promise<void> {
-    await notifee.cancelTriggerNotification(this.habitNotificationId(habitId));
+    const id = this.habitNotificationId(habitId);
+    await withTimeout(
+      notifee.cancelTriggerNotification(id),
+      `notifee.cancelTriggerNotification(${id})`,
+    );
   }
 
   /**
@@ -140,7 +195,10 @@ class NotificationService {
    * "daily-habit-reminder" or any unrelated trigger.
    */
   async cancelAllHabitReminders(): Promise<void> {
-    const triggers = await notifee.getTriggerNotifications();
+    const triggers = await withTimeout(
+      notifee.getTriggerNotifications(),
+      'notifee.getTriggerNotifications',
+    );
     const habitIds = triggers
       .map(t => t.notification.id)
       .filter(
@@ -148,7 +206,12 @@ class NotificationService {
           typeof id === 'string' && id.startsWith(HABIT_NOTIFICATION_PREFIX),
       );
     await Promise.all(
-      habitIds.map(id => notifee.cancelTriggerNotification(id)),
+      habitIds.map(id =>
+        withTimeout(
+          notifee.cancelTriggerNotification(id),
+          `notifee.cancelTriggerNotification(${id})`,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Context

Fifth attempt at the unresponsive notification toggles (#95–#98 all failed). Post-merge device QA confirms the JS reactive/render layer is now working — per-habit toggles visually flip from greyed-out to white when the Daily Reminder turns off. But two symptoms remain, with **no alert dialogs** appearing for either:

1. **Daily Reminder** can be turned OFF but **tapping to turn it back ON does nothing**.
2. **Per-habit NOTIFY** toggles become tappable-looking (opacity flips) but **taps do nothing**.

Each symptom has a distinct root cause, so this PR makes two independent fixes plus a diagnostic.

## Fix 1 — Timeout every notifee bridge call (Daily Reminder hang)

A `notifee.*` call silently **never resolves** on the device. The `await` hangs forever, the `catch` never fires, `setReminderEnabled(true)` never runs, and no alert appears — a never-rejecting Promise is invisible to `try/catch`.

`NotificationService` now wraps every notifee call in a 5s `withTimeout` helper that rejects with a self-identifying label (e.g. `Timed out waiting for notifee.createTriggerNotification(daily) (5000ms)`). The hang now surfaces through the existing `try/catch` as a real Alert. The timer is cleared in `.finally` so a successful resolve doesn't leak a pending timer.

If the toggle still can't turn back ON after this, the alert will now name the exact hanging call — turning a silent failure into a diagnosable one.

## Fix 2 — Decouple per-habit `disabled` from `reminderEnabled` (stuck Pressable)

On Android, a `Pressable` whose `accessibilityState.disabled` transitions `true → false` can leave the native View's touch responder stuck — JS-side opacity updates, but `onPress` never fires again. The Daily Reminder toggle is immune (it has no `disabled` prop), which is why only the per-habit toggles are affected.

The per-habit toggle's `disabled` is now `!item.isActive` only (no longer gated on `reminderEnabled`), so it never makes that disabled→enabled transition on a global toggle. Behavior change:

- The per-habit toggle always reflects the user's preference and is tappable whenever the habit is active.
- `handleHabitNotificationToggle` always persists the preference to the DB, but only schedules a per-habit notifee trigger when the global reminder is **off** (otherwise the global trigger already covers it — a per-habit one would be redundant noise).
- When the global reminder is later turned off, the existing OFF fan-out (`getHabitsWithNotifications` → `scheduleHabitReminder`) activates the saved preferences.

## Fix 3 — Diagnostics

- Every catch logs via `console.error` (visible in `adb logcat`) in addition to the Alert.
- Late Alert/state updates are gated on a `mountedRef` so a call that resolves after the user navigates away doesn't warn.

## Tests

- `NotificationService`: new tests assert `withTimeout` rejects with a labelled error when notifee hangs (fake timers + forever-pending mock), and that a successful resolve leaves zero pending timers.
- `SettingsScreen`: per-habit toggles stay enabled regardless of global state; preference persists without scheduling notifee while global is ON; OFF fan-out activates saved preferences.
- Full suite: 280 passing. `tsc --noEmit` clean. ESLint clean (only pre-existing/convention-consistent warnings).

## Test plan
- [ ] **Device QA (the real validation)** — install on Android:
  - [ ] Daily Reminder ON → OFF → ON responds in both directions. If it still can't turn ON, a timeout Alert now names the hanging notifee call.
  - [ ] Per-habit NOTIFY toggles tappable with Daily Reminder both ON and OFF.
  - [ ] With Daily Reminder ON, tapping per-habit NOTIFY persists the preference but schedules no per-habit trigger.
  - [ ] After turning Daily Reminder OFF, previously-set per-habit preferences begin firing.

> Note: Fix 2 is a UX shift (per-habit toggles are now independent of the global toggle). If device QA still shows per-habit toggles unresponsive, the next step is to remove `accessibilityState.disabled` from `NBToggle` entirely or force-remount the Pressable — deferred until QA data demands it.

https://claude.ai/code/session_01WN8F6879BbcbvmZDsdpM13

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN8F6879BbcbvmZDsdpM13)_