### PR TITLE
Fix auth navigation ESLint and TypeScript CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "react-native run-android",
     "lint": "eslint .",
     "test": "jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "validate": "npm run lint && npm run typecheck"
   },
   "dependencies": {
     "@notifee/react-native": "^9.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,14 @@ const SyncBootstrap: React.FC = () => {
   return null;
 };
 
+const NavigationBootstrap: React.FC = () => {
+  const services = useServices();
+  if (!services) {
+    return null;
+  }
+  return <AppNavigator habitService={services.habitService} />;
+};
+
 const App: React.FC = () => {
   return (
     <ServicesProvider>
@@ -77,7 +85,7 @@ const App: React.FC = () => {
         <NotificationBootstrap />
         <SyncBootstrap />
         <NavigationContainer>
-          <AppNavigator />
+          <NavigationBootstrap />
         </NavigationContainer>
       </SafeAreaProvider>
     </ServicesProvider>

--- a/src/__tests__/navigation/AppNavigator.test.tsx
+++ b/src/__tests__/navigation/AppNavigator.test.tsx
@@ -11,7 +11,7 @@ jest.mock('../../context/AuthContext', () => ({
 
 // Mock HabitsProvider using inline require for View
 jest.mock('../../hooks/useHabitsContext', () => {
-  const { View } = require('react-native');
+  const { View } = jest.requireActual('react-native') as typeof import('react-native');
   return {
     HabitsProvider: ({ children }: { children: React.ReactNode }) => (
       <View testID="habits-provider-mock">{children}</View>
@@ -21,31 +21,31 @@ jest.mock('../../hooks/useHabitsContext', () => {
 
 // Mock Navigation Screens using inline require for Text
 jest.mock('../../screens/LoginScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return {
     LoginScreen: () => <Text>LoginScreenMock</Text>,
   };
 });
 jest.mock('../../screens/RegisterScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return {
     RegisterScreen: () => <Text>RegisterScreenMock</Text>,
   };
 });
 jest.mock('../../screens/DashboardScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return () => <Text>DashboardScreenMock</Text>;
 });
 jest.mock('../../screens/StreaksScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return () => <Text>StreaksScreenMock</Text>;
 });
 jest.mock('../../screens/StatsListScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return () => <Text>StatsListScreenMock</Text>;
 });
 jest.mock('../../screens/SettingsScreen', () => {
-  const { Text } = require('react-native');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return () => <Text>SettingsScreenMock</Text>;
 });
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,4 +17,4 @@ const database = new Database({
 });
 
 export default database;
-export {Habit, HabitLog};
+export {database, Habit, HabitLog};

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -7,6 +7,8 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { AuthProvider, useAuth } from '../context/AuthContext';
 import { HabitsProvider } from '../hooks/useHabitsContext';
+import type HabitService from '../services/HabitService';
+import type { AuthStackParamList } from './types';
 
 import { LoginScreen } from '../screens/LoginScreen';
 import { RegisterScreen } from '../screens/RegisterScreen';
@@ -15,7 +17,7 @@ import StreaksScreen from '../screens/StreaksScreen';
 import StatsListScreen from '../screens/StatsListScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 
-const AuthStack = createNativeStackNavigator();
+const AuthStack = createNativeStackNavigator<AuthStackParamList>();
 const Tab = createBottomTabNavigator();
 
 const AuthNavigator = () => (
@@ -34,7 +36,9 @@ const MainTabNavigator = () => (
   </Tab.Navigator>
 );
 
-export const RootNavigator = () => {
+export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
+  habitService,
+}) => {
   const { isAuthenticated, isLoading } = useAuth();
 
   if (isLoading) {
@@ -48,7 +52,7 @@ export const RootNavigator = () => {
   return (
     <NavigationContainer>
       {isAuthenticated ? (
-        <HabitsProvider>
+        <HabitsProvider habitService={habitService!}>
           <MainTabNavigator />
         </HabitsProvider>
       ) : (
@@ -58,10 +62,10 @@ export const RootNavigator = () => {
   );
 };
 
-export const AppNavigator: React.FC = () => {
+const AppNavigator: React.FC<{habitService: HabitService}> = ({habitService}) => {
   return (
     <AuthProvider>
-      <RootNavigator />
+      <RootNavigator habitService={habitService} />
     </AuthProvider>
   );
 };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,4 @@
+export type AuthStackParamList = {
+  Login: undefined;
+  Register: undefined;
+};

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -2,8 +2,12 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { AuthStackParamList } from '../navigation/types';
 
-export const LoginScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
+type LoginScreenProps = NativeStackScreenProps<AuthStackParamList, 'Login'>;
+
+export const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { login } = useAuth();

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -2,8 +2,12 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { AuthStackParamList } from '../navigation/types';
 
-export const RegisterScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
+type RegisterScreenProps = NativeStackScreenProps<AuthStackParamList, 'Register'>;
+
+export const RegisterScreen: React.FC<RegisterScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { login } = useAuth();

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -35,7 +35,7 @@ const apiClient = axios.create({
 let cachedToken: string | null = null;
 let tokenHydrated = false;
 
-async function hydrateToken(): Promise<void> {
+export async function hydrateToken(): Promise<void> {
   if (tokenHydrated) {
     return;
   }


### PR DESCRIPTION
## Summary
- replace untyped auth-screen navigation props with a shared native-stack param list
- replace hoisted Jest mock `require()` calls with `jest.requireActual()`
- pass the existing HabitService into navigation without coupling tests to native service modules
- export the auth/database helpers required by AuthContext and add an npm validation script

## Verification
- `npm run validate`
- `npm test -- --runInBand` (15 suites, 288 tests)
- `npx jest src/__tests__/navigation/AppNavigator.test.tsx --runInBand`

ESLint completes with zero errors; existing warnings remain unchanged.