### PR TITLE
Fix Daily Reminder toggle hanging on notifee.requestPermission

### DIFF
--- a/src/__tests__/services/NotificationService.test.ts
+++ b/src/__tests__/services/NotificationService.test.ts
@@ -5,6 +5,7 @@ jest.mock('@notifee/react-native', () => ({
   __esModule: true,
   default: {
     requestPermission: jest.fn(),
+    getNotificationSettings: jest.fn(),
     createChannel: jest.fn().mockResolvedValue(''),
     createTriggerNotification: jest.fn().mockResolvedValue(''),
     cancelTriggerNotification: jest.fn().mockResolvedValue(undefined),
@@ -23,6 +24,7 @@ jest.mock('@notifee/react-native', () => ({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockNotifee = notifee as any as {
   requestPermission: jest.Mock;
+  getNotificationSettings: jest.Mock;
   createChannel: jest.Mock;
   createTriggerNotification: jest.Mock;
   cancelTriggerNotification: jest.Mock;
@@ -34,6 +36,12 @@ describe('NotificationService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default to DENIED so requestPermission tests still flow through to
+    // the actual notifee.requestPermission() prompt path. The
+    // already-granted short-circuit is exercised by its own tests.
+    mockNotifee.getNotificationSettings.mockResolvedValue({
+      authorizationStatus: 0, // DENIED
+    });
     service = new NotificationService();
   });
 
@@ -63,6 +71,35 @@ describe('NotificationService', () => {
 
       const result = await service.requestPermission();
       expect(result).toBe(false);
+    });
+
+    it('returns true without calling requestPermission when already authorized', async () => {
+      // The user's reported hang: notifee.requestPermission() never
+      // resolves when permission is already granted. Short-circuit via the
+      // non-interactive getNotificationSettings() read so it is never
+      // called.
+      mockNotifee.getNotificationSettings.mockResolvedValue({
+        authorizationStatus: 1, // AUTHORIZED
+      });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe(true);
+      expect(mockNotifee.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it('prompts via requestPermission when status is not yet determined', async () => {
+      mockNotifee.getNotificationSettings.mockResolvedValue({
+        authorizationStatus: -1, // NOT_DETERMINED
+      });
+      mockNotifee.requestPermission.mockResolvedValue({
+        authorizationStatus: 1, // AUTHORIZED
+      });
+
+      const result = await service.requestPermission();
+
+      expect(result).toBe(true);
+      expect(mockNotifee.requestPermission).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -45,6 +45,26 @@ class NotificationService {
    * On older Android this is a no-op (granted at install).
    */
   async requestPermission(): Promise<boolean> {
+    // notifee.requestPermission() can hang forever on Android when no
+    // system dialog is shown (most commonly when permission is already
+    // granted): the onRequestPermissionsResult callback that resolves the
+    // promise never fires. getNotificationSettings() is a non-interactive
+    // read that resolves reliably, so check the current status first and
+    // short-circuit the already-granted case rather than calling the
+    // hanging request. NOTE: on Android this cannot distinguish "never
+    // asked" from "permanently blocked" (both report DENIED), so the
+    // blocked case still falls through to requestPermission() and relies
+    // on the withTimeout net.
+    const current = await withTimeout(
+      notifee.getNotificationSettings(),
+      'notifee.getNotificationSettings',
+    );
+    if (
+      current.authorizationStatus === AuthorizationStatus.AUTHORIZED ||
+      current.authorizationStatus === AuthorizationStatus.PROVISIONAL
+    ) {
+      return true;
+    }
     const settings = await withTimeout(
       notifee.requestPermission(),
       'notifee.requestPermission',


### PR DESCRIPTION
## Context

Attempt 6. The attempt-5 timeout net (PR #99) did its job — device QA produced the decisive diagnostic:

> **Notifications** — Failed to request notification permission.
> Timed out waiting for **notifee.requestPermission (5000ms)**

This fires when toggling the **Daily Reminder ON**, and **the app already has OS notification permission granted**. So the failing call is now known: `notifee.requestPermission()` never resolves on this device.

## Root cause (observed, not a documented guarantee)

`requestPermission()` awaits an `onRequestPermissionsResult` callback. When Android shows **no system dialog** — which is the case when permission is already granted (and also when it's permanently blocked) — that callback may never fire and the Promise hangs. This is **observed behaviour consistent with known, still-open Android permission-request bugs**, reported across multiple RN libraries, not a notifee-specific fact:

- [facebook/react-native#53887](https://github.com/facebook/react-native/issues/53887) — "Request permission is not resolving in Android 16 if the status is never_ask_again"
- [facebook/react-native#17985](https://github.com/facebook/react-native/issues/17985) — "PermissionsAndroid.request never resolves"
- [zoontek/react-native-permissions#902](https://github.com/zoontek/react-native-permissions/issues/902) — "Permission Request Freezing and not resolving"

The recurring ecosystem fix is exactly **"check current status and return early instead of calling request."**

## Fix

In `NotificationService.requestPermission()`, query the **non-interactive** `notifee.getNotificationSettings()` first (it reads the current status without registering a permission-result callback, so it resolves reliably). If already `AUTHORIZED`/`PROVISIONAL`, return `true` immediately and **never call the hanging `requestPermission()`**. Only fall through to `requestPermission()` when the status is not yet granted.

Every UI path routes through this one service method, so it fixes both the Daily Reminder toggle and the per-habit permission prompt. The `Promise<boolean>` contract is unchanged, so no screen changes. Both calls remain wrapped in the attempt-5 `withTimeout`.

## Known limitation — do not read this as fully safe

On Android, `getNotificationSettings()` reports **`DENIED` for both "never asked" and "permanently blocked"** — it cannot tell them apart. So a user who has **permanently blocked** notifications still falls through to `requestPermission()`, which is the state most associated with the hang. Those users will still hit the 5s timeout + labelled alert (the attempt-5 net), not a working toggle. That's acceptable here because:

- The user's reported case is **already granted**, which this fix resolves definitively.
- A blocked user can't be re-prompted by the OS anyway — the resolution is "open system Settings", which the existing `Notifications Disabled` alert already advises.

Distinguishing blocked-vs-never-asked (an AsyncStorage "have we prompted" flag, or `PermissionsAndroid.check`) is a possible follow-up, deliberately out of scope to keep this surgical.

## Upstream

Installed `@notifee/react-native` is **9.1.8** (already the latest 9.x). The corroborating reports indicate an Android-platform-level problem, so a version bump is not a dependable fix — the check-first short-circuit is the right primary remedy and doubles as defense-in-depth.

## Tests

- New: `requestPermission` returns `true` **without** calling `notifee.requestPermission` when `getNotificationSettings` reports AUTHORIZED.
- New: `requestPermission` falls through and prompts when status is NOT_DETERMINED.
- Existing `requestPermission` tests retained — a DENIED default for `getNotificationSettings` in `beforeEach` keeps them flowing through the prompt path (including the attempt-5 timeout tests).
- Full suite: **282 passing**. `tsc --noEmit` clean. ESLint clean.

## Test plan
- [ ] **Device QA (the real validation)** — Android, notification permission **already granted**:
  - [ ] Toggle Daily Reminder **ON** → sticks ON, time picker appears, **no timeout alert** (the exact failing case from the screenshot).
  - [ ] Toggle OFF → ON → OFF repeatedly → responds every time.
  - [ ] Per-habit NOTIFY ON while global OFF → still prompts/schedules.
  - [ ] (Edge) Revoke permission in system settings → ON runs the real prompt path; permanently-blocked may still time out into the "open Settings" alert (known limitation above).

https://claude.ai/code/session_01WN8F6879BbcbvmZDsdpM13

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN8F6879BbcbvmZDsdpM13)_