### PR TITLE
feat: complete multi-user architecture (#103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository contribution rules
+
+## Issue-closing pull requests
+
+Whenever a pull request is created to resolve a GitHub issue, its description
+must reference the issue with a GitHub closing keyword, for example:
+
+```text
+Closes #103
+```
+
+Use `Closes`, `Fixes`, or `Resolves` followed by the exact issue number. Do not
+rely on a plain issue reference such as `#103`; the closing keyword ensures
+GitHub automatically closes the issue when the pull request is merged.

--- a/backend/alembic/versions/004_multi_user.py
+++ b/backend/alembic/versions/004_multi_user.py
@@ -1,0 +1,51 @@
+"""add users and ownership to habit data"""
+
+from typing import Sequence, Union
+import uuid
+import hashlib
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("password_hash", sa.String(255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+    op.create_index("ix_users_email", "users", ["email"])
+
+    legacy_id = "00000000-0000-0000-0000-000000000000"
+    salt = uuid.uuid4().hex
+    digest = hashlib.pbkdf2_hmac("sha256", b"legacy-disabled", salt.encode(), 240000).hex()
+    op.bulk_insert(sa.table("users", sa.column("id", sa.String), sa.column("email", sa.String), sa.column("password_hash", sa.String), sa.column("created_at", sa.DateTime())), [{
+        "id": legacy_id, "email": "legacy@local.invalid", "password_hash": f"pbkdf2_sha256$240000${salt}${digest}", "created_at": sa.func.now()
+    }])
+    for table in ("habits", "habit_logs"):
+        op.add_column(table, sa.Column("user_id", sa.String(36), nullable=True))
+        op.create_index(f"ix_{table}_user_id", table, ["user_id"])
+        op.execute(sa.text(f"UPDATE {table} SET user_id = :legacy_id"), {"legacy_id": legacy_id})
+        with op.batch_alter_table(table) as batch:
+            batch.alter_column("user_id", nullable=False)
+    # Replace the old global uniqueness rule with ownership-aware uniqueness.
+    with op.batch_alter_table("habit_logs") as batch:
+        batch.drop_constraint("uq_habit_date", type_="unique")
+        batch.create_unique_constraint("uq_user_habit_date", ["user_id", "habit_id", "completed_date"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("habit_logs") as batch:
+        batch.drop_constraint("uq_user_habit_date", type_="unique")
+        batch.create_unique_constraint("uq_habit_date", ["habit_id", "completed_date"])
+    for table in ("habits", "habit_logs"):
+        op.drop_column(table, "user_id")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -22,3 +22,10 @@ async def require_token(
             detail="Invalid or expired token",
         )
     return payload
+
+
+def user_id_from_token(payload: dict) -> str:
+    user_id = payload.get("sub")
+    if not isinstance(user_id, str) or not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token subject missing")
+    return user_id

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,12 +17,22 @@ class Base(DeclarativeBase):
     pass
 
 
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
 class Habit(Base):
     __tablename__ = "habits"
 
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
+    user_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, default="user")
     name: Mapped[str] = mapped_column(String(50), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow
@@ -35,12 +45,13 @@ class Habit(Base):
 class HabitLog(Base):
     __tablename__ = "habit_logs"
     __table_args__ = (
-        UniqueConstraint("habit_id", "completed_date", name="uq_habit_date"),
+        UniqueConstraint("user_id", "habit_id", "completed_date", name="uq_user_habit_date"),
     )
 
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
+    user_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, default="user")
     habit_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("habits.id"), index=True, nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,23 +1,75 @@
 import hmac
+import hashlib
+import re
+import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from jose import jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.schemas import TokenRequest, TokenResponse
+from app.database import get_db
+from app.models import User
+from app.schemas import RegisterRequest, TokenRequest, TokenResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+def _hash_password(password: str) -> str:
+    salt = uuid.uuid4().hex
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), 240_000)
+    return f"pbkdf2_sha256$240000${salt}${digest.hex()}"
+
+
+def _verify_password(password: str, encoded: str) -> bool:
+    try:
+        algorithm, rounds, salt, expected = encoded.split("$", 3)
+        actual = hashlib.pbkdf2_hmac("sha256", password.encode(), salt.encode(), int(rounds)).hex()
+        return algorithm == "pbkdf2_sha256" and hmac.compare_digest(actual, expected)
+    except (ValueError, TypeError):
+        return False
+
+
+def _email(value: str) -> str:
+    value = value.strip().lower()
+    if not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", value):
+        raise HTTPException(status_code=422, detail="Invalid email")
+    return value
+
+
+def _token(user_id: str) -> TokenResponse:
+    expire = datetime.now(timezone.utc) + timedelta(hours=settings.jwt_expiry_hours)
+    return TokenResponse(access_token=jwt.encode({"sub": user_id, "exp": expire}, settings.jwt_secret, algorithm=settings.jwt_algorithm))
+
+
+@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)) -> TokenResponse:
+    email = _email(body.email)
+    existing = await db.scalar(select(User).where(User.email == email))
+    if existing:
+        raise HTTPException(status_code=409, detail="Email already registered")
+    user = User(email=email, password_hash=_hash_password(body.password))
+    db.add(user)
+    await db.commit()
+    return _token(user.id)
+
+
 @router.post("/token", response_model=TokenResponse)
 async def issue_token(body: TokenRequest) -> TokenResponse:
-    if not hmac.compare_digest(body.secret, settings.jwt_secret):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid secret",
-        )
-    expire = datetime.now(timezone.utc) + timedelta(hours=settings.jwt_expiry_hours)
-    payload = {"sub": "user", "exp": expire}
-    token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
-    return TokenResponse(access_token=token)
+    if body.secret is not None:
+        if not hmac.compare_digest(body.secret, settings.jwt_secret):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid secret")
+        return _token("user")
+    raise HTTPException(status_code=422, detail="Email and password are required")
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(body: TokenRequest, db: AsyncSession = Depends(get_db)) -> TokenResponse:
+    if not body.email or not body.password:
+        raise HTTPException(status_code=422, detail="Email and password are required")
+    user = await db.scalar(select(User).where(User.email == _email(body.email)))
+    if not user or not _verify_password(body.password, user.password_hash):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+    return _token(user.id)

--- a/backend/app/routers/habits.py
+++ b/backend/app/routers/habits.py
@@ -5,29 +5,27 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.middleware.auth import require_token
+from app.middleware.auth import require_token, user_id_from_token
 from app.models import Habit
 from app.schemas import (
     HabitCreate,
     HabitRead,
     HabitSyncRequest,
     HabitSyncResponse,
+    HabitSyncPullResponse,
     HabitUpdate,
 )
 
-router = APIRouter(
-    prefix="/habits",
-    tags=["habits"],
-    dependencies=[Depends(require_token)],
-)
+router = APIRouter(prefix="/habits", tags=["habits"])
 
 
 @router.get("/", response_model=list[HabitRead])
 async def list_habits(
     active: bool | None = Query(None),
+    token: dict = Depends(require_token),
     db: AsyncSession = Depends(get_db),
 ):
-    stmt = select(Habit).order_by(Habit.created_at)
+    stmt = select(Habit).where(Habit.user_id == user_id_from_token(token)).order_by(Habit.created_at)
     if active is not None:
         stmt = stmt.where(Habit.is_active == active)
     result = await db.execute(stmt)
@@ -35,19 +33,25 @@ async def list_habits(
 
 
 @router.post("/", response_model=HabitRead, status_code=status.HTTP_201_CREATED)
-async def create_habit(body: HabitCreate, db: AsyncSession = Depends(get_db)):
-    habit = Habit(name=body.name)
+async def create_habit(body: HabitCreate, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+    habit = Habit(name=body.name, user_id=user_id_from_token(token))
     db.add(habit)
     await db.commit()
     await db.refresh(habit)
     return habit
 
 
+@router.get("/sync", response_model=HabitSyncPullResponse)
+async def pull_habits(token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+    result = await db.scalars(select(Habit).where(Habit.user_id == user_id_from_token(token)).order_by(Habit.created_at))
+    return HabitSyncPullResponse(habits=list(result))
+
+
 @router.patch("/{habit_id}", response_model=HabitRead)
 async def update_habit(
-    habit_id: str, body: HabitUpdate, db: AsyncSession = Depends(get_db)
+    habit_id: str, body: HabitUpdate, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)
 ):
-    habit = await db.get(Habit, habit_id)
+    habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id_from_token(token)))
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")
     for field, value in body.model_dump(exclude_unset=True).items():
@@ -58,15 +62,18 @@ async def update_habit(
 
 
 @router.post("/sync", response_model=HabitSyncResponse)
-async def sync_habits(body: HabitSyncRequest, db: AsyncSession = Depends(get_db)):
+async def sync_habits(body: HabitSyncRequest, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
     """
     Upsert habits using client-supplied IDs. The local-first client owns IDs
     and pushes habit creates/updates here so subsequent log syncs can resolve
     their habit_id references.
     """
+    user_id = user_id_from_token(token)
     synced_ids: list[str] = []
     for entry in body.habits:
-        existing = await db.get(Habit, entry.id)
+        existing = await db.scalar(select(Habit).where(Habit.id == entry.id, Habit.user_id == user_id))
+        if existing is None and await db.get(Habit, entry.id):
+            raise HTTPException(status_code=409, detail="Habit belongs to another user")
         created_at = datetime.fromtimestamp(entry.created_at_ms / 1000, tz=timezone.utc)
         if existing:
             existing.name = entry.name
@@ -78,6 +85,7 @@ async def sync_habits(body: HabitSyncRequest, db: AsyncSession = Depends(get_db)
                     name=entry.name,
                     created_at=created_at,
                     is_active=entry.is_active,
+                    user_id=user_id,
                 )
             )
         synced_ids.append(entry.id)

--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -8,15 +8,11 @@ from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.middleware.auth import require_token
+from app.middleware.auth import require_token, user_id_from_token
 from app.models import Habit, HabitLog
 from app.schemas import HabitLogRead, SyncError, SyncRequest, SyncResponse
 
-router = APIRouter(
-    prefix="/logs",
-    tags=["logs"],
-    dependencies=[Depends(require_token)],
-)
+router = APIRouter(prefix="/logs", tags=["logs"])
 
 
 def _upsert_habit_log_stmt(dialect_name: str, values: list[dict[str, Any]]):
@@ -35,7 +31,7 @@ def _upsert_habit_log_stmt(dialect_name: str, values: list[dict[str, Any]]):
     if dialect_name == "postgresql":
         stmt = postgresql.insert(HabitLog).values(values)
         return stmt.on_conflict_do_update(
-            constraint="uq_habit_date",
+            constraint="uq_user_habit_date",
             set_={
                 "synced_at": stmt.excluded.synced_at,
                 "deleted_at": stmt.excluded.deleted_at,
@@ -44,7 +40,7 @@ def _upsert_habit_log_stmt(dialect_name: str, values: list[dict[str, Any]]):
     if dialect_name == "sqlite":
         stmt = sqlite.insert(HabitLog).values(values)
         return stmt.on_conflict_do_update(
-            index_elements=["habit_id", "completed_date"],
+            index_elements=["user_id", "habit_id", "completed_date"],
             set_={
                 "synced_at": stmt.excluded.synced_at,
                 "deleted_at": stmt.excluded.deleted_at,
@@ -54,8 +50,9 @@ def _upsert_habit_log_stmt(dialect_name: str, values: list[dict[str, Any]]):
 
 
 @router.post("/sync", response_model=SyncResponse)
-async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
+async def sync_logs(body: SyncRequest, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
     errors: list[SyncError] = []
+    user_id = user_id_from_token(token)
 
     if not body.logs:
         return SyncResponse(synced=0, errors=errors)
@@ -63,7 +60,7 @@ async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
     habit_ids = {entry.habit_id for entry in body.logs}
     existing_habits = set(
         (
-            await db.execute(select(Habit.id).where(Habit.id.in_(habit_ids)))
+            await db.execute(select(Habit.id).where(Habit.id.in_(habit_ids), Habit.user_id == user_id))
         ).scalars()
     )
 
@@ -84,6 +81,7 @@ async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
             continue
         deduped[(entry.habit_id, entry.completed_date)] = {
             "id": str(uuid.uuid4()),
+            "user_id": user_id,
             "habit_id": entry.habit_id,
             "completed_date": entry.completed_date,
             "synced_at": now,
@@ -102,15 +100,27 @@ async def sync_logs(body: SyncRequest, db: AsyncSession = Depends(get_db)):
     return SyncResponse(synced=synced, errors=errors)
 
 
+@router.get("/sync", response_model=list[HabitLogRead])
+async def pull_logs(token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+    result = await db.scalars(
+        select(HabitLog)
+        .where(HabitLog.user_id == user_id_from_token(token), HabitLog.deleted_at.is_(None))
+        .order_by(HabitLog.completed_date)
+    )
+    return list(result)
+
+
 @router.get("/{habit_id}", response_model=list[HabitLogRead])
 async def get_logs(
     habit_id: str,
     start: date = Query(...),
     end: date = Query(...),
+    token: dict = Depends(require_token),
     db: AsyncSession = Depends(get_db),
 ):
     # Verify habit exists
-    habit = await db.get(Habit, habit_id)
+    user_id = user_id_from_token(token)
+    habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id))
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")
 
@@ -118,6 +128,7 @@ async def get_logs(
         select(HabitLog)
         .where(
             HabitLog.habit_id == habit_id,
+            HabitLog.user_id == user_id,
             HabitLog.completed_date >= start,
             HabitLog.completed_date <= end,
             HabitLog.deleted_at.is_(None),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -69,6 +69,10 @@ class HabitSyncResponse(BaseModel):
     synced_ids: list[str]
 
 
+class HabitSyncPullResponse(BaseModel):
+    habits: list[HabitRead]
+
+
 # ── Habit Logs ──────────────────────────────────────────
 
 class HabitLogCreate(BaseModel):
@@ -106,7 +110,14 @@ class SyncResponse(BaseModel):
 # ── Auth ────────────────────────────────────────────────
 
 class TokenRequest(BaseModel):
-    secret: str
+    secret: str | None = None
+    email: str | None = None
+    password: str | None = None
+
+
+class RegisterRequest(BaseModel):
+    email: str
+    password: str = Field(..., min_length=8)
 
 
 class TokenResponse(BaseModel):

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@ import { database } from '../models'; // Adjust import based on your WatermelonD
 
 interface AuthContextType {
   token: string | null;
+  userId: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (newToken: string) => Promise<void>;
@@ -16,6 +17,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [token, setTokenState] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -26,6 +28,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         const storedToken = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
         if (storedToken) {
           setTokenState(storedToken);
+          setUserId(decodeSubject(storedToken));
         }
       } catch (error) {
         console.error('Failed to hydrate auth token:', error);
@@ -40,6 +43,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const login = async (newToken: string) => {
     await setAuthToken(newToken);
     setTokenState(newToken);
+    setUserId(decodeSubject(newToken));
   };
 
   const logout = async () => {
@@ -47,6 +51,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       // 1. Clear token in persistent storage & Axios interceptor memory
       await setAuthToken(null);
       setTokenState(null);
+      setUserId(null);
 
       // 2. Wipe local WatermelonDB so no user data remains on device
       await database.write(async () => {
@@ -61,6 +66,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     <AuthContext.Provider
       value={{
         token,
+        userId,
         isAuthenticated: !!token,
         isLoading,
         login,
@@ -71,6 +77,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     </AuthContext.Provider>
   );
 };
+
+function decodeSubject(token: string): string | null {
+  try {
+    const part = token.split('.')[1];
+    if (!part) return null;
+    const payload = JSON.parse(atob(part.replace(/-/g, '+').replace(/_/g, '/')));
+    return typeof payload.sub === 'string' ? payload.sub : null;
+  } catch { return null; }
+}
 
 export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);

--- a/src/models/Habit.ts
+++ b/src/models/Habit.ts
@@ -11,6 +11,7 @@ export default class Habit extends Model {
   };
 
   @field('name') name!: string;
+  @field('user_id') userId!: string;
   @field('created_at') createdAt!: number;
   @field('is_active') isActive!: boolean;
   @field('synced') synced!: boolean;

--- a/src/models/HabitLog.ts
+++ b/src/models/HabitLog.ts
@@ -17,6 +17,7 @@ export default class HabitLog extends Model {
   };
 
   @field('habit_id') habitId!: string;
+  @field('user_id') userId!: string;
   // Plain string in "YYYY-MM-DD" format to avoid timezone issues.
   @field('completed_date') completedDate!: string;
   @field('synced') synced!: boolean;

--- a/src/models/migrations.ts
+++ b/src/models/migrations.ts
@@ -51,5 +51,12 @@ export const migrations = schemaMigrations({
         }),
       ],
     },
+    {
+      toVersion: 5,
+      steps: [
+        addColumns({table: 'habits', columns: [{name: 'user_id', type: 'string', isIndexed: true}]}),
+        addColumns({table: 'habit_logs', columns: [{name: 'user_id', type: 'string', isIndexed: true}]}),
+      ],
+    },
   ],
 });

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,12 +1,13 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export const schema = appSchema({
-  version: 4,
+  version: 5,
   tables: [
     tableSchema({
       name: 'habits',
       columns: [
         {name: 'name', type: 'string'},
+        {name: 'user_id', type: 'string', isIndexed: true},
         {name: 'created_at', type: 'number'},
         {name: 'is_active', type: 'boolean'},
         {name: 'synced', type: 'boolean', isIndexed: true},
@@ -22,6 +23,7 @@ export const schema = appSchema({
       name: 'habit_logs',
       columns: [
         {name: 'habit_id', type: 'string', isIndexed: true},
+        {name: 'user_id', type: 'string', isIndexed: true},
         // Stored as "YYYY-MM-DD" string to avoid timezone issues.
         // NOTE: The pair (habit_id, completed_date) should be treated as
         // logically unique among non-tombstoned rows. Enforce this in the

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -27,19 +27,32 @@ const AuthNavigator = () => (
   </AuthStack.Navigator>
 );
 
-const MainTabNavigator = () => (
-  <Tab.Navigator>
+const MainTabNavigator = () => {
+  const {logout} = useAuth();
+  return <Tab.Navigator>
     <Tab.Screen name="Dashboard" component={DashboardScreen} />
     <Tab.Screen name="Streaks" component={StreaksScreen} />
     <Tab.Screen name="Stats" component={StatsListScreen} />
-    <Tab.Screen name="Settings" component={SettingsScreen} />
-  </Tab.Navigator>
-);
+    <Tab.Screen name="Settings">
+      {props => <SettingsScreen {...props} onLogout={logout} />}
+    </Tab.Screen>
+  </Tab.Navigator>;
+};
 
 export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
   habitService,
 }) => {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, userId } = useAuth();
+
+  // Set ownership before the provider mounts so its first query cannot expose
+  // the previous account's local rows during an account switch.
+  if (habitService && userId) {
+    habitService.setUserId(userId);
+  }
+
+  React.useEffect(() => {
+    if (habitService && userId) habitService.setUserId(userId);
+  }, [habitService, userId]);
 
   if (isLoading) {
     return (
@@ -51,10 +64,12 @@ export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
 
   return (
     <NavigationContainer>
-      {isAuthenticated ? (
-        <HabitsProvider habitService={habitService!}>
+      {isAuthenticated && habitService ? (
+        <HabitsProvider key={userId ?? 'user'} habitService={habitService}>
           <MainTabNavigator />
         </HabitsProvider>
+      ) : isAuthenticated ? (
+        <MainTabNavigator />
       ) : (
         <AuthNavigator />
       )}

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
+import apiClient from '../services/api';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../navigation/types';
 
@@ -13,9 +14,8 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const { login } = useAuth();
 
   const handleLogin = async () => {
-    // TODO: Replace with backend API request to backend/app/routers/auth.py
-    const mockToken = 'jwt-token-placeholder';
-    await login(mockToken);
+    const response = await apiClient.post('/auth/login', {email, password});
+    await login(response.data.access_token);
   };
 
   return (

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
+import apiClient from '../services/api';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../navigation/types';
 
@@ -13,9 +14,8 @@ export const RegisterScreen: React.FC<RegisterScreenProps> = ({ navigation }) =>
   const { login } = useAuth();
 
   const handleRegister = async () => {
-    // TODO: Replace with backend API register call
-    const mockToken = 'jwt-token-placeholder';
-    await login(mockToken);
+    const response = await apiClient.post('/auth/register', {email, password});
+    await login(response.data.access_token);
   };
 
   return (

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -41,6 +41,7 @@ interface SettingsScreenProps {
   habitService?: HabitService;
   syncService?: SyncService;
   notificationService?: NotificationService;
+  onLogout?: () => Promise<void>;
 }
 
 const SectionHeader: React.FC<{label: string; count?: string | number}> = ({
@@ -59,6 +60,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   habitService,
   syncService,
   notificationService,
+  onLogout,
 }) => {
   const ctxServices = useServices();
   const hService = habitService ?? ctxServices?.habitService;
@@ -758,6 +760,16 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
             }
           />
         </NBCard>
+
+        {onLogout && (
+          <NBButton
+            variant="secondary"
+            testID="logout-button"
+            onPress={onLogout}
+            style={styles.connectButton}>
+            LOG OUT
+          </NBButton>
+        )}
 
         <View style={styles.bottomSpacer} />
       </ScrollView>

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -27,15 +27,20 @@ export function backoffMsFor(retryCount: number): number {
 
 export default class HabitService {
   private database: Database;
+  private userId = 'user';
 
   constructor(database: Database) {
     this.database = database;
   }
 
+  setUserId(userId: string): void {
+    this.userId = userId;
+  }
+
   getActiveHabits(): Observable<Habit[]> {
     return this.database
       .get<Habit>('habits')
-      .query(Q.where('is_active', true), Q.sortBy('created_at', Q.asc))
+      .query(Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')), Q.where('is_active', true), Q.sortBy('created_at', Q.asc))
       .observe();
   }
 
@@ -47,7 +52,7 @@ export default class HabitService {
     // the UI.
     return this.database
       .get<Habit>('habits')
-      .query(Q.sortBy('created_at', Q.asc))
+      .query(Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')), Q.sortBy('created_at', Q.asc))
       .observeWithColumns([
         'is_active',
         'notifications_enabled',
@@ -79,6 +84,7 @@ export default class HabitService {
     return this.database.write(async () => {
       return this.database.get<Habit>('habits').create(habit => {
         habit.name = trimmed;
+        habit.userId = this.userId;
         habit.createdAt = Date.now();
         habit.isActive = true;
         habit.synced = false;
@@ -111,6 +117,7 @@ export default class HabitService {
       .query(
         Q.where('notifications_enabled', true),
         Q.where('is_active', true),
+        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
       )
       .fetch();
   }
@@ -125,6 +132,7 @@ export default class HabitService {
         .query(
           Q.where('habit_id', habitId),
           Q.where('completed_date', date),
+          Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
         )
         .fetch();
 
@@ -164,6 +172,7 @@ export default class HabitService {
 
       await this.database.get<HabitLog>('habit_logs').create(log => {
         log.habitId = habitId;
+        log.userId = this.userId;
         log.completedDate = date;
         log.synced = false;
         log.deletedAt = null;
@@ -174,7 +183,9 @@ export default class HabitService {
   }
 
   async getHabitById(habitId: string): Promise<Habit> {
-    return this.database.get<Habit>('habits').find(habitId);
+    const habits = await this.database.get<Habit>('habits').query(Q.where('id', habitId), Q.or(Q.where('user_id', this.userId), Q.where('user_id', ''))).fetch();
+    if (!habits[0]) throw new Error('Habit not found');
+    return habits[0];
   }
 
   async getLogsForHabit(
@@ -186,6 +197,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
+        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
         Q.where('completed_date', Q.gte(startDate)),
         Q.where('completed_date', Q.lte(endDate)),
         Q.where('deleted_at', null),
@@ -202,6 +214,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('synced', false),
+        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
         Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
       )
       .fetch();
@@ -221,7 +234,7 @@ export default class HabitService {
   async getUnsyncedHabits(): Promise<Habit[]> {
     return this.database
       .get<Habit>('habits')
-      .query(Q.where('synced', false))
+      .query(Q.where('synced', false), Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')))
       .fetch();
   }
 
@@ -307,6 +320,53 @@ export default class HabitService {
     }
   }
 
+  async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean}>): Promise<void> {
+    await this.database.write(async () => {
+      for (const remote of habits) {
+        let local: Habit | null = null;
+        try { local = await this.database.get<Habit>('habits').find(remote.id); } catch { /* new row */ }
+        if (local) {
+          if (!local.synced) continue; // never overwrite offline work
+          await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; });
+        } else {
+          await this.database.get<Habit>('habits').create(h => {
+            h._raw.id = remote.id;
+            h.userId = this.userId;
+            h.name = remote.name;
+            h.createdAt = Date.parse(remote.created_at);
+            h.isActive = remote.is_active;
+            h.synced = true;
+            h.notificationsEnabled = false;
+            h.notificationTime = '08:00';
+          });
+        }
+      }
+    });
+  }
+
+  async applyPulledLogs(logs: Array<{id: string; habit_id: string; completed_date: string}>): Promise<void> {
+    await this.database.write(async () => {
+      for (const remote of logs) {
+        const existing = await this.database.get<HabitLog>('habit_logs').query(
+          Q.where('habit_id', remote.habit_id), Q.where('completed_date', remote.completed_date),
+          Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        ).fetch();
+        if (existing.some(log => log.deletedAt == null)) continue;
+        const tombstone = existing[0];
+        if (tombstone) {
+          await tombstone.update(log => { log.deletedAt = null; log.synced = true; });
+        } else {
+          await this.database.get<HabitLog>('habit_logs').create(log => {
+            log._raw.id = remote.id;
+            log.userId = this.userId; log.habitId = remote.habit_id;
+            log.completedDate = remote.completed_date; log.synced = true;
+            log.deletedAt = null; log.retryCount = 0; log.lastAttemptAt = null;
+          });
+        }
+      }
+    });
+  }
+
   observeUnsyncedCount(): Observable<number> {
     // Match getUnsyncedLogs: exclude rows past the permanent-failure cap so
     // the UI doesn't show a forever-growing "N pending" for dead-end logs.
@@ -314,6 +374,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('synced', false),
+        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
         Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
       )
       .observe();

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -108,6 +108,7 @@ export default class SyncService {
     }
     this.inFlight = true;
     try {
+      await this.pullHabits();
       // If auth previously failed permanently, don't retry
       const authFailed = await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY);
       if (authFailed === 'true') {
@@ -139,6 +140,17 @@ export default class SyncService {
       return await this.pushBatch(unsyncedLogs);
     } finally {
       this.inFlight = false;
+    }
+  }
+
+  private async pullHabits(): Promise<void> {
+    try {
+      const response = await apiClient.get('/habits/sync');
+      await this.habitService.applyPulledHabits(response.data?.habits ?? []);
+      const logs = await apiClient.get('/logs/sync');
+      await this.habitService.applyPulledLogs(logs.data ?? []);
+    } catch {
+      // Pull is best-effort; local-first writes remain available offline.
     }
   }
 


### PR DESCRIPTION
## Summary

Completes the multi-user architecture required before leaderboard and scoring work.

- Adds the backend User model, registration/login, password hashing, UUID-subject JWTs, and migration 004.
- Scopes habits, logs, sync, and pull APIs by authenticated user.
- Adds local WatermelonDB user ownership and account-safe service filtering.
- Wires auth-aware login/register, navigation, sync/pull behavior, and logout cleanup.
- Preserves legacy secret-token compatibility during migration.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings remain)
- `npm test -- --runInBand --silent` (288 passed)
- Python compilation and diff checks passed.
- Backend pytest was not runnable because Python dependencies are unavailable in the workspace.

Closes #103