### PR TITLE
Add habit scoring, metrics, and head-to-head leaderboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,23 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    # Production runs MariaDB (backend/docker-compose.yml, backend/.env.example).
+    # batch_alter_table only rewrites the table on SQLite, so a migration that
+    # is broken on MySQL/MariaDB compiles fine against SQLite -- the MariaDB
+    # steps below are the gating ones.
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: secret
+          MARIADB_DATABASE: habits
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
     steps:
       - uses: actions/checkout@v4
 
@@ -72,13 +89,64 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest-cov
+          # pymysql: sync MySQL driver, used only for the offline --sql compile
+          # check (alembic/env.py's online path requires an async driver).
+          pip install pytest-cov pymysql
 
-      - name: Verify Alembic migrations
+      - name: Verify Alembic migrations (SQLite)
         env:
           DATABASE_URL: sqlite+aiosqlite:///./ci-migrations.db
           JWT_SECRET: ci-verification-secret
         run: PYTHONPATH=. alembic upgrade head
+
+      - name: Verify Alembic migrations (MariaDB, empty schema)
+        env:
+          DATABASE_URL: mysql+asyncmy://root:secret@127.0.0.1:3306/habits
+          JWT_SECRET: ci-verification-secret
+        run: PYTHONPATH=. alembic upgrade head
+
+      # The path production actually takes: it sits at 003, so 004 is the very
+      # next revision it runs, against a database that already holds rows.
+      - name: Verify Alembic migrations (MariaDB, upgrading from 003 with data)
+        env:
+          DATABASE_URL: mysql+asyncmy://root:secret@127.0.0.1:3306/habits_003
+          JWT_SECRET: ci-verification-secret
+        run: |
+          python - <<'PY'
+          import pymysql
+          conn = pymysql.connect(host="127.0.0.1", user="root", password="secret")
+          conn.cursor().execute("CREATE DATABASE IF NOT EXISTS habits_003")
+          conn.close()
+          PY
+          PYTHONPATH=. alembic upgrade 003
+          python - <<'PY'
+          import pymysql
+          conn = pymysql.connect(host="127.0.0.1", user="root", password="secret", database="habits_003")
+          cur = conn.cursor()
+          cur.execute("INSERT INTO habits (id, name, created_at, is_active) VALUES ('h1', 'Read', NOW(), 1)")
+          cur.execute("INSERT INTO habit_logs (id, habit_id, completed_date, synced_at) VALUES ('l1', 'h1', '2026-08-01', NOW())")
+          conn.commit()
+          conn.close()
+          PY
+          PYTHONPATH=. alembic upgrade head
+          python - <<'PY'
+          import pymysql
+          conn = pymysql.connect(host="127.0.0.1", user="root", password="secret", database="habits_003")
+          cur = conn.cursor()
+          cur.execute("SELECT COUNT(*) FROM habits")
+          habits = cur.fetchone()[0]
+          cur.execute("SELECT COUNT(*) FROM habit_logs")
+          logs = cur.fetchone()[0]
+          conn.close()
+          assert (habits, logs) == (1, 1), f"rows lost across the migration: {habits} habits, {logs} logs"
+          print(f"survived migration: {habits} habit, {logs} log")
+          PY
+
+      - name: Compile migrations against the MySQL dialect (offline)
+        env:
+          DATABASE_URL: mysql+pymysql://root:secret@127.0.0.1:3306/habits
+          JWT_SECRET: ci-verification-secret
+        run: PYTHONPATH=. alembic upgrade head --sql > /dev/null
 
       - name: Run pytest with coverage
         run: pytest --cov=app --cov-report=term-missing --cov-fail-under=85

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
           pip install -r requirements.txt
           pip install pytest-cov
 
+      - name: Verify Alembic migrations
+        env:
+          DATABASE_URL: sqlite+aiosqlite:///./ci-migrations.db
+          JWT_SECRET: ci-verification-secret
+        run: PYTHONPATH=. alembic upgrade head
+
       - name: Run pytest with coverage
         run: pytest --cov=app --cov-report=term-missing --cov-fail-under=85
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -68,6 +68,50 @@ cp .env.example .env
 docker compose up -d
 ```
 
+### Legacy data: claiming pre-multi-user habits and logs
+
+**This applies to any deployment that ran before the multi-user migration (004),
+including production, which held real habits and logs at the time of this change.
+Skip it only for a brand-new, empty database.**
+
+Migration `004` adds ownership to `habits` and `habit_logs` and assigns every
+pre-existing row to a sentinel user, `00000000-0000-0000-0000-000000000000`. That
+account cannot be logged into — its password is PBKDF2 of a constant with a salt
+the migration discards — and every API read is scoped to the caller's own user id.
+Until the rows are claimed they are intact in the database and reachable by nobody.
+
+Deploy in this order:
+
+```bash
+# 1. Count what you have, before touching anything.
+docker compose exec db mariadb -uroot -p habits \
+  -e "SELECT (SELECT COUNT(*) FROM habits) AS habits,
+             (SELECT COUNT(*) FROM habit_logs) AS logs;"
+
+# 2. Migrate.
+docker compose exec api sh -c "PYTHONPATH=. alembic upgrade head"
+
+# 3. Register the account that should own the data (mobile app, or curl).
+curl -X POST https://your-host/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"you@example.com","password":"..."}'
+
+# 4. Preview the claim, then run it.
+docker compose exec api python -m app.claim_legacy --email you@example.com --dry-run
+docker compose exec api python -m app.claim_legacy --email you@example.com
+
+# 5. Confirm the counts match step 1 and nothing is left on the sentinel.
+docker compose exec db mariadb -uroot -p habits \
+  -e "SELECT user_id, COUNT(*) FROM habits GROUP BY user_id;
+      SELECT COUNT(*) AS stranded FROM habits
+       WHERE user_id = '00000000-0000-0000-0000-000000000000';"
+```
+
+The claim runs in one transaction and is idempotent — a second run reports zero
+rows. It moves ownership only; it never deletes habits or logs. It refuses an
+email that is not already registered, so a typo fails loudly rather than
+stranding the data under a new empty account.
+
 ### Exposing the API with Cloudflare Tunnels
 
 Cloudflare Tunnels let you securely expose `localhost:8000` to the internet

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 cp .env.example .env
 
 # Run database migrations
-alembic upgrade head
+PYTHONPATH=. alembic upgrade head
 
 # Start the development server
 uvicorn app.main:app --reload --port 8000
@@ -34,6 +34,25 @@ This starts:
 ```bash
 pytest
 ```
+
+### Backend verification in CI / Codex
+
+The authoritative backend verification is the `backend-tests` GitHub Actions
+job. It installs the backend requirements, applies the Alembic migrations, and
+runs the complete pytest suite with the coverage gate.
+
+In the restricted Codex sandbox, the local `aiosqlite` test path can hang while
+its worker thread tries to wake the asyncio event loop. This is a sandbox
+process-isolation limitation, not an application test result. For local
+verification, run the backend suite with unrestricted execution, or rely on
+the required GitHub Actions backend check before merging:
+
+```bash
+pytest --cov=app --cov-report=term-missing --cov-fail-under=85
+```
+
+Do not treat a restricted-sandbox hang as a passing or failing backend result;
+use unrestricted execution or CI verification instead.
 
 ## Deployment
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -8,6 +9,9 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from app.models import Base
 
 config = context.config
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 

--- a/backend/alembic/versions/004_multi_user.py
+++ b/backend/alembic/versions/004_multi_user.py
@@ -34,8 +34,11 @@ def upgrade() -> None:
         op.add_column(table, sa.Column("user_id", sa.String(36), nullable=True))
         op.create_index(f"ix_{table}_user_id", table, ["user_id"])
         op.execute(sa.text(f"UPDATE {table} SET user_id = :legacy_id").bindparams(legacy_id=legacy_id))
+        # batch_alter_table only rewrites the table on SQLite. On MySQL/MariaDB
+        # it degrades to a real MODIFY COLUMN, which refuses to run without the
+        # existing type -- so existing_type is required, not optional.
         with op.batch_alter_table(table) as batch:
-            batch.alter_column("user_id", nullable=False)
+            batch.alter_column("user_id", existing_type=sa.String(36), nullable=False)
     # Replace the old global uniqueness rule with ownership-aware uniqueness.
     with op.batch_alter_table("habit_logs") as batch:
         batch.drop_constraint("uq_habit_date", type_="unique")

--- a/backend/alembic/versions/004_multi_user.py
+++ b/backend/alembic/versions/004_multi_user.py
@@ -1,6 +1,7 @@
 """add users and ownership to habit data"""
 
 from typing import Sequence, Union
+from datetime import datetime, timezone
 import uuid
 import hashlib
 from alembic import op
@@ -27,12 +28,12 @@ def upgrade() -> None:
     salt = uuid.uuid4().hex
     digest = hashlib.pbkdf2_hmac("sha256", b"legacy-disabled", salt.encode(), 240000).hex()
     op.bulk_insert(sa.table("users", sa.column("id", sa.String), sa.column("email", sa.String), sa.column("password_hash", sa.String), sa.column("created_at", sa.DateTime())), [{
-        "id": legacy_id, "email": "legacy@local.invalid", "password_hash": f"pbkdf2_sha256$240000${salt}${digest}", "created_at": sa.func.now()
+        "id": legacy_id, "email": "legacy@local.invalid", "password_hash": f"pbkdf2_sha256$240000${salt}${digest}", "created_at": datetime.now(timezone.utc)
     }])
     for table in ("habits", "habit_logs"):
         op.add_column(table, sa.Column("user_id", sa.String(36), nullable=True))
         op.create_index(f"ix_{table}_user_id", table, ["user_id"])
-        op.execute(sa.text(f"UPDATE {table} SET user_id = :legacy_id"), {"legacy_id": legacy_id})
+        op.execute(sa.text(f"UPDATE {table} SET user_id = :legacy_id").bindparams(legacy_id=legacy_id))
         with op.batch_alter_table(table) as batch:
             batch.alter_column("user_id", nullable=False)
     # Replace the old global uniqueness rule with ownership-aware uniqueness.

--- a/backend/alembic/versions/005_habit_ratings.py
+++ b/backend/alembic/versions/005_habit_ratings.py
@@ -1,0 +1,23 @@
+"""add v1 habit rating fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "005_habit_ratings"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    for name in ("impact", "friction", "keystone", "time_cost"):
+        op.add_column(
+            "habits",
+            sa.Column(name, sa.Integer(), nullable=False, server_default="3"),
+        )
+
+
+def downgrade() -> None:
+    for name in ("time_cost", "keystone", "friction", "impact"):
+        op.drop_column("habits", name)

--- a/backend/alembic/versions/006_usernames.py
+++ b/backend/alembic/versions/006_usernames.py
@@ -11,15 +11,22 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("users", sa.Column("username", sa.String(50), nullable=True))
-    bind = op.get_bind()
-    rows = bind.execute(sa.text("SELECT id FROM users WHERE username IS NULL")).mappings()
-    for row in rows:
-        bind.execute(
-            sa.text("UPDATE users SET username = :username WHERE id = :id"),
-            {"username": f"user_{row['id'][:8]}", "id": row["id"]},
-        )
+    # One set-based UPDATE rather than a row-at-a-time loop over a live cursor:
+    # the loop issued writes on the connection it was still reading from, which
+    # raises "Commands out of sync" on an unbuffered MySQL cursor, and it broke
+    # outright under `alembic upgrade --sql`, where get_bind().execute()
+    # returns None. .concat() compiles to concat() on MySQL and || elsewhere.
+    users = sa.table("users", sa.column("id", sa.String), sa.column("username", sa.String))
+    op.execute(
+        users.update()
+        .where(users.c.username.is_(None))
+        .values(username=sa.literal("user_").concat(sa.func.substr(users.c.id, 1, 8)))
+    )
+    # existing_type is required for the MySQL/MariaDB MODIFY COLUMN this
+    # becomes outside SQLite. The column is added above without a server
+    # default, so there is none to strip here.
     with op.batch_alter_table("users") as batch:
-        batch.alter_column("username", nullable=False, server_default=None)
+        batch.alter_column("username", existing_type=sa.String(50), nullable=False)
         batch.create_unique_constraint("uq_users_username", ["username"])
 
 

--- a/backend/alembic/versions/006_usernames.py
+++ b/backend/alembic/versions/006_usernames.py
@@ -1,0 +1,29 @@
+"""add usernames for leaderboard identity"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "006_usernames"
+down_revision = "005_habit_ratings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("username", sa.String(50), nullable=True))
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id FROM users WHERE username IS NULL")).mappings()
+    for row in rows:
+        bind.execute(
+            sa.text("UPDATE users SET username = :username WHERE id = :id"),
+            {"username": f"user_{row['id'][:8]}", "id": row["id"]},
+        )
+    with op.batch_alter_table("users") as batch:
+        batch.alter_column("username", nullable=False, server_default=None)
+        batch.create_unique_constraint("uq_users_username", ["username"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch:
+        batch.drop_constraint("uq_users_username", type_="unique")
+    op.drop_column("users", "username")

--- a/backend/app/claim_legacy.py
+++ b/backend/app/claim_legacy.py
@@ -1,0 +1,166 @@
+"""Reassign pre-multi-user habit data from the legacy sentinel owner.
+
+Migration 004 adds ``user_id`` to ``habits`` and ``habit_logs`` and stamps every
+pre-existing row with :data:`LEGACY_USER_ID`. It also inserts a matching ``users``
+row whose password is PBKDF2 of a constant with a salt the migration discards, so
+nothing can ever authenticate as it. Every read is scoped by the token's ``sub``,
+which means those rows are intact in the database and reachable by nobody.
+
+This module is the claim step that makes them reachable again. Run it once, after
+migrating and after registering the account that should own the data:
+
+    python -m app.claim_legacy --email you@example.com
+
+It is idempotent: a second run matches zero rows. Use ``--dry-run`` to see the
+counts without writing anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Habit, HabitLog, User
+
+# Kept in sync with alembic/versions/004_multi_user.py, which writes this id.
+LEGACY_USER_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class ClaimError(Exception):
+    """Raised when the claim cannot proceed, e.g. the target account is absent."""
+
+
+@dataclass(frozen=True)
+class ClaimResult:
+    email: str
+    target_user_id: str
+    habits: int
+    habit_logs: int
+    legacy_user_removed: bool
+    dry_run: bool
+
+
+async def _count_legacy(session: AsyncSession, model: type) -> int:
+    stmt = select(func.count()).select_from(model).where(model.user_id == LEGACY_USER_ID)
+    return await session.scalar(stmt) or 0
+
+
+async def claim_legacy_data(
+    session: AsyncSession, email: str, *, dry_run: bool = False
+) -> ClaimResult:
+    """Move every legacy-owned habit and log to the account registered as ``email``.
+
+    The target account must already exist -- this never creates one, so a typo
+    fails loudly instead of stranding the data under a new empty user.
+    """
+    email = email.strip().lower()
+    user = await session.scalar(select(User).where(User.email == email))
+    if user is None:
+        raise ClaimError(
+            f"No account registered as {email!r}. Register it through /auth/register "
+            "first, then re-run this command."
+        )
+    if user.id == LEGACY_USER_ID:
+        raise ClaimError(
+            "Refusing to claim the legacy rows for the legacy user itself; "
+            "pass the email of a real account."
+        )
+
+    habits = await _count_legacy(session, Habit)
+    habit_logs = await _count_legacy(session, HabitLog)
+    legacy_user = await session.scalar(select(User).where(User.id == LEGACY_USER_ID))
+
+    if dry_run:
+        return ClaimResult(
+            email=email,
+            target_user_id=user.id,
+            habits=habits,
+            habit_logs=habit_logs,
+            legacy_user_removed=False,
+            dry_run=True,
+        )
+
+    # One transaction: either ownership moves wholesale or nothing does.
+    await session.execute(
+        update(Habit).where(Habit.user_id == LEGACY_USER_ID).values(user_id=user.id)
+    )
+    await session.execute(
+        update(HabitLog).where(HabitLog.user_id == LEGACY_USER_ID).values(user_id=user.id)
+    )
+    if legacy_user is not None:
+        # Nothing can log in as it and it now owns no rows, so leaving it would
+        # only leave a login-shaped row that no one can use.
+        await session.execute(delete(User).where(User.id == LEGACY_USER_ID))
+    await session.commit()
+
+    return ClaimResult(
+        email=email,
+        target_user_id=user.id,
+        habits=habits,
+        habit_logs=habit_logs,
+        legacy_user_removed=legacy_user is not None,
+        dry_run=False,
+    )
+
+
+def format_result(result: ClaimResult) -> str:
+    lines = [
+        f"legacy user : {LEGACY_USER_ID}",
+        f"target      : {result.email} ({result.target_user_id})",
+        "",
+        f"  habits     : {result.habits:>4} rows -> {result.email}",
+        f"  habit_logs : {result.habit_logs:>4} rows -> {result.email}",
+    ]
+    if result.dry_run:
+        lines += ["", "dry run: nothing was written."]
+    else:
+        lines += [
+            "  users      : legacy row removed"
+            if result.legacy_user_removed
+            else "  users      : no legacy row present",
+            "",
+            "committed.",
+        ]
+    return "\n".join(lines)
+
+
+async def _run(email: str, *, dry_run: bool) -> ClaimResult:
+    # Imported here rather than at module scope: app.database builds an engine
+    # from settings on import, which tests supply for themselves.
+    from app.database import async_session
+
+    async with async_session() as session:
+        return await claim_legacy_data(session, email, dry_run=dry_run)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.claim_legacy",
+        description=(
+            "Reassign habits and logs owned by the legacy sentinel user "
+            "(created by migration 004) to a real registered account."
+        ),
+    )
+    parser.add_argument("--email", required=True, help="email of the account that should own the data")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report the counts without writing"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = asyncio.run(_run(args.email, dry_run=args.dry_run))
+    except ClaimError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(format_result(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,13 @@
 from fastapi import FastAPI
 
-from app.routers import auth, habits, logs
+from app.routers import auth, habits, logs, leaderboards
 
 app = FastAPI(title="Daily Habit Tracker API", version="0.1.0")
 
 app.include_router(auth.router)
 app.include_router(habits.router)
 app.include_router(logs.router)
+app.include_router(leaderboards.router)
 
 
 @app.get("/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date, datetime, timezone
 
-from sqlalchemy import Boolean, Date, DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -22,6 +22,7 @@ class User(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False, default="user")
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
@@ -38,6 +39,10 @@ class Habit(Base):
         DateTime(timezone=True), default=_utcnow
     )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    impact: Mapped[int] = mapped_column(Integer, nullable=False, default=3, server_default="3")
+    friction: Mapped[int] = mapped_column(Integer, nullable=False, default=3, server_default="3")
+    keystone: Mapped[int] = mapped_column(Integer, nullable=False, default=3, server_default="3")
+    time_cost: Mapped[int] = mapped_column(Integer, nullable=False, default=3, server_default="3")
 
     logs: Mapped[list["HabitLog"]] = relationship(back_populates="habit")
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -39,6 +39,11 @@ def _email(value: str) -> str:
     return value
 
 
+def _username(email: str) -> str:
+    value = email.split("@", 1)[0].strip()
+    return value[:50] or "user"
+
+
 def _token(user_id: str) -> TokenResponse:
     expire = datetime.now(timezone.utc) + timedelta(hours=settings.jwt_expiry_hours)
     return TokenResponse(access_token=jwt.encode({"sub": user_id, "exp": expire}, settings.jwt_secret, algorithm=settings.jwt_algorithm))
@@ -50,7 +55,13 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)) ->
     existing = await db.scalar(select(User).where(User.email == email))
     if existing:
         raise HTTPException(status_code=409, detail="Email already registered")
-    user = User(email=email, password_hash=_hash_password(body.password))
+    username = (body.username or _username(email)).strip()
+    if not username:
+        raise HTTPException(status_code=422, detail="Username must not be blank")
+    username_exists = await db.scalar(select(User).where(User.username == username))
+    if username_exists:
+        raise HTTPException(status_code=409, detail="Username already registered")
+    user = User(email=email, username=username, password_hash=_hash_password(body.password))
     db.add(user)
     await db.commit()
     return _token(user.id)

--- a/backend/app/routers/habits.py
+++ b/backend/app/routers/habits.py
@@ -1,12 +1,12 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.middleware.auth import require_token, user_id_from_token
-from app.models import Habit
+from app.models import Habit, HabitLog
 from app.schemas import (
     HabitCreate,
     HabitRead,
@@ -14,9 +14,27 @@ from app.schemas import (
     HabitSyncResponse,
     HabitSyncPullResponse,
     HabitUpdate,
+    HabitMetricsRead,
+    habit_score,
 )
 
 router = APIRouter(prefix="/habits", tags=["habits"])
+
+
+def _read_habit(habit: Habit) -> HabitRead:
+    return HabitRead(
+        id=habit.id,
+        name=habit.name,
+        created_at=habit.created_at,
+        is_active=habit.is_active,
+        impact=habit.impact,
+        friction=habit.friction,
+        keystone=habit.keystone,
+        time_cost=habit.time_cost,
+        score=habit_score(
+            habit.impact, habit.friction, habit.keystone, habit.time_cost,
+        ),
+    )
 
 
 @router.get("/", response_model=list[HabitRead])
@@ -29,22 +47,25 @@ async def list_habits(
     if active is not None:
         stmt = stmt.where(Habit.is_active == active)
     result = await db.execute(stmt)
-    return result.scalars().all()
+    return [_read_habit(habit) for habit in result.scalars().all()]
 
 
 @router.post("/", response_model=HabitRead, status_code=status.HTTP_201_CREATED)
 async def create_habit(body: HabitCreate, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
-    habit = Habit(name=body.name, user_id=user_id_from_token(token))
+    habit = Habit(
+        name=body.name, user_id=user_id_from_token(token), impact=body.impact,
+        friction=body.friction, keystone=body.keystone, time_cost=body.time_cost,
+    )
     db.add(habit)
     await db.commit()
     await db.refresh(habit)
-    return habit
+    return _read_habit(habit)
 
 
 @router.get("/sync", response_model=HabitSyncPullResponse)
 async def pull_habits(token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
     result = await db.scalars(select(Habit).where(Habit.user_id == user_id_from_token(token)).order_by(Habit.created_at))
-    return HabitSyncPullResponse(habits=list(result))
+    return HabitSyncPullResponse(habits=[_read_habit(habit) for habit in result])
 
 
 @router.patch("/{habit_id}", response_model=HabitRead)
@@ -58,7 +79,7 @@ async def update_habit(
         setattr(habit, field, value)
     await db.commit()
     await db.refresh(habit)
-    return habit
+    return _read_habit(habit)
 
 
 @router.post("/sync", response_model=HabitSyncResponse)
@@ -78,6 +99,10 @@ async def sync_habits(body: HabitSyncRequest, token: dict = Depends(require_toke
         if existing:
             existing.name = entry.name
             existing.is_active = entry.is_active
+            existing.impact = entry.impact
+            existing.friction = entry.friction
+            existing.keystone = entry.keystone
+            existing.time_cost = entry.time_cost
         else:
             db.add(
                 Habit(
@@ -86,8 +111,76 @@ async def sync_habits(body: HabitSyncRequest, token: dict = Depends(require_toke
                     created_at=created_at,
                     is_active=entry.is_active,
                     user_id=user_id,
+                    impact=entry.impact,
+                    friction=entry.friction,
+                    keystone=entry.keystone,
+                    time_cost=entry.time_cost,
                 )
             )
         synced_ids.append(entry.id)
     await db.commit()
     return HabitSyncResponse(synced_ids=synced_ids)
+
+
+@router.get("/{habit_id}/metrics", response_model=HabitMetricsRead)
+async def get_habit_metrics(
+    habit_id: str,
+    start: date = Query(...),
+    end: date = Query(...),
+    as_of: date = Query(...),
+    token: dict = Depends(require_token),
+    db: AsyncSession = Depends(get_db),
+):
+    if start > end:
+        raise HTTPException(status_code=422, detail="start must not be after end")
+
+    user_id = user_id_from_token(token)
+    habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id))
+    if not habit:
+        raise HTTPException(status_code=404, detail="Habit not found")
+
+    # SQLite may return a naive value for a timezone-aware column. Stored
+    # habit timestamps are UTC by contract, so interpret a naive value as UTC
+    # rather than allowing the caller's local timezone to affect the date.
+    created_at = habit.created_at
+    if created_at.tzinfo is None:
+        creation_date = created_at.date()
+    else:
+        creation_date = created_at.astimezone(timezone.utc).date()
+
+    completed_days = await db.scalar(
+        select(func.count(func.distinct(HabitLog.completed_date))).where(
+            HabitLog.habit_id == habit_id,
+            HabitLog.user_id == user_id,
+            HabitLog.completed_date >= creation_date,
+            HabitLog.completed_date >= start,
+            HabitLog.completed_date <= end,
+            HabitLog.deleted_at.is_(None),
+        )
+    )
+    eligible_days = (end - start).days + 1
+    completed_days = int(completed_days or 0)
+    completion_rate = (200 * completed_days + eligible_days) // (2 * eligible_days)
+
+    streak_dates = await db.scalars(select(HabitLog.completed_date).where(
+        HabitLog.habit_id == habit_id,
+        HabitLog.user_id == user_id,
+        HabitLog.completed_date >= creation_date,
+        HabitLog.completed_date <= as_of,
+        HabitLog.deleted_at.is_(None),
+    ))
+    date_set = set(streak_dates)
+    current = as_of if as_of in date_set else as_of - timedelta(days=1)
+    current_streak = 0
+    while current in date_set:
+        current_streak += 1
+        current -= timedelta(days=1)
+
+    return HabitMetricsRead(
+        habit_id=habit.id,
+        score=habit_score(habit.impact, habit.friction, habit.keystone, habit.time_cost),
+        completed_days=completed_days,
+        eligible_days=eligible_days,
+        completion_rate=completion_rate,
+        current_streak=current_streak,
+    )

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -1,0 +1,145 @@
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.middleware.auth import require_token, user_id_from_token
+from app.models import Habit, HabitLog, User
+from app.schemas import (
+    HeadToHeadResponse,
+    LeaderboardMeta,
+    LeaderboardRanking,
+    LeaderboardTieBreakers,
+    habit_score,
+)
+
+router = APIRouter(prefix="/v1/leaderboards", tags=["leaderboards"])
+
+
+def _epoch_datetime(value: int) -> datetime:
+    # JavaScript clients send epoch milliseconds; accepting seconds as well
+    # keeps the endpoint friendly to non-JS clients without changing meaning.
+    seconds = value / 1000 if value >= 100_000_000_000 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail="Invalid epoch boundary") from exc
+
+
+def _streak_days(completed: set[date], as_of: date) -> int:
+    current = as_of if as_of in completed else as_of - timedelta(days=1)
+    streak = 0
+    while current in completed:
+        streak += 1
+        current -= timedelta(days=1)
+    return streak
+
+
+@router.get("/head-to-head", response_model=HeadToHeadResponse)
+async def head_to_head(
+    opponent_id: str = Query(..., min_length=1),
+    start: int = Query(..., description="UTC epoch boundary in milliseconds"),
+    end: int = Query(..., description="UTC epoch boundary in milliseconds"),
+    token: dict = Depends(require_token),
+    db: AsyncSession = Depends(get_db),
+) -> HeadToHeadResponse:
+    current_user_id = user_id_from_token(token)
+    if opponent_id == current_user_id:
+        raise HTTPException(status_code=422, detail="opponent_id must identify another user")
+
+    period_start = _epoch_datetime(start)
+    period_end = _epoch_datetime(end)
+    if period_start > period_end:
+        raise HTTPException(status_code=422, detail="start must not be after end")
+
+    users = list(await db.scalars(select(User).where(User.id.in_([current_user_id, opponent_id]))))
+    users_by_id = {user.id: user for user in users}
+    if opponent_id not in users_by_id:
+        raise HTTPException(status_code=404, detail="Opponent not found")
+    if current_user_id not in users_by_id:
+        raise HTTPException(status_code=401, detail="Current user not found")
+
+    start_date = period_start.date()
+    end_date = period_end.date()
+    day_count = (end_date - start_date).days + 1
+    user_ids = [current_user_id, opponent_id]
+    rows = await db.execute(
+        select(HabitLog, Habit)
+        .join(Habit, Habit.id == HabitLog.habit_id)
+        .where(
+            HabitLog.user_id.in_(user_ids),
+            Habit.user_id == HabitLog.user_id,
+            HabitLog.completed_date >= start_date,
+            HabitLog.completed_date <= end_date,
+            HabitLog.deleted_at.is_(None),
+        )
+    )
+    habits = list(await db.scalars(select(Habit).where(Habit.user_id.in_(user_ids))))
+    habit_counts = {user_id: 0 for user_id in user_ids}
+    for habit in habits:
+        habit_counts[habit.user_id] += 1
+
+    points = {user_id: 0 for user_id in user_ids}
+    completed_pairs: dict[str, set[tuple[str, date]]] = {user_id: set() for user_id in user_ids}
+    completed_dates: dict[str, set[date]] = {user_id: set() for user_id in user_ids}
+    last_sync: dict[str, datetime | None] = {user_id: None for user_id in user_ids}
+    for log, habit in rows:
+        points[log.user_id] += habit_score(habit.impact, habit.friction, habit.keystone, habit.time_cost)
+        completed_pairs[log.user_id].add((log.habit_id, log.completed_date))
+        completed_dates[log.user_id].add(log.completed_date)
+        if last_sync[log.user_id] is None or log.synced_at > last_sync[log.user_id]:
+            last_sync[log.user_id] = log.synced_at
+
+    updated_at = max((sync for sync in last_sync.values() if sync is not None), default=datetime.now(timezone.utc))
+    rankings_data = []
+    for user_id in user_ids:
+        eligible_days = habit_counts[user_id] * day_count
+        completion_rate = (100 * len(completed_pairs[user_id]) / eligible_days) if eligible_days else 0.0
+        rankings_data.append({
+            "user_id": user_id,
+            "display_name": users_by_id[user_id].username,
+            "is_current_user": user_id == current_user_id,
+            "score": points[user_id],
+            "streak_days": _streak_days(completed_dates[user_id], end_date),
+            "completion_rate_pct": round(completion_rate, 2),
+            "last_authoritative_sync": last_sync[user_id],
+        })
+
+    rankings_data.sort(key=lambda item: (
+        -item["score"],
+        -item["streak_days"],
+        -item["completion_rate_pct"],
+        item["last_authoritative_sync"] or datetime.max.replace(tzinfo=timezone.utc),
+        item["user_id"],
+    ))
+    rankings = [
+        LeaderboardRanking(
+            rank=index,
+            user_id=item["user_id"],
+            display_name=item["display_name"],
+            is_current_user=item["is_current_user"],
+            score=item["score"],
+            tie_breakers=LeaderboardTieBreakers(
+                streak_days=item["streak_days"],
+                completion_rate_pct=item["completion_rate_pct"],
+                last_authoritative_sync=item["last_authoritative_sync"],
+            ),
+        )
+        for index, item in enumerate(rankings_data, start=1)
+    ]
+    status = "active" if period_start <= datetime.now(timezone.utc) <= period_end else (
+        "upcoming" if datetime.now(timezone.utc) < period_start else "completed"
+    )
+    return HeadToHeadResponse(
+        competition_id=f"head-to-head_{start}_{end}",
+        meta=LeaderboardMeta(
+            status=status,
+            timezone="UTC",
+            period_start=period_start,
+            period_end=period_end,
+            updated_at=updated_at,
+        ),
+        rankings=rankings,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,12 +1,25 @@
 from datetime import date, datetime
+from typing import Annotated
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, StrictInt, field_validator
 
 
 # ── Habits ──────────────────────────────────────────────
 
+Rating = Annotated[StrictInt, Field(ge=1, le=5)]
+
+
+def habit_score(impact: int, friction: int, keystone: int, time_cost: int) -> int:
+    """Return the contract score using exact integer half-up rounding."""
+    raw_minus_minimum = impact + (6 - friction) + keystone + (6 - time_cost) - 4
+    return (100 * raw_minus_minimum * 2 + 16) // (16 * 2)
+
 class HabitCreate(BaseModel):
     name: str = Field(..., max_length=50)
+    impact: Rating = 3
+    friction: Rating = 3
+    keystone: Rating = 3
+    time_cost: Rating = 3
 
     @field_validator("name")
     @classmethod
@@ -20,6 +33,10 @@ class HabitCreate(BaseModel):
 class HabitUpdate(BaseModel):
     name: str | None = Field(None, max_length=50)
     is_active: bool | None = None
+    impact: Rating | None = None
+    friction: Rating | None = None
+    keystone: Rating | None = None
+    time_cost: Rating | None = None
 
     @field_validator("name")
     @classmethod
@@ -37,6 +54,11 @@ class HabitRead(BaseModel):
     name: str
     created_at: datetime
     is_active: bool
+    impact: int
+    friction: int
+    keystone: int
+    time_cost: int
+    score: int
 
     model_config = {"from_attributes": True}
 
@@ -49,6 +71,10 @@ class HabitSyncEntry(BaseModel):
     # request time so creation order is consistent across devices.
     created_at_ms: int
     is_active: bool = True
+    impact: Rating = 3
+    friction: Rating = 3
+    keystone: Rating = 3
+    time_cost: Rating = 3
 
     @field_validator("name")
     @classmethod
@@ -71,6 +97,15 @@ class HabitSyncResponse(BaseModel):
 
 class HabitSyncPullResponse(BaseModel):
     habits: list[HabitRead]
+
+
+class HabitMetricsRead(BaseModel):
+    habit_id: str
+    score: int
+    completed_days: int
+    eligible_days: int
+    completion_rate: int
+    current_streak: int
 
 
 # ── Habit Logs ──────────────────────────────────────────
@@ -118,8 +153,38 @@ class TokenRequest(BaseModel):
 class RegisterRequest(BaseModel):
     email: str
     password: str = Field(..., min_length=8)
+    username: str | None = Field(None, min_length=1, max_length=50)
 
 
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+
+class LeaderboardTieBreakers(BaseModel):
+    streak_days: int
+    completion_rate_pct: float
+    last_authoritative_sync: datetime | None
+
+
+class LeaderboardRanking(BaseModel):
+    rank: int
+    user_id: str
+    display_name: str
+    is_current_user: bool
+    score: int
+    tie_breakers: LeaderboardTieBreakers
+
+
+class LeaderboardMeta(BaseModel):
+    status: str
+    timezone: str
+    period_start: datetime
+    period_end: datetime
+    updated_at: datetime
+
+
+class HeadToHeadResponse(BaseModel):
+    competition_id: str
+    meta: LeaderboardMeta
+    rankings: list[LeaderboardRanking]

--- a/backend/tests/test_claim_legacy.py
+++ b/backend/tests/test_claim_legacy.py
@@ -1,0 +1,298 @@
+"""The migrate-then-claim path for pre-multi-user data (issue #119).
+
+The rest of the suite builds its schema with ``Base.metadata.create_all``, so
+migration 004 is never exercised there. These tests drive Alembic for real
+against a file-backed SQLite database, because the whole defect is what 004
+does to rows that already exist.
+
+Two constraints shape the harness:
+
+* the database must be **file-backed** -- with ``sqlite+aiosqlite://`` the
+  Alembic engine and the assertion engine would each get their own private
+  in-memory database;
+* the tests must be **sync** -- ``alembic/env.py`` calls ``asyncio.run``, which
+  raises inside a running event loop, so an ``async def`` test would have to
+  hop threads to drive it.
+"""
+
+import asyncio
+import pathlib
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.claim_legacy import LEGACY_USER_ID, ClaimError, claim_legacy_data, format_result
+from app.models import User
+from app.routers.auth import _hash_password
+
+BACKEND_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+PRE_004_HABITS = [("h1", "Read"), ("h2", "Run"), ("h3", "Stretch")]
+PRE_004_LOGS = [
+    ("l1", "h1", "2026-08-01"),
+    ("l2", "h1", "2026-08-02"),
+    ("l3", "h2", "2026-08-01"),
+]
+
+
+def _alembic_config(db_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> Config:
+    url = f"sqlite+aiosqlite:///{db_path}"
+    # env.py reads DATABASE_URL from the process environment on each run.
+    monkeypatch.setenv("DATABASE_URL", url)
+    cfg = Config(str(BACKEND_DIR / "alembic.ini"))
+    cfg.set_main_option("script_location", str(BACKEND_DIR / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+def _seed_pre_004(db_path: pathlib.Path) -> None:
+    """Insert habits and logs in the shape they have at revision 003."""
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO habits (id, name, created_at, is_active) VALUES (?, ?, ?, 1)",
+        [(hid, name, "2026-07-01 00:00:00") for hid, name in PRE_004_HABITS],
+    )
+    conn.executemany(
+        "INSERT INTO habit_logs (id, habit_id, completed_date, synced_at) VALUES (?, ?, ?, ?)",
+        [(lid, hid, day, "2026-07-01 00:00:00") for lid, hid, day in PRE_004_LOGS],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _owners(db_path: pathlib.Path, table: str) -> dict[str, int]:
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(f"SELECT user_id, COUNT(*) FROM {table} GROUP BY user_id").fetchall()
+    conn.close()
+    return {owner: count for owner, count in rows}
+
+
+@pytest.fixture
+def migrated_db(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """A database seeded at 003, then migrated to head -- production's exact path."""
+    db_path = tmp_path / "habits.db"
+    cfg = _alembic_config(db_path, monkeypatch)
+    command.upgrade(cfg, "003")
+    _seed_pre_004(db_path)
+    command.upgrade(cfg, "head")
+    return db_path
+
+
+def _register(db_path: pathlib.Path, email: str) -> str:
+    """Create a real account the way /auth/register would, returning its id."""
+
+    async def _create() -> str:
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as session:
+            user = User(
+                email=email,
+                username=email.split("@")[0],
+                password_hash=_hash_password("correct horse"),
+                created_at=datetime.now(timezone.utc),
+            )
+            session.add(user)
+            await session.commit()
+            user_id = user.id
+        await engine.dispose()
+        return user_id
+
+    return asyncio.run(_create())
+
+
+def _claim(db_path: pathlib.Path, email: str, *, dry_run: bool = False):
+    async def _run():
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with factory() as session:
+            result = await claim_legacy_data(session, email, dry_run=dry_run)
+        await engine.dispose()
+        return result
+
+    return asyncio.run(_run())
+
+
+def test_migration_004_strands_existing_rows_on_the_legacy_user(migrated_db):
+    """The defect itself: after migrating, every row belongs to an unusable account."""
+    assert _owners(migrated_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}
+    assert _owners(migrated_db, "habit_logs") == {LEGACY_USER_ID: len(PRE_004_LOGS)}
+
+
+def test_claim_moves_every_legacy_row_to_the_registered_account(migrated_db):
+    user_id = _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "owner@example.com")
+
+    assert result.habits == len(PRE_004_HABITS)
+    assert result.habit_logs == len(PRE_004_LOGS)
+    # Row counts survive: the claim moves ownership, it never deletes data.
+    assert _owners(migrated_db, "habits") == {user_id: len(PRE_004_HABITS)}
+    assert _owners(migrated_db, "habit_logs") == {user_id: len(PRE_004_LOGS)}
+
+
+def test_claim_removes_the_legacy_user_row(migrated_db):
+    _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "owner@example.com")
+
+    assert result.legacy_user_removed is True
+    conn = sqlite3.connect(migrated_db)
+    remaining = conn.execute(
+        "SELECT COUNT(*) FROM users WHERE id = ?", (LEGACY_USER_ID,)
+    ).fetchone()[0]
+    conn.close()
+    assert remaining == 0
+
+
+def test_claim_is_idempotent(migrated_db):
+    user_id = _register(migrated_db, "owner@example.com")
+    _claim(migrated_db, "owner@example.com")
+
+    second = _claim(migrated_db, "owner@example.com")
+
+    assert (second.habits, second.habit_logs) == (0, 0)
+    assert second.legacy_user_removed is False
+    assert _owners(migrated_db, "habits") == {user_id: len(PRE_004_HABITS)}
+
+
+def test_dry_run_reports_counts_without_writing(migrated_db):
+    _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "owner@example.com", dry_run=True)
+
+    assert (result.habits, result.habit_logs) == (len(PRE_004_HABITS), len(PRE_004_LOGS))
+    assert result.dry_run is True
+    assert "dry run" in format_result(result)
+    # Nothing moved.
+    assert _owners(migrated_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}
+
+
+def test_claim_refuses_an_unregistered_email(migrated_db):
+    with pytest.raises(ClaimError, match="No account registered"):
+        _claim(migrated_db, "nobody@example.com")
+
+    # The data is left exactly as it was, not stranded somewhere new.
+    assert _owners(migrated_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}
+
+
+def test_claim_refuses_the_legacy_user_itself(migrated_db):
+    with pytest.raises(ClaimError, match="Refusing to claim"):
+        _claim(migrated_db, "legacy@local.invalid")
+
+
+def test_claim_normalises_the_email_argument(migrated_db):
+    user_id = _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "  Owner@Example.COM  ")
+
+    assert result.target_user_id == user_id
+
+
+def test_format_result_reports_what_moved(migrated_db):
+    _register(migrated_db, "owner@example.com")
+
+    rendered = format_result(_claim(migrated_db, "owner@example.com"))
+
+    assert LEGACY_USER_ID in rendered
+    assert "owner@example.com" in rendered
+    assert "legacy row removed" in rendered
+    assert "committed." in rendered
+
+
+def test_sentinel_id_matches_the_one_migration_004_writes():
+    """Guards against the constant and the migration drifting apart."""
+    source = (BACKEND_DIR / "alembic" / "versions" / "004_multi_user.py").read_text()
+    assert f'"{LEGACY_USER_ID}"' in source
+
+
+def test_claimed_rows_are_reachable_through_the_api(migrated_db, monkeypatch):
+    """The point of the whole exercise: GET /habits returns the rescued rows."""
+    from datetime import timedelta
+
+    from fastapi.testclient import TestClient
+    from jose import jwt
+
+    from app.config import settings
+    from app.database import get_db
+    from app.main import app
+
+    user_id = _register(migrated_db, "owner@example.com")
+    _claim(migrated_db, "owner@example.com")
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{migrated_db}")
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _override_get_db():
+        async with factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    token = jwt.encode(
+        {"sub": user_id, "exp": datetime.now(timezone.utc) + timedelta(hours=1)},
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+    )
+    try:
+        with TestClient(app) as client:
+            resp = client.get("/habits", headers={"Authorization": f"Bearer {token}"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert sorted(h["name"] for h in resp.json()) == sorted(n for _, n in PRE_004_HABITS)
+
+
+@pytest.fixture
+def cli_db(migrated_db, monkeypatch):
+    """Point the CLI's session factory at the test database.
+
+    ``app.database`` builds its engine at import time from the settings conftest
+    loads, so setting DATABASE_URL alone would not redirect it.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{migrated_db}")
+    monkeypatch.setattr(
+        "app.database.async_session",
+        async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False),
+    )
+    return migrated_db
+
+
+def test_cli_main_reports_a_missing_account(cli_db, capsys):
+    from app import claim_legacy
+
+    exit_code = claim_legacy.main(["--email", "nobody@example.com"])
+
+    assert exit_code == 1
+    assert "No account registered" in capsys.readouterr().err
+    # A typo must not disturb the data it failed to claim.
+    assert _owners(cli_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}
+
+
+def test_cli_main_claims_and_prints_a_summary(cli_db, capsys):
+    from app import claim_legacy
+
+    _register(cli_db, "owner@example.com")
+
+    exit_code = claim_legacy.main(["--email", "owner@example.com"])
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "committed." in out
+    assert f"{len(PRE_004_HABITS)} rows" in out
+    assert _owners(cli_db, "habits") != {LEGACY_USER_ID: len(PRE_004_HABITS)}
+
+
+def test_cli_dry_run_writes_nothing(cli_db, capsys):
+    from app import claim_legacy
+
+    _register(cli_db, "owner@example.com")
+
+    exit_code = claim_legacy.main(["--email", "owner@example.com", "--dry-run"])
+
+    assert exit_code == 0
+    assert "dry run" in capsys.readouterr().out
+    assert _owners(cli_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}

--- a/backend/tests/test_habit_metrics.py
+++ b/backend/tests/test_habit_metrics.py
@@ -1,0 +1,63 @@
+import pytest
+from httpx import AsyncClient
+
+
+async def create_habit(client: AsyncClient, headers: dict) -> str:
+    response = await client.post(
+        "/habits/",
+        json={"name": "Metrics", "impact": 4, "friction": 2, "keystone": 3, "time_cost": 4},
+        headers=headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["score"] == 56
+    return data["id"]
+
+
+@pytest.mark.asyncio
+async def test_metrics_counts_inclusive_days_and_yesterday_streak(
+    client: AsyncClient, auth_header: dict
+):
+    habit_id = await create_habit(client, auth_header)
+    response = await client.post(
+        "/logs/sync",
+        json={"logs": [
+            {"habit_id": habit_id, "completed_date": "2099-08-25"},
+            {"habit_id": habit_id, "completed_date": "2099-08-26"},
+        ]},
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+
+    response = await client.get(
+        f"/habits/{habit_id}/metrics?start=2099-08-25&end=2099-08-27&as_of=2099-08-27",
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "habit_id": habit_id,
+        "score": 56,
+        "completed_days": 2,
+        "eligible_days": 3,
+        "completion_rate": 67,
+        "current_streak": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_metrics_rejects_reversed_range_and_invalid_rating_types(
+    client: AsyncClient, auth_header: dict
+):
+    response = await client.post(
+        "/habits/",
+        json={"name": "Bad", "impact": "3"},
+        headers=auth_header,
+    )
+    assert response.status_code == 422
+
+    habit_id = await create_habit(client, auth_header)
+    response = await client.get(
+        f"/habits/{habit_id}/metrics?start=2099-08-28&end=2099-08-27&as_of=2099-08-27",
+        headers=auth_header,
+    )
+    assert response.status_code == 422

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -1,0 +1,57 @@
+from datetime import date, datetime, timezone
+
+import pytest
+
+from app.models import Habit, HabitLog, User
+
+
+def epoch_ms(value: str) -> int:
+    return int(datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+@pytest.mark.asyncio
+async def test_head_to_head_aggregates_habit_scores_and_marks_current_user(client, db_session, auth_header):
+    db_session.add_all([
+        User(id="user", email="me@example.com", username="Me", password_hash="x"),
+        User(id="opponent", email="them@example.com", username="Them", password_hash="x"),
+    ])
+    db_session.add_all([
+        Habit(id="my-high", user_id="user", name="High", impact=5, friction=1, keystone=5, time_cost=1),
+        Habit(id="their-neutral", user_id="opponent", name="Neutral", impact=3, friction=3, keystone=3, time_cost=3),
+    ])
+    db_session.add_all([
+        HabitLog(id="my-log-1", user_id="user", habit_id="my-high", completed_date=date(2026, 8, 30)),
+        HabitLog(id="my-log-2", user_id="user", habit_id="my-high", completed_date=date(2026, 8, 31)),
+        HabitLog(id="their-log", user_id="opponent", habit_id="their-neutral", completed_date=date(2026, 8, 10)),
+    ])
+    await db_session.commit()
+
+    response = await client.get(
+        "/v1/leaderboards/head-to-head",
+        params={
+            "opponent_id": "opponent",
+            "start": epoch_ms("2026-08-01T00:00:00"),
+            "end": epoch_ms("2026-08-31T23:59:59.999"),
+        },
+        headers=auth_header,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["meta"]["timezone"] == "UTC"
+    assert body["rankings"][0]["user_id"] == "user"
+    assert body["rankings"][0]["display_name"] == "Me"
+    assert body["rankings"][0]["is_current_user"] is True
+    assert body["rankings"][0]["score"] == 200
+    assert body["rankings"][0]["tie_breakers"]["streak_days"] == 2
+    assert body["rankings"][1]["score"] == 50
+
+
+@pytest.mark.asyncio
+async def test_head_to_head_requires_distinct_existing_opponent(client, auth_header):
+    response = await client.get(
+        "/v1/leaderboards/head-to-head",
+        params={"opponent_id": "user", "start": 1, "end": 2},
+        headers=auth_header,
+    )
+    assert response.status_code == 422

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -1,0 +1,16 @@
+from app.schemas import habit_score
+
+
+def test_score_contract_examples():
+    assert habit_score(5, 1, 5, 1) == 100
+    assert habit_score(3, 3, 3, 3) == 50
+    assert habit_score(1, 5, 1, 5) == 0
+    assert habit_score(4, 2, 3, 4) == 56
+
+
+def test_score_directionality():
+    neutral = habit_score(3, 3, 3, 3)
+    assert habit_score(4, 3, 3, 3) > neutral
+    assert habit_score(3, 3, 4, 3) > neutral
+    assert habit_score(3, 4, 3, 3) < neutral
+    assert habit_score(3, 3, 3, 4) < neutral

--- a/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
+++ b/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
@@ -1,0 +1,237 @@
+# Issue #105 — Habit weights and scoring contract
+
+Status: proposed for implementation
+
+This document settles the data and metric semantics before UI or API coding
+starts. It is the v1 contract for habit weights, score, completion rate, and
+streaks.
+
+## Goals
+
+- Let every habit be compared using the same four user-editable dimensions.
+- Keep score behavior deterministic across Android, backend, and future
+  clients.
+- Preserve useful offline behavior without allowing a client to define the
+  authoritative result.
+- Make completion and streak numbers reproducible from the stored logs.
+
+## Decisions
+
+### 1. Storage ownership and fields
+
+The four values are properties of a habit, not of a completion log. They are
+stored on the existing `habits` record in both stores:
+
+| Field | Type | Range | Meaning | Direction |
+| --- | --- | --- | --- | --- |
+| `impact` | integer | 1–5 | Benefit when this habit is completed | higher is better |
+| `friction` | integer | 1–5 | How difficult it is to complete | lower is better |
+| `keystone` | integer | 1–5 | How much this habit enables other habits | higher is better |
+| `time_cost` | integer | 1–5 | Time required for one completion | lower is better |
+
+The API uses snake_case (`time_cost`); the React Native model uses the same
+database column names and idiomatic properties (`timeCost` is acceptable in
+TypeScript code). Values are server-persisted habit data and therefore are
+included in habit create, update, push-sync, and pull-sync payloads. They are
+not device-local preferences like notification settings, and they are not
+copied onto `habit_logs`.
+
+Existing habits are migrated with the neutral value `3` for all four fields.
+New habits also default all four fields to `3`. A value is never null in the
+v1 schema; “missing” input means “use 3” at the API boundary, while persisted
+rows always contain an explicit integer. Values outside 1–5 are rejected with
+HTTP 422 (and rejected by the client validation layer).
+The API accepts only strict JSON integers for these fields: booleans, numeric
+strings, and fractional values are rejected rather than coerced. Omitted
+fields still default to `3` during the compatibility window.
+
+The server remains the source of truth for synced values. As with the current
+local-first habit flow, an offline client may hold an unsynced edit; conflict
+handling follows the existing habit sync behavior and is outside this scoring
+contract.
+
+### 2. Score formula
+
+The score is an integer from 0 through 100. All four dimensions have equal
+weight. Friction and time cost are inverted because lower values are better.
+
+```text
+impact_component   = impact
+friction_component = 6 - friction
+keystone_component = keystone
+time_component     = 6 - time_cost
+
+raw = impact_component + friction_component + keystone_component + time_component
+score = round(100 * (raw - 4) / 16)
+```
+
+The `raw` range is 4–20, so the normalization maps the worst possible habit
+to 0 and the best possible habit to 100. `round` means mathematical
+half-up rounding; implementations must not use locale-dependent formatting
+or floating-point display values. A score is recalculated whenever any input
+rating changes.
+
+Examples:
+
+- `(impact=5, friction=1, keystone=5, time_cost=1)` → `100`.
+- `(3, 3, 3, 3)` → `50`.
+- `(impact=4, friction=2, keystone=3, time_cost=4)` → `56`.
+
+The score is derived data and is not stored as an independent column in v1.
+This prevents stale scores after edits and keeps migration/backfill simple.
+
+### 3. Authority and calculation location
+
+Scoring is server-authoritative. The server validates the four ratings and
+ computes the score in every habit read/detail response and in ranking or
+ metrics responses. The score is therefore available to lists and
+ leaderboards without an extra request, while date-dependent metrics remain
+ behind the metrics endpoint. Clients must treat a server-returned score as authoritative
+after synchronization.
+
+For responsive offline UI, the Android client may calculate the same formula
+locally as a provisional value. The formula and rounding behavior must be
+covered by shared-equivalent client and backend tests. The client must not
+send a score as writable input, and the server must ignore/reject a client
+supplied score.
+
+Completion and streak metrics are also derived from logs. The client may
+compute them while offline for display, but a server metrics response is
+authoritative once available.
+
+### 4. Completion rate
+
+Completion rate is a percentage for an explicit inclusive calendar-date
+range `[start, end]`:
+
+```text
+eligible_days = number of calendar days from start through end
+completed_days = count of distinct, non-deleted logs for this habit in the range
+completion_rate = round(100 * completed_days / eligible_days)
+```
+
+`start` must not be after `end`. The range is interpreted in the user/device
+calendar timezone as `YYYY-MM-DD`; no UTC conversion is permitted. A day is
+completed at most once because `(habit_id, completed_date)` is unique.
+
+For a default lifetime metric, `start` is the habit creation date converted
+from the stored UTC `created_at` timestamp using UTC, and `end` is the
+requested as-of date (normally today). For a standard dashboard
+window, the caller must pass the window explicitly; v1 does not silently
+change the denominator based on active/inactive status. The denominator
+includes today even when today is not yet completed. An empty range is invalid
+rather than returning a fabricated percentage.
+
+Logs before creation, logs marked deleted, and logs belonging to another user
+do not count. Historical logs remain valid after a habit is deactivated.
+
+### 5. Streak
+
+Streak is the number of consecutive completed calendar days ending at the
+latest completed day at or before the as-of date. It is calculated from
+distinct, non-deleted logs and has no maximum in the contract.
+
+To preserve the app’s existing behavior, if the as-of date is not completed,
+the calculation starts at the previous calendar day. Therefore a user who has
+completed yesterday but not yet today still sees the active streak; a missed
+day breaks it. If neither the as-of date nor the previous date is completed,
+the streak is `0`.
+
+Examples as of Friday:
+
+- Wed/Thu/Fri completed → `3`.
+- Tue/Wed/Thu completed, Fri pending → `3`.
+- Tue/Thu/Fri completed → `2` (Thu–Fri; Wednesday is the break).
+- No completed day at or immediately before Friday → `0`.
+
+The as-of date is a local calendar date, not a timestamp. Inactive status does
+not erase or truncate a streak; the caller can choose whether to request
+metrics for an inactive habit.
+
+## Data flow and interface requirements
+
+```text
+user edits ratings
+        │
+        ├─ local habits row (unsynced) ──> provisional client score
+        │
+        └─ habit create/update sync ──> server validates + persists ratings
+                                           │
+                                           └─ server derives score/metrics
+                                              in read/metrics responses
+```
+
+Habit create/update and sync contracts must add the four ratings as optional
+request fields during the compatibility window, defaulting omitted fields to
+`3`; responses must always return all four ratings. Once all clients are
+migrated, requests may become required for newly created records while update
+requests remain partial. The metrics endpoint must accept
+`habit_id`, `start`, `end`, and `as_of` as explicit local-date parameters and
+return the score, completion rate, completed-day count, eligible-day count,
+and current streak.
+
+`as_of` is independent of `[start, end]`; it may be outside the completion
+rate range for historical streak queries. The response shape is:
+
+```json
+{
+  "habit_id": "…",
+  "score": 50,
+  "completed_days": 3,
+  "eligible_days": 7,
+  "completion_rate": 43,
+  "current_streak": 2
+}
+```
+
+The Android habit screen and leaderboard screen are the v1 consumers of
+ratings and score. The existing Stats screen must use the metrics endpoint
+with an explicitly selected date window rather than its current local-only
+month-to-date calculation.
+
+This contract exposes the per-habit score needed by a leaderboard, but does
+not define cross-user ranking, participant identity, privacy, tie-breaking,
+or a leaderboard endpoint. Those decisions remain part of #107; until that
+contract exists, clients must not synthesize a head-to-head leaderboard from
+one user's local habits.
+
+The head-to-head integration defined by #107 uses:
+
+```text
+GET /v1/leaderboards/head-to-head?opponent_id={user_id}&start={epoch_ms}&end={epoch_ms}
+```
+
+`opponent_id` is required and must identify a user other than the authenticated
+caller. Boundaries are generated dynamically by the client for daily, weekly,
+monthly, and yearly tabs; they are not persisted as competitions. The response
+contains exactly the authenticated user and opponent. Each user's aggregate
+score is the sum of the derived habit score for every distinct, non-deleted
+habit log inside the requested window. Rankings sort by score descending,
+streak descending, completion rate descending, then earliest authoritative sync.
+The current storage represents completion as a calendar date, so epoch
+boundaries are normalized to UTC dates by the backend.
+
+## Migration and testing requirements
+
+- Add the four non-null habit columns with default `3` in the backend
+  migration/model and WatermelonDB schema migration.
+- Include the fields in local create, local pull, local push, backend create,
+  update, and sync paths.
+- Test bounds, omitted values, and rejection of invalid values.
+- Test score extremes, neutral score, inversion of friction/time cost, and
+  half-up rounding.
+- Test completion rates with today pending, deleted logs, duplicate input,
+  date boundaries, and a one-day range.
+- Test streaks across month/year boundaries, missing today, a gap, and deleted
+  logs, retaining the existing DST-safe date tests.
+- Do not backfill or rewrite existing completion logs.
+
+## Non-goals and deferred decisions
+
+- Per-habit schedules, skipped days, weekly frequencies, or grace days.
+- Different score weights by user, habit category, or habit type.
+- Persisted score history; changing a rating changes the current derived score.
+- Cross-habit “keystone effect” calculations; `keystone` is currently a
+  user-entered rating, not an inferred graph relationship.
+- A product decision about which dashboard date window to display by default;
+  callers must provide that window explicitly.

--- a/src/__tests__/components/RatingEditor.test.tsx
+++ b/src/__tests__/components/RatingEditor.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {act, fireEvent, render, waitFor} from '@testing-library/react-native';
+import RatingEditor, {type HabitRatings} from '../../components/RatingEditor';
+
+// Mock the database import to avoid SQLite initialization in tests
+jest.mock('../../models', () => ({}));
+
+const RATINGS: HabitRatings = {impact: 3, friction: 3, keystone: 3, timeCost: 3};
+
+function renderEditor(
+  overrides: Partial<HabitRatings> = {},
+  onSave = jest.fn().mockResolvedValue(undefined),
+) {
+  const ratings = {...RATINGS, ...overrides};
+  return {onSave, ...render(<RatingEditor ratings={ratings} onSave={onSave} />)};
+}
+
+describe('RatingEditor', () => {
+  it('renders a control for every rating field at its current value', () => {
+    const {getByTestId, getByText} = renderEditor({impact: 5, timeCost: 1});
+
+    expect(getByText('RATE THIS HABIT')).toBeTruthy();
+    expect(getByTestId('rating-impact').props.children).toBe(5);
+    expect(getByTestId('rating-friction').props.children).toBe(3);
+    expect(getByTestId('rating-keystone').props.children).toBe(3);
+    expect(getByTestId('rating-timeCost').props.children).toBe(1);
+  });
+
+  it('increments and decrements a field', () => {
+    const {getByLabelText, getByTestId} = renderEditor();
+
+    fireEvent.press(getByLabelText('Increase impact'));
+    expect(getByTestId('rating-impact').props.children).toBe(4);
+
+    fireEvent.press(getByLabelText('Decrease impact'));
+    fireEvent.press(getByLabelText('Decrease impact'));
+    expect(getByTestId('rating-impact').props.children).toBe(2);
+  });
+
+  it('clamps at the ends of the 1-5 range', () => {
+    const {getByLabelText, getByTestId} = renderEditor({impact: 5, friction: 1});
+
+    // The controls at the boundary are disabled, so the value cannot leave 1-5.
+    expect(getByLabelText('Increase impact').props.accessibilityState?.disabled).toBe(true);
+    expect(getByLabelText('Decrease friction').props.accessibilityState?.disabled).toBe(true);
+
+    fireEvent.press(getByLabelText('Increase impact'));
+    fireEvent.press(getByLabelText('Decrease friction'));
+    expect(getByTestId('rating-impact').props.children).toBe(5);
+    expect(getByTestId('rating-friction').props.children).toBe(1);
+  });
+
+  it('saves the edited draft rather than the original ratings', async () => {
+    const {getByLabelText, onSave} = renderEditor();
+
+    fireEvent.press(getByLabelText('Increase keystone'));
+    await act(async () => {
+      fireEvent.press(getByLabelText('Save habit ratings'));
+    });
+
+    expect(onSave).toHaveBeenCalledWith({
+      impact: 3,
+      friction: 3,
+      keystone: 4,
+      timeCost: 3,
+    });
+  });
+
+  it('shows a saving state while the save is in flight', async () => {
+    let release: () => void = () => {};
+    const onSave = jest.fn(
+      () => new Promise<void>(resolve => {
+        release = resolve;
+      }),
+    );
+    const {getByLabelText, getByText} = renderEditor({}, onSave);
+
+    fireEvent.press(getByLabelText('Save habit ratings'));
+
+    expect(getByText('SAVING…')).toBeTruthy();
+    // Controls are locked so a second tap cannot double-submit.
+    expect(getByLabelText('Increase impact').props.accessibilityState?.disabled).toBe(true);
+
+    await act(async () => {
+      release();
+    });
+    await waitFor(() => expect(getByText('SAVE RATINGS')).toBeTruthy());
+  });
+
+  it('adopts new ratings arriving from props', () => {
+    const onSave = jest.fn().mockResolvedValue(undefined);
+    const {getByTestId, rerender} = render(
+      <RatingEditor ratings={RATINGS} onSave={onSave} />,
+    );
+
+    rerender(<RatingEditor ratings={{...RATINGS, impact: 1}} onSave={onSave} />);
+
+    expect(getByTestId('rating-impact').props.children).toBe(1);
+  });
+});

--- a/src/__tests__/hooks/useHabitsContext.test.tsx
+++ b/src/__tests__/hooks/useHabitsContext.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {Text} from 'react-native';
+import {render, waitFor} from '@testing-library/react-native';
+import {of} from 'rxjs';
+import {HabitsProvider, useHabitsContext} from '../../hooks/useHabitsContext';
+import type HabitService from '../../services/HabitService';
+
+// Mock the database import to avoid SQLite initialization in tests
+jest.mock('../../models', () => ({}));
+
+function createMockHabitService(habits: Array<{id: string; name: string}> = []) {
+  return {
+    getActiveHabits: jest.fn().mockReturnValue(of(habits)),
+    getAllHabits: jest.fn().mockReturnValue(of(habits)),
+    calculateStreak: jest.fn().mockResolvedValue(0),
+    getLogsForHabit: jest.fn().mockResolvedValue([]),
+    toggleHabitCompletion: jest.fn().mockResolvedValue(undefined),
+    getHabitScore: jest.fn().mockReturnValue(0),
+  } as unknown as HabitService;
+}
+
+const Consumer: React.FC = () => {
+  const {habits} = useHabitsContext();
+  return <Text testID="habit-count">{habits.length}</Text>;
+};
+
+describe('useHabitsContext', () => {
+  it('exposes the shared habits state to descendants', async () => {
+    const service = createMockHabitService([
+      {id: 'h1', name: 'Read'},
+      {id: 'h2', name: 'Run'},
+    ]);
+
+    const {getByTestId} = render(
+      <HabitsProvider habitService={service}>
+        <Consumer />
+      </HabitsProvider>,
+    );
+
+    // useHabits resolves logs and streaks before it publishes, so the count
+    // arrives a microtask after render.
+    await waitFor(() =>
+      expect(getByTestId('habit-count').props.children).toBe(2),
+    );
+  });
+
+  it('opens a single subscription no matter how many consumers read it', () => {
+    const service = createMockHabitService([{id: 'h1', name: 'Read'}]);
+
+    render(
+      <HabitsProvider habitService={service}>
+        <Consumer />
+        <Consumer />
+        <Consumer />
+      </HabitsProvider>,
+    );
+
+    // The whole point of the provider: three consumers, one query.
+    expect(service.getActiveHabits).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a directed error when used outside a provider', () => {
+    // React logs the error boundary trace; silence it for this expected throw.
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<Consumer />)).toThrow(
+      /useHabitsContext must be used within a HabitsProvider/,
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/__tests__/performance.test.tsx
+++ b/src/__tests__/performance.test.tsx
@@ -45,6 +45,7 @@ describe('Performance benchmarks', () => {
 
       const habit = await database.write(async () => {
         return database.get<Habit>('habits').create(h => {
+          h.userId = 'user';
           h.name = 'Daily Exercise';
           h.createdAt = Date.now();
           h.isActive = true;
@@ -57,6 +58,7 @@ describe('Performance benchmarks', () => {
       await database.write(async () => {
         for (let i = 0; i < 365; i++) {
           await database.get<HabitLog>('habit_logs').create(log => {
+            log.userId = 'user';
             log.habitId = habit.id;
             log.completedDate = formatDate(subDays(today, i));
             log.synced = false;
@@ -134,6 +136,7 @@ describe('Performance benchmarks', () => {
       await database.write(async () => {
         for (let i = 0; i < 100; i++) {
           await database.get<Habit>('habits').create(h => {
+            h.userId = 'user';
             h.name = `Habit ${i}`;
             h.createdAt = Date.now() + i;
             h.isActive = true;

--- a/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
@@ -339,12 +339,14 @@ exports[`DashboardScreen matches snapshot 1`] = `
             "completedToday": true,
             "id": "1",
             "name": "Exercise",
+            "score": 50,
             "streak": 7,
           },
           {
             "completedToday": false,
             "id": "2",
             "name": "Read",
+            "score": 50,
             "streak": 0,
           },
         ]
@@ -645,6 +647,12 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 🔥 
                 7 days
               </Text>
+              <Text
+                testID="score-1"
+              >
+                SCORE 
+                50
+              </Text>
             </View>
           </View>
         </View>
@@ -858,6 +866,12 @@ exports[`DashboardScreen matches snapshot 1`] = `
               >
                 🔥 
                 0 days
+              </Text>
+              <Text
+                testID="score-2"
+              >
+                SCORE 
+                50
               </Text>
             </View>
           </View>

--- a/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
@@ -4315,7 +4315,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   }
                 }
               >
-                MONTH
+                SELECTED WINDOW
               </Text>
               <Text
                 style={
@@ -4353,7 +4353,7 @@ exports[`StatsScreen matches snapshot 1`] = `
               >
                 0
                  / 
-                10
+                31
                  days completed
               </Text>
               <View
@@ -4384,6 +4384,129 @@ exports[`StatsScreen matches snapshot 1`] = `
                 />
               </View>
             </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "position": "relative",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              [
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                {
+                  "backgroundColor": "#3D2F52",
+                  "borderRadius": 22,
+                  "transform": [
+                    {
+                      "translateX": 5,
+                    },
+                    {
+                      "translateY": 5,
+                    },
+                  ],
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              [
+                {
+                  "overflow": "hidden",
+                },
+                {
+                  "backgroundColor": "#FAF5EA",
+                  "borderColor": "#6A5A86",
+                  "borderRadius": 22,
+                  "borderWidth": 2.5,
+                },
+                null,
+                {
+                  "alignItems": "center",
+                  "marginBottom": 16,
+                  "paddingBottom": 16,
+                },
+              ]
+            }
+            testID="score-section"
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#6A5A86",
+                  "flexDirection": "row",
+                  "justifyContent": "space-between",
+                  "paddingHorizontal": 14,
+                  "paddingVertical": 8,
+                  "width": "100%",
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "#FAF5EA",
+                    "fontFamily": "Space Mono",
+                    "fontSize": 11,
+                    "fontWeight": "700",
+                    "letterSpacing": 0.7,
+                  }
+                }
+              >
+                HABIT SCORE
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "#FAF5EA",
+                    "fontFamily": "Space Mono",
+                    "fontSize": 11,
+                    "fontWeight": "700",
+                    "letterSpacing": 0.7,
+                  }
+                }
+              >
+                0—100
+              </Text>
+            </View>
+            <Text
+              style={
+                {
+                  "color": "#6A5A86",
+                  "fontFamily": "Archivo Black",
+                  "fontSize": 64,
+                  "lineHeight": 64,
+                  "marginTop": 8,
+                }
+              }
+            >
+              50
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "#5B544B",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 10,
+                }
+              }
+            >
+              SERVER-AUTHORITATIVE WEIGHTED SCORE
+            </Text>
           </View>
         </View>
         <View

--- a/src/__tests__/services/HabitService.ratings.test.ts
+++ b/src/__tests__/services/HabitService.ratings.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Coverage for the rating methods #118 added to HabitService.
+ *
+ * These live in their own file because they need `./api` mocked, while the main
+ * HabitService suite deliberately runs against a real WatermelonDB and must not
+ * pull the network client (or AsyncStorage) into the module graph.
+ *
+ * getHabitMetrics and getHeadToHeadLeaderboard are not covered here: they reach
+ * the network through `await import('./api')`, and a dynamic import throws
+ * under Jest's CommonJS VM ("A dynamic import callback was invoked without
+ * --experimental-vm-modules"). Metro handles it natively, so this is a test
+ * harness limitation, not a defect in those methods.
+ */
+import {Database} from '@nozbe/watermelondb';
+import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
+import {schema} from '../../models/schema';
+import Habit from '../../models/Habit';
+import HabitLog from '../../models/HabitLog';
+import HabitService from '../../services/HabitService';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('../../services/api', () => ({
+  __esModule: true,
+  default: {get: jest.fn()},
+}));
+
+function createTestDatabase(): Database {
+  const adapter = new LokiJSAdapter({
+    schema,
+    useWebWorker: false,
+    useIncrementalIndexedDB: false,
+  });
+  return new Database({adapter, modelClasses: [Habit, HabitLog]});
+}
+
+describe('HabitService rating methods', () => {
+  let database: Database;
+  let service: HabitService;
+
+  beforeEach(() => {
+    database = createTestDatabase();
+    service = new HabitService(database);
+  });
+
+  async function createHabit(): Promise<Habit> {
+    return database.write(async () =>
+      database.get<Habit>('habits').create(h => {
+        h.userId = 'user';
+        h.name = 'Read';
+        h.createdAt = Date.now();
+        h.isActive = true;
+        h.synced = true;
+        h.impact = 3;
+        h.friction = 3;
+        h.keystone = 3;
+        h.timeCost = 3;
+      }),
+    );
+  }
+
+  describe('setHabitRatings', () => {
+    it('persists the four ratings and marks the habit unsynced', async () => {
+      const habit = await createHabit();
+
+      await service.setHabitRatings(habit.id, {
+        impact: 5,
+        friction: 2,
+        keystone: 4,
+        timeCost: 1,
+      });
+
+      const updated = await database.get<Habit>('habits').find(habit.id);
+      expect([updated.impact, updated.friction, updated.keystone, updated.timeCost])
+        .toEqual([5, 2, 4, 1]);
+      expect(updated.synced).toBe(false);
+    });
+
+    it.each([
+      ['below the range', {impact: 0, friction: 3, keystone: 3, timeCost: 3}],
+      ['above the range', {impact: 3, friction: 6, keystone: 3, timeCost: 3}],
+      ['not an integer', {impact: 3, friction: 3, keystone: 2.5, timeCost: 3}],
+    ])('rejects a rating %s', async (_label, ratings) => {
+      const habit = await createHabit();
+
+      await expect(service.setHabitRatings(habit.id, ratings)).rejects.toThrow(
+        'Habit ratings must be integers from 1 to 5.',
+      );
+
+      // The habit is left untouched by a rejected update.
+      const unchanged = await database.get<Habit>('habits').find(habit.id);
+      expect(unchanged.impact).toBe(3);
+      expect(unchanged.synced).toBe(true);
+    });
+
+    it('refuses to rate a habit belonging to another account', async () => {
+      const habit = await createHabit();
+      service.setUserId('11111111-1111-1111-1111-111111111111');
+
+      await expect(
+        service.setHabitRatings(habit.id, {
+          impact: 5,
+          friction: 5,
+          keystone: 5,
+          timeCost: 5,
+        }),
+      ).rejects.toThrow('Habit not found');
+    });
+  });
+
+  describe('getHabitScore', () => {
+    it('scores a habit from its ratings', async () => {
+      const habit = await createHabit();
+
+      expect(service.getHabitScore(habit)).toBeGreaterThan(0);
+    });
+
+    it('falls back to the neutral rating when a field is unset', async () => {
+      const habit = await createHabit();
+      const neutral = service.getHabitScore(habit);
+
+      await database.write(async () => {
+        await habit.update(h => {
+          h.impact = 0;
+          h.friction = 0;
+          h.keystone = 0;
+          h.timeCost = 0;
+        });
+      });
+
+      // 0 is falsy, so each field defaults back to 3 -- same score as neutral.
+      expect(service.getHabitScore(habit)).toBe(neutral);
+    });
+  });
+});

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -25,13 +25,20 @@ function formatDate(date: Date): string {
   return format(date, 'yyyy-MM-dd');
 }
 
+// Ownership is explicit in these helpers. The default matches HabitService's
+// own starting userId, so tests that don't care about accounts read as before;
+// the multi-account tests pass a real id.
+const DEFAULT_OWNER = 'user';
+
 async function createTestHabit(
   database: Database,
   name: string = 'Exercise',
   synced: boolean = true,
+  owner: string = DEFAULT_OWNER,
 ): Promise<Habit> {
   return database.write(async () => {
     return database.get<Habit>('habits').create(h => {
+      h.userId = owner;
       h.name = name;
       h.createdAt = Date.now();
       h.isActive = true;
@@ -45,9 +52,11 @@ async function createTestLog(
   habitId: string,
   date: string,
   synced: boolean = false,
+  owner: string = DEFAULT_OWNER,
 ): Promise<HabitLog> {
   return database.write(async () => {
     return database.get<HabitLog>('habit_logs').create(log => {
+      log.userId = owner;
       log.habitId = habitId;
       log.completedDate = date;
       log.synced = synced;
@@ -290,6 +299,7 @@ describe('HabitService', () => {
       await database.write(async () => {
         for (let i = 0; i < 100; i++) {
           await database.get<HabitLog>('habit_logs').create(log => {
+            log.userId = DEFAULT_OWNER;
             log.habitId = habit.id;
             log.completedDate = formatDate(subDays(today, i));
             log.synced = false;
@@ -362,6 +372,7 @@ describe('HabitService', () => {
       await database.write(async () => {
         for (let i = 0; i < 411; i++) {
           await database.get<HabitLog>('habit_logs').create(log => {
+            log.userId = DEFAULT_OWNER;
             log.habitId = habit.id;
             log.completedDate = formatDate(subDays(today, i));
             log.synced = false;
@@ -375,6 +386,155 @@ describe('HabitService', () => {
       );
 
       expect(streak).toBe(401);
+    });
+  });
+
+  // ─── Multi-account isolation (#123) ────────────────────────────────
+
+  describe('account isolation', () => {
+    const ALICE = '11111111-1111-1111-1111-111111111111';
+    const BOB = '22222222-2222-2222-2222-222222222222';
+
+    it('does not show one account the other account habits', async () => {
+      await createTestHabit(database, 'Alice habit', true, ALICE);
+      await createTestHabit(database, 'Bob habit', true, BOB);
+
+      service.setUserId(BOB);
+      const habits = await new Promise<Habit[]>(resolve => {
+        const sub = service.getAllHabits().subscribe(list => {
+          resolve(list);
+          setTimeout(() => sub.unsubscribe(), 0);
+        });
+      });
+
+      expect(habits.map(h => h.name)).toEqual(['Bob habit']);
+    });
+
+    it('does not show one account the other account logs', async () => {
+      const aliceHabit = await createTestHabit(database, 'Alice habit', true, ALICE);
+      await createTestLog(database, aliceHabit.id, '2026-03-07', true, ALICE);
+
+      service.setUserId(BOB);
+
+      expect(
+        await service.getLogsForHabit(aliceHabit.id, '2026-01-01', '2026-12-31'),
+      ).toEqual([]);
+      // The habit itself is not reachable either, so Bob cannot edit it.
+      await expect(service.getHabitById(aliceHabit.id)).rejects.toThrow('Habit not found');
+    });
+
+    it('counts only the signed-in account unsynced rows', async () => {
+      await createTestHabit(database, 'Alice unsynced', false, ALICE);
+      const bobHabit = await createTestHabit(database, 'Bob unsynced', false, BOB);
+      await createTestLog(database, bobHabit.id, '2026-03-07', false, BOB);
+
+      service.setUserId(BOB);
+      const count = await new Promise<number>(resolve => {
+        const sub = service.observeUnsyncedCount().subscribe(value => {
+          resolve(value);
+          setTimeout(() => sub.unsubscribe(), 0);
+        });
+      });
+
+      // Bob's habit + Bob's log, and none of Alice's.
+      expect(count).toBe(2);
+    });
+
+    it('does not let a pulled log collide with another account row', async () => {
+      const aliceHabit = await createTestHabit(database, 'Alice habit', true, ALICE);
+      const aliceLog = await createTestLog(database, aliceHabit.id, '2026-03-07', true, ALICE);
+
+      service.setUserId(BOB);
+      await service.applyPulledLogs([
+        {id: aliceLog.id, habit_id: aliceHabit.id, completed_date: '2026-03-07'},
+      ]);
+
+      const row = await database.get<HabitLog>('habit_logs').find(aliceLog.id);
+      expect(row.userId).toBe(ALICE);
+    });
+
+    it('does not let a pulled habit overwrite another account row', async () => {
+      const aliceHabit = await createTestHabit(database, 'Alice habit', true, ALICE);
+
+      service.setUserId(BOB);
+      await service.applyPulledHabits([
+        {
+          id: aliceHabit.id,
+          name: 'Bob version',
+          created_at: new Date().toISOString(),
+          is_active: true,
+          impact: 5,
+          friction: 1,
+          keystone: 5,
+          time_cost: 1,
+        },
+      ]);
+
+      const alicesRow = await database.get<Habit>('habits').find(aliceHabit.id);
+      expect(alicesRow.name).toBe('Alice habit');
+      expect(alicesRow.userId).toBe(ALICE);
+    });
+  });
+
+  // ─── Legacy row claiming (#123) ────────────────────────────────────
+
+  describe('claimLegacyRows', () => {
+    const ALICE = '11111111-1111-1111-1111-111111111111';
+    const BOB = '22222222-2222-2222-2222-222222222222';
+
+    it('adopts rows left unowned by the schema v5 migration', async () => {
+      const habit = await createTestHabit(database, 'Legacy habit', true, '');
+      await createTestLog(database, habit.id, '2026-03-07', true, '');
+
+      const claimed = await service.claimLegacyRows(ALICE);
+
+      expect(claimed).toBe(2);
+      service.setUserId(ALICE);
+      expect(await service.getHabitById(habit.id)).toBeTruthy();
+      expect(
+        await service.getLogsForHabit(habit.id, '2026-01-01', '2026-12-31'),
+      ).toHaveLength(1);
+    });
+
+    it('adopts rows written under the pre-login placeholder owner', async () => {
+      const habit = await createTestHabit(database, 'Placeholder habit', true, 'user');
+
+      expect(await service.claimLegacyRows(ALICE)).toBe(1);
+
+      const claimedRow = await database.get<Habit>('habits').find(habit.id);
+      expect(claimedRow.userId).toBe(ALICE);
+    });
+
+    it('leaves a second account nothing to claim', async () => {
+      const habit = await createTestHabit(database, 'Legacy habit', true, '');
+      await service.claimLegacyRows(ALICE);
+
+      expect(await service.claimLegacyRows(BOB)).toBe(0);
+
+      // The rows stayed with the account that claimed them.
+      const row = await database.get<Habit>('habits').find(habit.id);
+      expect(row.userId).toBe(ALICE);
+      service.setUserId(BOB);
+      await expect(service.getHabitById(habit.id)).rejects.toThrow('Habit not found');
+    });
+
+    it('does not touch rows already owned by a real account', async () => {
+      const habit = await createTestHabit(database, 'Alice habit', true, ALICE);
+
+      expect(await service.claimLegacyRows(BOB)).toBe(0);
+
+      const row = await database.get<Habit>('habits').find(habit.id);
+      expect(row.userId).toBe(ALICE);
+    });
+
+    it('is a no-op when there is nothing to claim', async () => {
+      expect(await service.claimLegacyRows(ALICE)).toBe(0);
+    });
+
+    it('ignores an empty user id rather than claiming rows for nobody', async () => {
+      await createTestHabit(database, 'Legacy habit', true, '');
+
+      expect(await service.claimLegacyRows('')).toBe(0);
     });
   });
 

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -351,6 +351,31 @@ describe('HabitService', () => {
       const streak = await service.calculateStreak(habit.id, '2026-03-07');
       expect(streak).toBe(1);
     });
+
+    it('does not fetch logs older than the 400-day cutoff', async () => {
+      const habit = await createTestHabit(database);
+      const today = new Date('2026-03-07T00:00:00');
+
+      // An unbroken run reaching further back than the cutoff. The query is
+      // bounded at asOf - 400, so the walk can only reach that day: 401 days
+      // inclusive. Without the bound it would run the full 411.
+      await database.write(async () => {
+        for (let i = 0; i < 411; i++) {
+          await database.get<HabitLog>('habit_logs').create(log => {
+            log.habitId = habit.id;
+            log.completedDate = formatDate(subDays(today, i));
+            log.synced = false;
+          });
+        }
+      });
+
+      const streak = await service.calculateStreak(
+        habit.id,
+        formatDate(today),
+      );
+
+      expect(streak).toBe(401);
+    });
   });
 
   // ─── getLogsForHabit ───────────────────────────────────────────────

--- a/src/__tests__/services/SyncService.untoggle.test.ts
+++ b/src/__tests__/services/SyncService.untoggle.test.ts
@@ -71,6 +71,7 @@ async function createSyncedHabit(
 ): Promise<Habit> {
   return database.write(async () => {
     return database.get<Habit>('habits').create(h => {
+      h.userId = 'user';
       h.name = name;
       h.createdAt = Date.now();
       h.isActive = true;
@@ -86,6 +87,7 @@ async function createSyncedLog(
 ): Promise<HabitLog> {
   return database.write(async () => {
     return database.get<HabitLog>('habit_logs').create(log => {
+      log.userId = 'user';
       log.habitId = habitId;
       log.completedDate = date;
       log.synced = true;

--- a/src/__tests__/utils/dateUtils.test.ts
+++ b/src/__tests__/utils/dateUtils.test.ts
@@ -27,6 +27,7 @@ async function createTestHabit(
 ): Promise<Habit> {
   return database.write(async () => {
     return database.get<Habit>('habits').create(h => {
+      h.userId = 'user';
       h.name = name;
       h.createdAt = Date.now();
       h.isActive = true;
@@ -41,6 +42,7 @@ async function createTestLog(
 ): Promise<HabitLog> {
   return database.write(async () => {
     return database.get<HabitLog>('habit_logs').create(log => {
+      log.userId = 'user';
       log.habitId = habitId;
       log.completedDate = date;
       log.synced = false;

--- a/src/__tests__/utils/habitScoring.test.ts
+++ b/src/__tests__/utils/habitScoring.test.ts
@@ -1,0 +1,20 @@
+import {calculateHabitScore} from '../../utils/habitScoring';
+
+describe('calculateHabitScore', () => {
+  it.each([
+    [[5, 1, 5, 1], 100],
+    [[3, 3, 3, 3], 50],
+    [[1, 5, 1, 5], 0],
+    [[4, 2, 3, 4], 56],
+  ])('scores %j as %d', (ratings, expected) => {
+    expect(calculateHabitScore(...(ratings as [number, number, number, number]))).toBe(expected);
+  });
+
+  it('improves with impact and keystone, and declines with friction and time cost', () => {
+    const neutral = calculateHabitScore(3, 3, 3, 3);
+    expect(calculateHabitScore(4, 3, 3, 3)).toBeGreaterThan(neutral);
+    expect(calculateHabitScore(3, 3, 4, 3)).toBeGreaterThan(neutral);
+    expect(calculateHabitScore(3, 4, 3, 3)).toBeLessThan(neutral);
+    expect(calculateHabitScore(3, 3, 3, 4)).toBeLessThan(neutral);
+  });
+});

--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -14,6 +14,7 @@ interface HabitCardProps {
   name: string;
   completedToday: boolean;
   streak: number;
+  score?: number;
   onToggle: (habitId: string) => void;
   onPress?: (habitId: string) => void;
 }
@@ -26,6 +27,7 @@ function areEqual(prev: HabitCardProps, next: HabitCardProps): boolean {
     prev.name === next.name &&
     prev.completedToday === next.completedToday &&
     prev.streak === next.streak &&
+    prev.score === next.score &&
     prev.onToggle === next.onToggle &&
     prev.onPress === next.onPress
   );
@@ -36,6 +38,7 @@ const HabitCard: React.FC<HabitCardProps> = ({
   name,
   completedToday,
   streak,
+  score,
   onToggle,
   onPress,
 }) => {
@@ -104,6 +107,9 @@ const HabitCard: React.FC<HabitCardProps> = ({
         <Text style={styles.streakText} testID={`streak-${habitId}`}>
           🔥 {streakLabel}
         </Text>
+        {score !== undefined && (
+          <Text testID={`score-${habitId}`}>SCORE {score}</Text>
+        )}
       </View>
     </Pressable>
   );

--- a/src/components/RatingEditor.tsx
+++ b/src/components/RatingEditor.tsx
@@ -1,0 +1,144 @@
+import React, {useEffect, useState} from 'react';
+import {Pressable, StyleSheet, Text, View} from 'react-native';
+import {colors} from '../theme/colors';
+import {fontFamily} from '../theme/typography';
+import {spacing} from '../theme/spacing';
+import {borders, radii} from '../theme';
+
+export interface HabitRatings {
+  impact: number;
+  friction: number;
+  keystone: number;
+  timeCost: number;
+}
+
+interface RatingEditorProps {
+  ratings: HabitRatings;
+  onSave: (ratings: HabitRatings) => Promise<void>;
+}
+
+const fields: Array<{key: keyof HabitRatings; label: string}> = [
+  {key: 'impact', label: 'IMPACT'},
+  {key: 'friction', label: 'FRICTION'},
+  {key: 'keystone', label: 'KEYSTONE'},
+  {key: 'timeCost', label: 'TIME COST'},
+];
+
+const RatingEditor: React.FC<RatingEditorProps> = ({ratings, onSave}) => {
+  const [draft, setDraft] = useState(ratings);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => setDraft(ratings), [ratings]);
+
+  const change = (key: keyof HabitRatings, delta: number) => {
+    setDraft(current => ({
+      ...current,
+      [key]: Math.max(1, Math.min(5, current[key] + delta)),
+    }));
+  };
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      await onSave(draft);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View testID="rating-editor" style={styles.container}>
+      <Text style={styles.heading}>RATE THIS HABIT</Text>
+      {fields.map(({key, label}) => (
+        <View key={key} style={styles.row}>
+          <Text style={styles.label}>{label}</Text>
+          <View style={styles.controls}>
+            <Pressable
+              accessibilityLabel={`Decrease ${label.toLowerCase()}`}
+              accessibilityRole="button"
+              disabled={draft[key] <= 1 || saving}
+              onPress={() => change(key, -1)}
+              style={styles.button}>
+              <Text style={styles.buttonText}>−</Text>
+            </Pressable>
+            <Text style={styles.value} testID={`rating-${key}`}>
+              {draft[key]}
+            </Text>
+            <Pressable
+              accessibilityLabel={`Increase ${label.toLowerCase()}`}
+              accessibilityRole="button"
+              disabled={draft[key] >= 5 || saving}
+              onPress={() => change(key, 1)}
+              style={styles.button}>
+              <Text style={styles.buttonText}>+</Text>
+            </Pressable>
+          </View>
+        </View>
+      ))}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Save habit ratings"
+        disabled={saving}
+        onPress={save}
+        style={styles.saveButton}>
+        <Text style={styles.saveText}>{saving ? 'SAVING…' : 'SAVE RATINGS'}</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: spacing.md,
+    padding: spacing.md,
+    backgroundColor: colors.card,
+    borderWidth: borders.base,
+    borderColor: colors.line,
+    borderRadius: radii.card,
+  },
+  heading: {
+    fontFamily: fontFamily.mono,
+    fontSize: 11,
+    color: colors.textSoft,
+    letterSpacing: 0.7,
+    marginBottom: spacing.sm,
+  },
+  row: {
+    minHeight: 42,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderTopWidth: borders.thin,
+    borderTopColor: colors.line,
+  },
+  label: {fontFamily: fontFamily.mono, fontSize: 11, color: colors.text},
+  controls: {flexDirection: 'row', alignItems: 'center', gap: spacing.sm},
+  button: {
+    width: 30,
+    height: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.darkBg,
+    borderRadius: radii.card,
+  },
+  buttonText: {fontSize: 20, lineHeight: 22, color: colors.darkBgText},
+  value: {
+    minWidth: 18,
+    textAlign: 'center',
+    fontFamily: fontFamily.display,
+    fontSize: 20,
+    color: colors.regalia,
+  },
+  saveButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+    backgroundColor: colors.tiger,
+    borderWidth: borders.base,
+    borderColor: colors.tigerDeep,
+    borderRadius: radii.card,
+  },
+  saveText: {fontFamily: fontFamily.mono, fontSize: 11, color: colors.darkBg},
+});
+
+export default RatingEditor;

--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -5,12 +5,14 @@ import type Habit from '../models/Habit';
 import type HabitService from '../services/HabitService';
 import {getTodayString} from '../utils/dateUtils';
 import {useSubscriptionLeakDetector} from './useSubscriptionLeakDetector';
+import {calculateHabitScore} from '../utils/habitScoring';
 
 export interface HabitDisplayData {
   id: string;
   name: string;
   completedToday: boolean;
   streak: number;
+  score: number;
 }
 
 export function useHabits(habitService: HabitService) {
@@ -49,6 +51,12 @@ export function useHabits(habitService: HabitService) {
             name: habit.name,
             completedToday,
             streak,
+            score: habitService.getHabitScore?.(habit) ?? calculateHabitScore(
+              habit.impact || 3,
+              habit.friction || 3,
+              habit.keystone || 3,
+              habit.timeCost || 3,
+            ),
           };
         }),
       );

--- a/src/models/Habit.ts
+++ b/src/models/Habit.ts
@@ -17,6 +17,10 @@ export default class Habit extends Model {
   @field('synced') synced!: boolean;
   @field('notifications_enabled') notificationsEnabled!: boolean;
   @field('notification_time') notificationTime!: string;
+  @field('impact') impact!: number;
+  @field('friction') friction!: number;
+  @field('keystone') keystone!: number;
+  @field('time_cost') timeCost!: number;
 
   @children('habit_logs') habitLogs!: Query<HabitLog>;
 

--- a/src/models/migrations.ts
+++ b/src/models/migrations.ts
@@ -1,6 +1,7 @@
 import {
   schemaMigrations,
   addColumns,
+  unsafeExecuteSql,
 } from '@nozbe/watermelondb/Schema/migrations';
 
 export const migrations = schemaMigrations({
@@ -56,6 +57,23 @@ export const migrations = schemaMigrations({
       steps: [
         addColumns({table: 'habits', columns: [{name: 'user_id', type: 'string', isIndexed: true}]}),
         addColumns({table: 'habit_logs', columns: [{name: 'user_id', type: 'string', isIndexed: true}]}),
+      ],
+    },
+    {
+      toVersion: 6,
+      steps: [
+        addColumns({
+          table: 'habits',
+          columns: [
+            {name: 'impact', type: 'number'},
+            {name: 'friction', type: 'number'},
+            {name: 'keystone', type: 'number'},
+            {name: 'time_cost', type: 'number'},
+          ],
+        }),
+        unsafeExecuteSql(
+          'UPDATE habits SET impact = 3, friction = 3, keystone = 3, time_cost = 3;',
+        ),
       ],
     },
   ],

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export const schema = appSchema({
-  version: 5,
+  version: 6,
   tables: [
     tableSchema({
       name: 'habits',
@@ -17,6 +17,10 @@ export const schema = appSchema({
         // reminder. Empty string = unset; service/UI falls back to "08:00".
         {name: 'notifications_enabled', type: 'boolean'},
         {name: 'notification_time', type: 'string'},
+        {name: 'impact', type: 'number'},
+        {name: 'friction', type: 'number'},
+        {name: 'keystone', type: 'number'},
+        {name: 'time_cost', type: 'number'},
       ],
     }),
     tableSchema({

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -51,7 +51,14 @@ export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
   }
 
   React.useEffect(() => {
-    if (habitService && userId) habitService.setUserId(userId);
+    if (!habitService || !userId) return;
+    habitService.setUserId(userId);
+    // Rows predating per-account ownership belong to nobody until the first
+    // account signs in and adopts them. Without this they would be invisible
+    // to every account, since queries now scope on the owner alone.
+    habitService.claimLegacyRows(userId).catch(error => {
+      console.warn('Failed to claim legacy rows:', error);
+    });
   }, [habitService, userId]);
 
   if (isLoading) {

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -135,6 +135,7 @@ const DashboardScreenBody: React.FC<DashboardScreenBodyProps> = ({
         name={item.name}
         completedToday={item.completedToday}
         streak={item.streak}
+        score={item.score}
         onToggle={handleToggle}
         onPress={handleHabitPress}
       />

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -81,6 +81,7 @@ const StatsListScreenBody: React.FC<StatsListScreenBodyProps> = ({
               {' '}
               {String(item.streak).padStart(3, '0')} DAYS
             </Text>
+            <Text style={styles.scoreText}> · SCORE {item.score}</Text>
           </View>
         </View>
         <NBChevron color={colors.regalia} />
@@ -179,6 +180,11 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.mono,
     fontSize: 11,
     color: colors.textSoft,
+  },
+  scoreText: {
+    fontFamily: fontFamily.mono,
+    fontSize: 11,
+    color: colors.regalia,
   },
   empty: {
     paddingHorizontal: spacing.lg,

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -15,11 +15,13 @@ import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
 import {radii, borders} from '../theme';
 import MonthCalendar from '../components/MonthCalendar';
+import RatingEditor, {type HabitRatings} from '../components/RatingEditor';
 import NBSurface from '../components/atoms/NBSurface';
 import NBCard from '../components/atoms/NBCard';
 import NBChip from '../components/atoms/NBChip';
 import HabitService from '../services/HabitService';
 import {getDefaultHabitService} from '../services/defaultHabitService';
+import {calculateHabitScore} from '../utils/habitScoring';
 
 interface StatsScreenProps {
   route?: {params: {habitId: string}};
@@ -33,6 +35,7 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
   habitService,
 }) => {
   const service = habitService ?? getDefaultHabitService();
+  const canEditRatings = typeof (service as unknown as {setHabitRatings?: unknown}).setHabitRatings === 'function';
   const habitId = route?.params?.habitId ?? '';
   const insets = useSafeAreaInsets();
   // Clear the system status bar before laying out the back button + title.
@@ -40,6 +43,14 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
 
   const [habitName, setHabitName] = useState('');
   const [streak, setStreak] = useState(0);
+  const [score, setScore] = useState(50);
+  const [completionRate, setCompletionRate] = useState(0);
+  const [ratings, setRatings] = useState<HabitRatings>({
+    impact: 3,
+    friction: 3,
+    keystone: 3,
+    timeCost: 3,
+  });
   const [completedDates, setCompletedDates] = useState<Set<string>>(new Set());
   // Single Date observation so year and month can't straddle a midnight/month
   // boundary (two separate `new Date()` calls could observe different values).
@@ -76,6 +87,21 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
     (async () => {
       const habit = await service.getHabitById(habitId);
       setHabitName(habit.name);
+      const nextRatings = {
+        impact: habit.impact ?? 3,
+        friction: habit.friction ?? 3,
+        keystone: habit.keystone ?? 3,
+        timeCost: habit.timeCost ?? 3,
+      };
+      setRatings(nextRatings);
+      setScore(
+        service.getHabitScore?.(habit) ?? calculateHabitScore(
+          nextRatings.impact,
+          nextRatings.friction,
+          nextRatings.keystone,
+          nextRatings.timeCost,
+        ),
+      );
       const today = getTodayString();
       const currentStreak = await service.calculateStreak(habitId, today);
       setStreak(currentStreak);
@@ -98,8 +124,49 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
       );
       const logs = await service.getLogsForHabit(habitId, startDate, endDate);
       setCompletedDates(new Set(logs.map(log => log.completedDate)));
+      let metrics;
+      try {
+        metrics = await service.getHabitMetrics?.(
+          habitId,
+          startDate,
+          endDate,
+          getTodayString(),
+        );
+      } catch {
+        // The calendar remains useful offline; local values are provisional
+        // until the server metrics request succeeds.
+        metrics = undefined;
+      }
+      if (metrics) {
+        setCompletionRate(metrics.completion_rate);
+        setScore(metrics.score);
+        setStreak(metrics.current_streak);
+      } else {
+        const daysInMonth = getDaysInMonth(new Date(calendarYear, calendarMonth));
+        setCompletionRate(
+          daysInMonth > 0 ? Math.round((new Set(logs.map(log => log.completedDate)).size * 100) / daysInMonth) : 0,
+        );
+      }
     })();
   }, [habitId, calendarYear, calendarMonth, service]);
+
+  const handleSaveRatings = useCallback(
+    async (nextRatings: HabitRatings) => {
+      const saveRatings = (service as unknown as {
+        setHabitRatings?: HabitService['setHabitRatings'];
+      }).setHabitRatings;
+      if (!saveRatings) return;
+      await saveRatings.call(service, habitId, nextRatings);
+      setRatings(nextRatings);
+      setScore(calculateHabitScore(
+        nextRatings.impact,
+        nextRatings.friction,
+        nextRatings.keystone,
+        nextRatings.timeCost,
+      ));
+    },
+    [habitId, service],
+  );
 
   const handleMonthChange = useCallback(
     (year: number, month: number) => {
@@ -114,19 +181,12 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
   }, [navigation]);
 
   const {completedCount, totalDays} = useMemo(() => {
-    const now = new Date();
-    const isCurrentMonth =
-      now.getFullYear() === calendarYear && now.getMonth() === calendarMonth;
     const daysInMonth = getDaysInMonth(
       new Date(calendarYear, calendarMonth),
     );
-    const total = isCurrentMonth ? now.getDate() : daysInMonth;
 
-    return {completedCount: completedDates.size, totalDays: total};
+    return {completedCount: completedDates.size, totalDays: daysInMonth};
   }, [completedDates, calendarYear, calendarMonth]);
-
-  const progressPercent =
-    totalDays > 0 ? completedCount / totalDays : 0;
 
   return (
     <NBSurface testID="stats-screen">
@@ -150,6 +210,10 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
         <Text style={styles.title} testID="habit-name">
           {habitName}
         </Text>
+
+        {canEditRatings && (
+          <RatingEditor ratings={ratings} onSave={handleSaveRatings} />
+        )}
 
         <NBCard style={styles.streakCard} testID="streak-section">
           <View style={styles.streakStrip}>
@@ -175,9 +239,9 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
 
         <NBCard style={styles.summaryCard} testID="monthly-summary">
           <View style={styles.summaryStrip}>
-            <Text style={styles.summaryStripText}>MONTH</Text>
+            <Text style={styles.summaryStripText}>SELECTED WINDOW</Text>
             <Text style={styles.summaryStripText}>
-              {Math.round(progressPercent * 100)}%
+              {completionRate}%
             </Text>
           </View>
           <View style={styles.summaryBody}>
@@ -188,12 +252,21 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
               <View
                 style={[
                   styles.progressBarFill,
-                  {width: `${Math.round(progressPercent * 100)}%`},
+                  {width: `${completionRate}%`},
                 ]}
                 testID="progress-bar"
               />
             </View>
           </View>
+        </NBCard>
+
+        <NBCard style={styles.scoreCard} testID="score-section">
+          <View style={styles.scoreStrip}>
+            <Text style={styles.summaryStripText}>HABIT SCORE</Text>
+            <Text style={styles.summaryStripText}>0—100</Text>
+          </View>
+          <Text style={styles.scoreNumber}>{score}</Text>
+          <Text style={styles.scoreCaption}>SERVER-AUTHORITATIVE WEIGHTED SCORE</Text>
         </NBCard>
 
         <View style={styles.bottomSpacer} />
@@ -265,6 +338,23 @@ const styles = StyleSheet.create({
   summaryCard: {
     marginBottom: spacing.md,
   },
+  scoreCard: {marginBottom: spacing.md, alignItems: 'center', paddingBottom: spacing.md},
+  scoreStrip: {
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    backgroundColor: colors.regalia,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  scoreNumber: {
+    fontFamily: fontFamily.display,
+    fontSize: 64,
+    lineHeight: 64,
+    color: colors.regalia,
+    marginTop: spacing.sm,
+  },
+  scoreCaption: {fontFamily: fontFamily.mono, fontSize: 10, color: colors.textSoft},
   summaryStrip: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -5,6 +5,41 @@ import {map} from 'rxjs/operators';
 import {subDays, format} from 'date-fns';
 import type Habit from '../models/Habit';
 import type HabitLog from '../models/HabitLog';
+import {calculateHabitScore} from '../utils/habitScoring';
+
+export interface HabitMetrics {
+  habit_id: string;
+  score: number;
+  completed_days: number;
+  eligible_days: number;
+  completion_rate: number;
+  current_streak: number;
+}
+
+export interface LeaderboardRanking {
+  rank: number;
+  user_id: string;
+  display_name: string;
+  is_current_user: boolean;
+  score: number;
+  tie_breakers: {
+    streak_days: number;
+    completion_rate_pct: number;
+    last_authoritative_sync: string | null;
+  };
+}
+
+export interface HeadToHeadResponse {
+  competition_id: string;
+  meta: {
+    status: string;
+    timezone: string;
+    period_start: string;
+    period_end: string;
+    updated_at: string;
+  };
+  rankings: LeaderboardRanking[];
+}
 
 // After this many server-rejected attempts a log is treated as permanently
 // dead and excluded from the sync queue. Prevents per-log failures like
@@ -41,7 +76,12 @@ export default class HabitService {
     return this.database
       .get<Habit>('habits')
       .query(Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')), Q.where('is_active', true), Q.sortBy('created_at', Q.asc))
-      .observe();
+      .observeWithColumns([
+        'impact',
+        'friction',
+        'keystone',
+        'time_cost',
+      ]);
   }
 
   getAllHabits(): Observable<Habit[]> {
@@ -57,6 +97,10 @@ export default class HabitService {
         'is_active',
         'notifications_enabled',
         'notification_time',
+        'impact',
+        'friction',
+        'keystone',
+        'time_cost',
       ]);
   }
 
@@ -90,8 +134,71 @@ export default class HabitService {
         habit.synced = false;
         habit.notificationsEnabled = false;
         habit.notificationTime = '08:00';
+        habit.impact = 3;
+        habit.friction = 3;
+        habit.keystone = 3;
+        habit.timeCost = 3;
       });
     });
+  }
+
+  async setHabitRatings(
+    habitId: string,
+    ratings: {impact: number; friction: number; keystone: number; timeCost: number},
+  ): Promise<void> {
+    for (const value of Object.values(ratings)) {
+      if (!Number.isInteger(value) || value < 1 || value > 5) {
+        throw new Error('Habit ratings must be integers from 1 to 5.');
+      }
+    }
+    const habit = await this.getHabitById(habitId);
+    await this.database.write(async () => {
+      await habit.update(h => {
+        h.impact = ratings.impact;
+        h.friction = ratings.friction;
+        h.keystone = ratings.keystone;
+        h.timeCost = ratings.timeCost;
+        h.synced = false;
+      });
+    });
+  }
+
+  getHabitScore(habit: Habit): number {
+    return calculateHabitScore(
+      habit.impact || 3,
+      habit.friction || 3,
+      habit.keystone || 3,
+      habit.timeCost || 3,
+    );
+  }
+
+  async getHabitMetrics(
+    habitId: string,
+    start: string,
+    end: string,
+    asOf: string,
+  ): Promise<HabitMetrics> {
+    // Load the network client lazily so local-only consumers and Jest's
+    // WatermelonDB tests do not initialize native AsyncStorage.
+    const {default: apiClient} = await import('./api');
+    const response = await apiClient.get<HabitMetrics>(
+      `/habits/${habitId}/metrics`,
+      {params: {start, end, as_of: asOf}},
+    );
+    return response.data;
+  }
+
+  async getHeadToHeadLeaderboard(
+    opponentId: string,
+    start: number,
+    end: number,
+  ): Promise<HeadToHeadResponse> {
+    const {default: apiClient} = await import('./api');
+    const response = await apiClient.get<HeadToHeadResponse>(
+      '/v1/leaderboards/head-to-head',
+      {params: {opponent_id: opponentId, start, end}},
+    );
+    return response.data;
   }
 
   async setHabitNotification(
@@ -320,14 +427,14 @@ export default class HabitService {
     }
   }
 
-  async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean}>): Promise<void> {
+  async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean; impact: number; friction: number; keystone: number; time_cost: number}>): Promise<void> {
     await this.database.write(async () => {
       for (const remote of habits) {
         let local: Habit | null = null;
         try { local = await this.database.get<Habit>('habits').find(remote.id); } catch { /* new row */ }
         if (local) {
           if (!local.synced) continue; // never overwrite offline work
-          await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; });
+          await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; h.impact = remote.impact ?? 3; h.friction = remote.friction ?? 3; h.keystone = remote.keystone ?? 3; h.timeCost = remote.time_cost ?? 3; });
         } else {
           await this.database.get<Habit>('habits').create(h => {
             h._raw.id = remote.id;
@@ -338,6 +445,10 @@ export default class HabitService {
             h.synced = true;
             h.notificationsEnabled = false;
             h.notificationTime = '08:00';
+            h.impact = remote.impact ?? 3;
+            h.friction = remote.friction ?? 3;
+            h.keystone = remote.keystone ?? 3;
+            h.timeCost = remote.time_cost ?? 3;
           });
         }
       }
@@ -394,19 +505,11 @@ export default class HabitService {
     let streak = 0;
     let currentDate = asOfDate;
 
-    // Only fetch logs within the last 400 days to bound the query size.
-    // A streak longer than 400 days would be extremely rare, and this avoids
-    // scanning thousands of historical rows for long-running habits.
-    const cutoffDate = format(
-      subDays(new Date(asOfDate + 'T00:00:00'), 400),
-      'yyyy-MM-dd',
-    );
-
     const logs = await this.database
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
-        Q.where('completed_date', Q.gte(cutoffDate)),
+        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
         Q.where('completed_date', Q.lte(asOfDate)),
         Q.where('deleted_at', null),
       )

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -60,6 +60,11 @@ export function backoffMsFor(retryCount: number): number {
   return Math.min(BACKOFF_BASE_MS * 2 ** exp, BACKOFF_CAP_MS);
 }
 
+// Owner values that mean "nobody yet": '' is what schema v5 left on rows that
+// predate the user_id column, 'user' is the placeholder this service holds
+// before the first login. Both are claimed on sign-in; see claimLegacyRows.
+const LEGACY_OWNER_IDS = ['', 'user'];
+
 export default class HabitService {
   private database: Database;
   private userId = 'user';
@@ -72,10 +77,45 @@ export default class HabitService {
     this.userId = userId;
   }
 
+  /**
+   * Assign rows that predate per-account ownership to `userId`.
+   *
+   * Schema v5 added `user_id` without a backfill, so rows created before that
+   * migration carry `''`, and rows created after it but before the first login
+   * carry the `'user'` placeholder this service starts with. Neither belongs to
+   * anyone. Queries used to match `''` explicitly, which made those rows visible
+   * to *every* account that signed in on the device; claiming them once, for the
+   * first account to sign in, is what lets every query scope on the owner alone.
+   *
+   * Idempotent: once claimed there is nothing left to match. Returns the number
+   * of rows adopted. `'user'` is never a real account id — those are UUIDs — so
+   * this cannot capture another account's rows.
+   */
+  async claimLegacyRows(userId: string): Promise<number> {
+    if (!userId) {
+      return 0;
+    }
+    const unowned = Q.where('user_id', Q.oneOf(LEGACY_OWNER_IDS));
+    const [habits, logs] = await Promise.all([
+      this.database.get<Habit>('habits').query(unowned).fetch(),
+      this.database.get<HabitLog>('habit_logs').query(unowned).fetch(),
+    ]);
+    if (habits.length === 0 && logs.length === 0) {
+      return 0;
+    }
+    await this.database.write(async () => {
+      await this.database.batch(
+        ...habits.map(habit => habit.prepareUpdate(h => { h.userId = userId; })),
+        ...logs.map(log => log.prepareUpdate(l => { l.userId = userId; })),
+      );
+    });
+    return habits.length + logs.length;
+  }
+
   getActiveHabits(): Observable<Habit[]> {
     return this.database
       .get<Habit>('habits')
-      .query(Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')), Q.where('is_active', true), Q.sortBy('created_at', Q.asc))
+      .query(Q.where('user_id', this.userId), Q.where('is_active', true), Q.sortBy('created_at', Q.asc))
       .observeWithColumns([
         'impact',
         'friction',
@@ -92,7 +132,7 @@ export default class HabitService {
     // the UI.
     return this.database
       .get<Habit>('habits')
-      .query(Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')), Q.sortBy('created_at', Q.asc))
+      .query(Q.where('user_id', this.userId), Q.sortBy('created_at', Q.asc))
       .observeWithColumns([
         'is_active',
         'notifications_enabled',
@@ -105,7 +145,7 @@ export default class HabitService {
   }
 
   async toggleHabitActive(habitId: string): Promise<void> {
-    const habit = await this.database.get<Habit>('habits').find(habitId);
+    const habit = await this.getHabitById(habitId);
     await this.database.write(async () => {
       await habit.update(h => {
         h.isActive = !h.isActive;
@@ -206,7 +246,7 @@ export default class HabitService {
     enabled: boolean,
     time: string,
   ): Promise<void> {
-    const habit = await this.database.get<Habit>('habits').find(habitId);
+    const habit = await this.getHabitById(habitId);
     await this.database.write(async () => {
       await habit.update(h => {
         h.notificationsEnabled = enabled;
@@ -224,7 +264,7 @@ export default class HabitService {
       .query(
         Q.where('notifications_enabled', true),
         Q.where('is_active', true),
-        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('user_id', this.userId),
       )
       .fetch();
   }
@@ -239,7 +279,7 @@ export default class HabitService {
         .query(
           Q.where('habit_id', habitId),
           Q.where('completed_date', date),
-          Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+          Q.where('user_id', this.userId),
         )
         .fetch();
 
@@ -290,7 +330,7 @@ export default class HabitService {
   }
 
   async getHabitById(habitId: string): Promise<Habit> {
-    const habits = await this.database.get<Habit>('habits').query(Q.where('id', habitId), Q.or(Q.where('user_id', this.userId), Q.where('user_id', ''))).fetch();
+    const habits = await this.database.get<Habit>('habits').query(Q.where('id', habitId), Q.where('user_id', this.userId)).fetch();
     if (!habits[0]) throw new Error('Habit not found');
     return habits[0];
   }
@@ -304,7 +344,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
-        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('user_id', this.userId),
         Q.where('completed_date', Q.gte(startDate)),
         Q.where('completed_date', Q.lte(endDate)),
         Q.where('deleted_at', null),
@@ -321,7 +361,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('synced', false),
-        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('user_id', this.userId),
         Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
       )
       .fetch();
@@ -341,7 +381,7 @@ export default class HabitService {
   async getUnsyncedHabits(): Promise<Habit[]> {
     return this.database
       .get<Habit>('habits')
-      .query(Q.where('synced', false), Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')))
+      .query(Q.where('synced', false), Q.where('user_id', this.userId))
       .fetch();
   }
 
@@ -408,6 +448,7 @@ export default class HabitService {
         .get<HabitLog>('habit_logs')
         .query(
           Q.where('habit_id', Q.oneOf(habitIds)),
+          Q.where('user_id', this.userId),
           Q.where('synced', false),
           Q.where('retry_count', Q.gt(0)),
         )
@@ -430,8 +471,13 @@ export default class HabitService {
   async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean; impact: number; friction: number; keystone: number; time_cost: number}>): Promise<void> {
     await this.database.write(async () => {
       for (const remote of habits) {
+        // Look up by id regardless of owner. Scoping the lookup instead would
+        // miss another account's row and then fail on the duplicate primary
+        // key; a row we don't own is skipped, which is what the server does
+        // too (409 "Habit belongs to another user", routers/habits.py).
         let local: Habit | null = null;
         try { local = await this.database.get<Habit>('habits').find(remote.id); } catch { /* new row */ }
+        if (local && local.userId !== this.userId) continue;
         if (local) {
           if (!local.synced) continue; // never overwrite offline work
           await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; h.impact = remote.impact ?? 3; h.friction = remote.friction ?? 3; h.keystone = remote.keystone ?? 3; h.timeCost = remote.time_cost ?? 3; });
@@ -460,9 +506,15 @@ export default class HabitService {
       for (const remote of logs) {
         const existing = await this.database.get<HabitLog>('habit_logs').query(
           Q.where('habit_id', remote.habit_id), Q.where('completed_date', remote.completed_date),
-          Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+          Q.where('user_id', this.userId),
         ).fetch();
         if (existing.some(log => log.deletedAt == null)) continue;
+        // As above: never re-create an id another account already holds.
+        if (existing.length === 0) {
+          let foreign: HabitLog | null = null;
+          try { foreign = await this.database.get<HabitLog>('habit_logs').find(remote.id); } catch { /* free id */ }
+          if (foreign && foreign.userId !== this.userId) continue;
+        }
         const tombstone = existing[0];
         if (tombstone) {
           await tombstone.update(log => { log.deletedAt = null; log.synced = true; });
@@ -485,13 +537,13 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('synced', false),
-        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('user_id', this.userId),
         Q.where('retry_count', Q.lt(MAX_LOG_RETRIES)),
       )
       .observe();
     const habits$ = this.database
       .get<Habit>('habits')
-      .query(Q.where('synced', false))
+      .query(Q.where('synced', false), Q.where('user_id', this.userId))
       .observe();
     return combineLatest([logs$, habits$]).pipe(
       map(([logs, habits]) => logs.length + habits.length),
@@ -517,7 +569,7 @@ export default class HabitService {
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
-        Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('user_id', this.userId),
         Q.where('completed_date', Q.gte(cutoffDate)),
         Q.where('completed_date', Q.lte(asOfDate)),
         Q.where('deleted_at', null),

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -505,11 +505,20 @@ export default class HabitService {
     let streak = 0;
     let currentDate = asOfDate;
 
+    // Only fetch logs within the last 400 days to bound the query size.
+    // A streak longer than 400 days would be extremely rare, and this avoids
+    // scanning thousands of historical rows for long-running habits.
+    const cutoffDate = format(
+      subDays(new Date(asOfDate + 'T00:00:00'), 400),
+      'yyyy-MM-dd',
+    );
+
     const logs = await this.database
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
         Q.or(Q.where('user_id', this.userId), Q.where('user_id', '')),
+        Q.where('completed_date', Q.gte(cutoffDate)),
         Q.where('completed_date', Q.lte(asOfDate)),
         Q.where('deleted_at', null),
       )

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -172,6 +172,10 @@ export default class SyncService {
         name: habit.name,
         created_at_ms: habit.createdAt,
         is_active: habit.isActive,
+        impact: habit.impact,
+        friction: habit.friction,
+        keystone: habit.keystone,
+        time_cost: habit.timeCost,
       })),
     };
 

--- a/src/utils/habitScoring.ts
+++ b/src/utils/habitScoring.ts
@@ -1,0 +1,12 @@
+export type HabitRating = 1 | 2 | 3 | 4 | 5;
+
+export function calculateHabitScore(
+  impact: number,
+  friction: number,
+  keystone: number,
+  timeCost: number,
+): number {
+  const rawMinusMinimum =
+    impact + (6 - friction) + keystone + (6 - timeCost) - 4;
+  return Math.floor((100 * rawMinusMinimum + 8) / 16);
+}

--- a/src/utils/leaderboardTimeWindow.ts
+++ b/src/utils/leaderboardTimeWindow.ts
@@ -1,0 +1,45 @@
+import {
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+} from 'date-fns';
+
+export type LeaderboardPeriod = 'daily' | 'weekly' | 'monthly' | 'yearly';
+
+export interface LeaderboardTimeWindow {
+  start: number;
+  end: number;
+}
+
+/** Return inclusive epoch-millisecond boundaries for the selected UI tab. */
+export function getLeaderboardTimeWindow(
+  period: LeaderboardPeriod,
+  now = new Date(),
+): LeaderboardTimeWindow {
+  let start: Date;
+  let end: Date;
+  switch (period) {
+    case 'daily':
+      start = startOfDay(now);
+      end = endOfDay(now);
+      break;
+    case 'weekly':
+      start = startOfWeek(now, {weekStartsOn: 1});
+      end = endOfWeek(now, {weekStartsOn: 1});
+      break;
+    case 'monthly':
+      start = startOfMonth(now);
+      end = endOfMonth(now);
+      break;
+    case 'yearly':
+      start = startOfYear(now);
+      end = endOfYear(now);
+      break;
+  }
+  return {start: start.getTime(), end: end.getTime()};
+}


### PR DESCRIPTION
## Summary
- implement the v1 habit ratings, derived scores, metrics endpoint, and Android rating flow
- add the dynamic head-to-head leaderboard **backend** aggregation with username
  identity (the leaderboard screen itself is still open, #107)
- add CI Alembic verification and document restricted-sandbox backend verification
- fix the existing Alembic revision and SQLite compatibility defects

### Blockers fixed before merge
- **#120** — migrations 004/006 failed on MySQL/MariaDB (`existing_type` missing on
  `batch.alter_column`, which only degrades to a real `MODIFY COLUMN` outside SQLite).
  CI now gates on a `mariadb:11` service, from an empty schema *and* from revision 003
  with rows present.
- **#119** — migration 004 stranded every pre-existing habit and log on an
  unauthenticatable sentinel user. Adds `python -m app.claim_legacy --email …` plus a
  deploy runbook; production holds data that needs this step.
- **#123** — legacy `user_id = ''` rows were matched by every account on a shared
  device. Rows are now claimed once at sign-in and every query scopes on the owner
  alone, including five that had no ownership filter at all.
- **#124** — the red `Unit Tests` check was the coverage gate, not a failing test.

## Verification
- `npx jest --coverage --ci --forceExit` — exits 0, 321 passed / 19 suites;
  lines 81.88%, functions 83.90%, branches 64.87% (gates 80/80/55, none lowered)
- `npm run lint` — 0 errors; `npx tsc --noEmit` — clean
- `pytest --cov=app --cov-fail-under=85` — 68 passed, 89.60% coverage
- Migrations against a real `mariadb:11` container: empty schema → head, and
  003 + seeded rows → head, with row counts asserted to survive
- `DATABASE_URL="mysql+pymysql://…" alembic upgrade head --sql` compiles clean
- SQLite migration chain still passes
- Legacy claim exercised end-to-end on MariaDB: 2 habits + 3 logs moved off the
  sentinel, second run a no-op

## Follow-ups filed
#125 (shared-secret `/auth/token` writes orphan rows), #126 (004 downgrade breaks on
SQLite), #127 (failed rating save is silent), #128 (unused `leaderboardTimeWindow`)

Closes #112
Closes #113
Closes #114
Closes #117
Closes #119
Closes #120
Closes #122
Closes #123
Closes #124

Part of #105 — this lands the rating storage/sync (#112), the scoring domain logic
(#113) and the server metrics endpoint (#114). The epic stays open for #115 and
#116.
Part of #115 — ratings are editable from the Stats screen, but the create-habit
flow (`src/screens/CreateHabitModal.tsx`) does not yet expose the four controls.
Related to #107 — this adds the head-to-head API contract and backend, not the
leaderboard screen. #107 remains open for the UI; see also #128 for the client
helper and service method that currently have no caller.
