### PR TITLE
fix: retire the shared-secret /auth/token path that writes orphan rows

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,11 +68,33 @@ cp .env.example .env
 docker compose up -d
 ```
 
+### Authentication: one path, and it belongs to a real account
+
+`POST /auth/token` — the shared-secret endpoint — is **retired and returns 410
+Gone**. It used to mint a token whose `sub` was the literal string `"user"`, an
+owner that is not a row in `users`, so everything synced under it was invisible
+to every real account; the mobile client also re-minted one on any background
+401, silently replacing a signed-in user's real token. See issue #125.
+
+The only ways to obtain a token are now `POST /auth/register` and
+`POST /auth/login`, both of which return the account's own UUID as `sub`. Two
+guards keep it that way:
+
+* every authenticated route resolves `sub` against `users` and returns 401 if
+  it names no account (`app/middleware/auth.py`, `current_user`);
+* `habits.user_id` and `habit_logs.user_id` are foreign keys to `users.id`
+  (migration `007`).
+
+**This is a breaking change for any client that authenticates with the shared
+secret.** Such a client cannot sync after this deploys until it is updated and
+the user signs in. Sequence the rollout accordingly: migrate, register, claim,
+then ship the new app build.
+
 ### Legacy data: claiming pre-multi-user habits and logs
 
 **This applies to any deployment that ran before the multi-user migration (004),
-including production, which held real habits and logs at the time of this change.
-Skip it only for a brand-new, empty database.**
+including production, which held 14 habits and 150 habit_logs at revision `003`
+when this was written. Skip it only for a brand-new, empty database.**
 
 Migration `004` adds ownership to `habits` and `habit_logs` and assigns every
 pre-existing row to a sentinel user, `00000000-0000-0000-0000-000000000000`. That
@@ -111,6 +133,25 @@ The claim runs in one transaction and is idempotent — a second run reports zer
 rows. It moves ownership only; it never deletes habits or logs. It refuses an
 email that is not already registered, so a typo fails loudly rather than
 stranding the data under a new empty account.
+
+#### Orphaned rows, and migration 007
+
+A deployment that ran migration `004` *and* then accepted a shared-secret sync
+also holds rows owned by `"user"` — an id that names no account at all, so the
+sentinel sweep above does not match them. Migration `007` refuses to add the
+ownership foreign keys while any such row exists, and names the counts it found.
+Add `--include-orphans` to claim them too:
+
+```bash
+docker compose exec api python -m app.claim_legacy \
+  --email you@example.com --include-orphans --dry-run   # reports
+docker compose exec api python -m app.claim_legacy \
+  --email you@example.com --include-orphans             # reassigns
+```
+
+Then re-run `alembic upgrade head`. Production at the time of writing was still
+at revision `003` and had never issued a `sub="user"` token against a `004`
+schema, so it holds no orphans — this is for deployments that ran ahead of it.
 
 ### Exposing the API with Cloudflare Tunnels
 

--- a/backend/alembic/versions/007_user_ownership_fk.py
+++ b/backend/alembic/versions/007_user_ownership_fk.py
@@ -1,0 +1,84 @@
+"""enforce habit ownership with foreign keys to users
+
+Until now nothing stopped a row in ``habits`` or ``habit_logs`` naming an owner
+absent from ``users``. The retired shared-secret ``/auth/token`` path minted
+tokens whose subject was the literal string "user", and every write stamped that
+straight into ``user_id`` -- data owned by an account that does not exist and
+therefore visible to nobody. See issue #125.
+"""
+
+from typing import Sequence, Union
+
+from alembic import context, op
+import sqlalchemy as sa
+
+revision: str = "007_user_ownership_fk"
+down_revision: Union[str, None] = "006_usernames"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLES = ("habits", "habit_logs")
+CONSTRAINTS = {
+    "habits": "fk_habits_user_id_users",
+    "habit_logs": "fk_habit_logs_user_id_users",
+}
+
+
+def _count_orphans(bind, table: str) -> int:
+    return bind.scalar(
+        sa.text(
+            f"SELECT COUNT(*) FROM {table} t "
+            "LEFT JOIN users u ON t.user_id = u.id WHERE u.id IS NULL"
+        )
+    )
+
+
+def _check_for_orphans() -> None:
+    """Refuse rather than repair.
+
+    Silently deleting orphans would destroy data and silently reassigning them
+    would hand one account another's habits; either is worse than stopping and
+    letting an operator decide. The claim tool is the supported repair, and its
+    --dry-run reports before it writes.
+    """
+    if context.is_offline_mode():
+        # `alembic upgrade --sql` has no connection to count rows over. The
+        # database still enforces the constraint when the emitted DDL is
+        # applied, so the check is deferred rather than skipped.
+        op.execute(
+            "-- 007 preflight skipped in offline mode: run "
+            "`python -m app.claim_legacy --email you@example.com "
+            "--include-orphans --dry-run` first if this deployment ever "
+            "accepted a shared-secret sync."
+        )
+        return
+
+    bind = op.get_bind()
+    orphans = {table: _count_orphans(bind, table) for table in TABLES}
+    if any(orphans.values()):
+        summary = ", ".join(f"{table}={count}" for table, count in orphans.items())
+        raise RuntimeError(
+            "Cannot add the ownership foreign keys: rows exist whose user_id "
+            f"names no account in users ({summary}). Reassign them first with:\n"
+            "    python -m app.claim_legacy --email you@example.com "
+            "--include-orphans --dry-run\n"
+            "then re-run without --dry-run, and repeat this migration."
+        )
+
+
+def upgrade() -> None:
+    _check_for_orphans()
+
+    for table in TABLES:
+        # SQLite cannot ALTER TABLE ... ADD CONSTRAINT; batch mode recreates the
+        # table instead. On MySQL/MariaDB it degrades to a real ADD CONSTRAINT.
+        with op.batch_alter_table(table) as batch:
+            batch.create_foreign_key(
+                CONSTRAINTS[table], "users", ["user_id"], ["id"]
+            )
+
+
+def downgrade() -> None:
+    for table in TABLES:
+        with op.batch_alter_table(table) as batch:
+            batch.drop_constraint(CONSTRAINTS[table], type_="foreignkey")

--- a/backend/app/claim_legacy.py
+++ b/backend/app/claim_legacy.py
@@ -13,6 +13,13 @@ migrating and after registering the account that should own the data:
 
 It is idempotent: a second run matches zero rows. Use ``--dry-run`` to see the
 counts without writing anything.
+
+``--include-orphans`` widens the sweep to every row whose ``user_id`` names no
+account at all, not just the migration's sentinel. That is what rescues rows
+written by the retired shared-secret ``/auth/token`` path, whose token subject
+was the literal string ``"user"`` (issue #125). Migration ``007`` refuses to add
+the ownership foreign keys while any such row exists, so this is also the repair
+step that unblocks it.
 """
 
 from __future__ import annotations
@@ -43,15 +50,35 @@ class ClaimResult:
     habit_logs: int
     legacy_user_removed: bool
     dry_run: bool
+    include_orphans: bool = False
+    orphan_habits: int = 0
+    orphan_habit_logs: int = 0
 
 
-async def _count_legacy(session: AsyncSession, model: type) -> int:
-    stmt = select(func.count()).select_from(model).where(model.user_id == LEGACY_USER_ID)
+def _is_orphan(model: type):
+    """Rows whose owner is absent from ``users`` entirely.
+
+    Disjoint from the sentinel predicate: the sentinel *does* have a ``users``
+    row until this command removes it, so the two never match the same row.
+    """
+    return ~model.user_id.in_(select(User.id))
+
+
+async def _count_where(session: AsyncSession, model: type, predicate) -> int:
+    stmt = select(func.count()).select_from(model).where(predicate)
     return await session.scalar(stmt) or 0
 
 
+async def _count_legacy(session: AsyncSession, model: type) -> int:
+    return await _count_where(session, model, model.user_id == LEGACY_USER_ID)
+
+
 async def claim_legacy_data(
-    session: AsyncSession, email: str, *, dry_run: bool = False
+    session: AsyncSession,
+    email: str,
+    *,
+    dry_run: bool = False,
+    include_orphans: bool = False,
 ) -> ClaimResult:
     """Move every legacy-owned habit and log to the account registered as ``email``.
 
@@ -73,6 +100,10 @@ async def claim_legacy_data(
 
     habits = await _count_legacy(session, Habit)
     habit_logs = await _count_legacy(session, HabitLog)
+    orphan_habits = orphan_habit_logs = 0
+    if include_orphans:
+        orphan_habits = await _count_where(session, Habit, _is_orphan(Habit))
+        orphan_habit_logs = await _count_where(session, HabitLog, _is_orphan(HabitLog))
     legacy_user = await session.scalar(select(User).where(User.id == LEGACY_USER_ID))
 
     if dry_run:
@@ -83,6 +114,9 @@ async def claim_legacy_data(
             habit_logs=habit_logs,
             legacy_user_removed=False,
             dry_run=True,
+            include_orphans=include_orphans,
+            orphan_habits=orphan_habits,
+            orphan_habit_logs=orphan_habit_logs,
         )
 
     # One transaction: either ownership moves wholesale or nothing does.
@@ -92,6 +126,15 @@ async def claim_legacy_data(
     await session.execute(
         update(HabitLog).where(HabitLog.user_id == LEGACY_USER_ID).values(user_id=user.id)
     )
+    if include_orphans:
+        # Runs after the sentinel move and before the sentinel row is deleted,
+        # so the two sweeps stay disjoint and nothing is counted twice.
+        await session.execute(
+            update(Habit).where(_is_orphan(Habit)).values(user_id=user.id)
+        )
+        await session.execute(
+            update(HabitLog).where(_is_orphan(HabitLog)).values(user_id=user.id)
+        )
     if legacy_user is not None:
         # Nothing can log in as it and it now owns no rows, so leaving it would
         # only leave a login-shaped row that no one can use.
@@ -105,6 +148,9 @@ async def claim_legacy_data(
         habit_logs=habit_logs,
         legacy_user_removed=legacy_user is not None,
         dry_run=False,
+        include_orphans=include_orphans,
+        orphan_habits=orphan_habits,
+        orphan_habit_logs=orphan_habit_logs,
     )
 
 
@@ -116,6 +162,13 @@ def format_result(result: ClaimResult) -> str:
         f"  habits     : {result.habits:>4} rows -> {result.email}",
         f"  habit_logs : {result.habit_logs:>4} rows -> {result.email}",
     ]
+    if result.include_orphans:
+        lines += [
+            "",
+            "orphans (user_id names no account):",
+            f"  habits     : {result.orphan_habits:>4} rows -> {result.email}",
+            f"  habit_logs : {result.orphan_habit_logs:>4} rows -> {result.email}",
+        ]
     if result.dry_run:
         lines += ["", "dry run: nothing was written."]
     else:
@@ -129,13 +182,15 @@ def format_result(result: ClaimResult) -> str:
     return "\n".join(lines)
 
 
-async def _run(email: str, *, dry_run: bool) -> ClaimResult:
+async def _run(email: str, *, dry_run: bool, include_orphans: bool) -> ClaimResult:
     # Imported here rather than at module scope: app.database builds an engine
     # from settings on import, which tests supply for themselves.
     from app.database import async_session
 
     async with async_session() as session:
-        return await claim_legacy_data(session, email, dry_run=dry_run)
+        return await claim_legacy_data(
+            session, email, dry_run=dry_run, include_orphans=include_orphans
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -150,10 +205,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--dry-run", action="store_true", help="report the counts without writing"
     )
+    parser.add_argument(
+        "--include-orphans",
+        action="store_true",
+        help=(
+            "also claim rows whose user_id names no account at all -- e.g. those "
+            "written by the retired shared-secret token, whose subject was 'user'"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
-        result = asyncio.run(_run(args.email, dry_run=args.dry_run))
+        result = asyncio.run(
+            _run(args.email, dry_run=args.dry_run, include_orphans=args.include_orphans)
+        )
     except ClaimError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/backend/app/middleware/auth.py
+++ b/backend/app/middleware/auth.py
@@ -1,8 +1,12 @@
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.database import get_db
+from app.models import User
 
 _scheme = HTTPBearer()
 
@@ -29,3 +33,24 @@ def user_id_from_token(payload: dict) -> str:
     if not isinstance(user_id, str) or not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token subject missing")
     return user_id
+
+
+async def current_user(
+    token: dict = Depends(require_token),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Resolve the token subject to a real account.
+
+    A well-formed signature is not enough: every write stamps ``user_id`` from
+    the subject, so a subject naming no row in ``users`` produces data owned by
+    nobody and visible to nobody. Rejecting it here means no request handler has
+    to remember the check, and a token for a since-deleted account fails with a
+    401 instead of an integrity error.
+    """
+    user = await db.scalar(select(User).where(User.id == user_id_from_token(token)))
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token subject is not a known account",
+        )
+    return user

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -22,7 +22,7 @@ class User(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
-    username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False, default="user")
+    username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
 
@@ -33,7 +33,9 @@ class Habit(Base):
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    user_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, default="user")
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id"), index=True, nullable=False
+    )
     name: Mapped[str] = mapped_column(String(50), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow
@@ -56,7 +58,9 @@ class HabitLog(Base):
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    user_id: Mapped[str] = mapped_column(String(36), index=True, nullable=False, default="user")
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id"), index=True, nullable=False
+    )
     habit_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("habits.id"), index=True, nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -67,13 +67,22 @@ async def register(body: RegisterRequest, db: AsyncSession = Depends(get_db)) ->
     return _token(user.id)
 
 
-@router.post("/token", response_model=TokenResponse)
-async def issue_token(body: TokenRequest) -> TokenResponse:
-    if body.secret is not None:
-        if not hmac.compare_digest(body.secret, settings.jwt_secret):
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid secret")
-        return _token("user")
-    raise HTTPException(status_code=422, detail="Email and password are required")
+# Retired. This endpoint used to mint a token whose ``sub`` was the literal
+# string "user" in exchange for the server's JWT secret. That subject names no
+# row in ``users``, so everything synced under it was owned by an account that
+# does not exist -- and the mobile client re-minted one on any background 401,
+# overwriting a signed-in user's real token. The route is kept as a 410 for one
+# release so builds still in the field get a diagnosable answer rather than a
+# bare 404. See issue #125.
+@router.post("/token")
+async def issue_token() -> None:
+    raise HTTPException(
+        status_code=status.HTTP_410_GONE,
+        detail=(
+            "The shared-secret token endpoint has been retired. "
+            "Sign in with POST /auth/login using email and password."
+        ),
+    )
 
 
 @router.post("/login", response_model=TokenResponse)

--- a/backend/app/routers/habits.py
+++ b/backend/app/routers/habits.py
@@ -5,8 +5,8 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.middleware.auth import require_token, user_id_from_token
-from app.models import Habit, HabitLog
+from app.middleware.auth import current_user
+from app.models import Habit, HabitLog, User
 from app.schemas import (
     HabitCreate,
     HabitRead,
@@ -40,10 +40,10 @@ def _read_habit(habit: Habit) -> HabitRead:
 @router.get("/", response_model=list[HabitRead])
 async def list_habits(
     active: bool | None = Query(None),
-    token: dict = Depends(require_token),
+    user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    stmt = select(Habit).where(Habit.user_id == user_id_from_token(token)).order_by(Habit.created_at)
+    stmt = select(Habit).where(Habit.user_id == user.id).order_by(Habit.created_at)
     if active is not None:
         stmt = stmt.where(Habit.is_active == active)
     result = await db.execute(stmt)
@@ -51,9 +51,9 @@ async def list_habits(
 
 
 @router.post("/", response_model=HabitRead, status_code=status.HTTP_201_CREATED)
-async def create_habit(body: HabitCreate, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+async def create_habit(body: HabitCreate, user: User = Depends(current_user), db: AsyncSession = Depends(get_db)):
     habit = Habit(
-        name=body.name, user_id=user_id_from_token(token), impact=body.impact,
+        name=body.name, user_id=user.id, impact=body.impact,
         friction=body.friction, keystone=body.keystone, time_cost=body.time_cost,
     )
     db.add(habit)
@@ -63,16 +63,16 @@ async def create_habit(body: HabitCreate, token: dict = Depends(require_token), 
 
 
 @router.get("/sync", response_model=HabitSyncPullResponse)
-async def pull_habits(token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
-    result = await db.scalars(select(Habit).where(Habit.user_id == user_id_from_token(token)).order_by(Habit.created_at))
+async def pull_habits(user: User = Depends(current_user), db: AsyncSession = Depends(get_db)):
+    result = await db.scalars(select(Habit).where(Habit.user_id == user.id).order_by(Habit.created_at))
     return HabitSyncPullResponse(habits=[_read_habit(habit) for habit in result])
 
 
 @router.patch("/{habit_id}", response_model=HabitRead)
 async def update_habit(
-    habit_id: str, body: HabitUpdate, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)
+    habit_id: str, body: HabitUpdate, user: User = Depends(current_user), db: AsyncSession = Depends(get_db)
 ):
-    habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id_from_token(token)))
+    habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user.id))
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")
     for field, value in body.model_dump(exclude_unset=True).items():
@@ -83,13 +83,13 @@ async def update_habit(
 
 
 @router.post("/sync", response_model=HabitSyncResponse)
-async def sync_habits(body: HabitSyncRequest, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+async def sync_habits(body: HabitSyncRequest, user: User = Depends(current_user), db: AsyncSession = Depends(get_db)):
     """
     Upsert habits using client-supplied IDs. The local-first client owns IDs
     and pushes habit creates/updates here so subsequent log syncs can resolve
     their habit_id references.
     """
-    user_id = user_id_from_token(token)
+    user_id = user.id
     synced_ids: list[str] = []
     for entry in body.habits:
         existing = await db.scalar(select(Habit).where(Habit.id == entry.id, Habit.user_id == user_id))
@@ -128,13 +128,13 @@ async def get_habit_metrics(
     start: date = Query(...),
     end: date = Query(...),
     as_of: date = Query(...),
-    token: dict = Depends(require_token),
+    user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ):
     if start > end:
         raise HTTPException(status_code=422, detail="start must not be after end")
 
-    user_id = user_id_from_token(token)
+    user_id = user.id
     habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id))
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.middleware.auth import require_token, user_id_from_token
+from app.middleware.auth import current_user
 from app.models import Habit, HabitLog, User
 from app.schemas import (
     HeadToHeadResponse,
@@ -42,10 +42,10 @@ async def head_to_head(
     opponent_id: str = Query(..., min_length=1),
     start: int = Query(..., description="UTC epoch boundary in milliseconds"),
     end: int = Query(..., description="UTC epoch boundary in milliseconds"),
-    token: dict = Depends(require_token),
+    user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ) -> HeadToHeadResponse:
-    current_user_id = user_id_from_token(token)
+    current_user_id = user.id
     if opponent_id == current_user_id:
         raise HTTPException(status_code=422, detail="opponent_id must identify another user")
 

--- a/backend/app/routers/logs.py
+++ b/backend/app/routers/logs.py
@@ -8,8 +8,8 @@ from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
-from app.middleware.auth import require_token, user_id_from_token
-from app.models import Habit, HabitLog
+from app.middleware.auth import current_user
+from app.models import Habit, HabitLog, User
 from app.schemas import HabitLogRead, SyncError, SyncRequest, SyncResponse
 
 router = APIRouter(prefix="/logs", tags=["logs"])
@@ -50,9 +50,9 @@ def _upsert_habit_log_stmt(dialect_name: str, values: list[dict[str, Any]]):
 
 
 @router.post("/sync", response_model=SyncResponse)
-async def sync_logs(body: SyncRequest, token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+async def sync_logs(body: SyncRequest, user: User = Depends(current_user), db: AsyncSession = Depends(get_db)):
     errors: list[SyncError] = []
-    user_id = user_id_from_token(token)
+    user_id = user.id
 
     if not body.logs:
         return SyncResponse(synced=0, errors=errors)
@@ -101,10 +101,10 @@ async def sync_logs(body: SyncRequest, token: dict = Depends(require_token), db:
 
 
 @router.get("/sync", response_model=list[HabitLogRead])
-async def pull_logs(token: dict = Depends(require_token), db: AsyncSession = Depends(get_db)):
+async def pull_logs(user: User = Depends(current_user), db: AsyncSession = Depends(get_db)):
     result = await db.scalars(
         select(HabitLog)
-        .where(HabitLog.user_id == user_id_from_token(token), HabitLog.deleted_at.is_(None))
+        .where(HabitLog.user_id == user.id, HabitLog.deleted_at.is_(None))
         .order_by(HabitLog.completed_date)
     )
     return list(result)
@@ -115,11 +115,11 @@ async def get_logs(
     habit_id: str,
     start: date = Query(...),
     end: date = Query(...),
-    token: dict = Depends(require_token),
+    user: User = Depends(current_user),
     db: AsyncSession = Depends(get_db),
 ):
     # Verify habit exists
-    user_id = user_id_from_token(token)
+    user_id = user.id
     habit = await db.scalar(select(Habit).where(Habit.id == habit_id, Habit.user_id == user_id))
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -145,7 +145,6 @@ class SyncResponse(BaseModel):
 # ── Auth ────────────────────────────────────────────────
 
 class TokenRequest(BaseModel):
-    secret: str | None = None
     email: str | None = None
     password: str | None = None
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,19 +10,32 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from jose import jwt
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 from app.database import get_db
 from app.main import app
-from app.models import Base
+from app.models import Base, User
 
 TEST_DB_URL = "sqlite+aiosqlite://"
+
+# The account every authenticated test acts as. It is a real row in ``users``:
+# habits.user_id and habit_logs.user_id are foreign keys to it, and the API
+# rejects a token whose subject names no account.
+TEST_USER_ID = "user"
 
 
 @pytest_asyncio.fixture
 async def db_session():
     engine = create_async_engine(TEST_DB_URL, echo=False)
+    # SQLite ignores foreign keys unless asked, which would let the suite pass
+    # while the constraints added in migration 007 went unexercised.
+    event.listen(
+        engine.sync_engine,
+        "connect",
+        lambda dbapi_conn, _record: dbapi_conn.execute("PRAGMA foreign_keys=ON"),
+    )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -45,10 +58,24 @@ async def client(db_session: AsyncSession):
     app.dependency_overrides.clear()
 
 
-@pytest.fixture
-def auth_header() -> dict[str, str]:
+@pytest_asyncio.fixture
+async def auth_header(db_session: AsyncSession) -> dict[str, str]:
+    """A bearer token for a real account.
+
+    merge() rather than add() so a test that wants its own email or display
+    name can merge over the same id without colliding on the primary key.
+    """
+    await db_session.merge(
+        User(
+            id=TEST_USER_ID,
+            email="user@test.invalid",
+            username="user",
+            password_hash="x",
+        )
+    )
+    await db_session.commit()
     payload = {
-        "sub": "user",
+        "sub": TEST_USER_ID,
         "exp": datetime.now(timezone.utc) + timedelta(hours=1),
     }
     token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
@@ -57,8 +84,9 @@ def auth_header() -> dict[str, str]:
 
 @pytest.fixture
 def expired_auth_header() -> dict[str, str]:
+    # No users row needed: this token never gets past signature validation.
     payload = {
-        "sub": "user",
+        "sub": TEST_USER_ID,
         "exp": datetime.now(timezone.utc) - timedelta(hours=1),
     }
     token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,38 +1,31 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import AsyncClient
 from jose import jwt
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from sqlalchemy import func, select
+
+from app.models import Habit, User
 
 
 @pytest.mark.asyncio
-async def test_issue_token_valid_secret(client: AsyncClient):
+async def test_token_endpoint_is_retired(client: AsyncClient):
+    """The shared-secret path minted sub="user" -- an owner absent from users."""
     resp = await client.post("/auth/token", json={"secret": settings.jwt_secret})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert "access_token" in data
-    assert data["token_type"] == "bearer"
-    # Verify the token is a valid JWT
-    payload = jwt.decode(
-        data["access_token"],
-        settings.jwt_secret,
-        algorithms=[settings.jwt_algorithm],
-    )
-    assert payload["sub"] == "user"
-    assert "exp" in payload
+    assert resp.status_code == 410
+    assert "/auth/login" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio
-async def test_issue_token_invalid_secret(client: AsyncClient):
-    resp = await client.post("/auth/token", json={"secret": "wrong-secret"})
-    assert resp.status_code == 401
-    assert "Invalid secret" in resp.json()["detail"]
-
-
-@pytest.mark.asyncio
-async def test_issue_token_missing_secret(client: AsyncClient):
-    resp = await client.post("/auth/token", json={})
-    assert resp.status_code == 422
+async def test_token_endpoint_is_retired_for_every_body(client: AsyncClient):
+    # No secret is privileged any more, and no body shape revives the route.
+    for body in ({}, {"secret": "wrong-secret"}, {"email": "a@b.co", "password": "x" * 8}):
+        resp = await client.post("/auth/token", json=body)
+        assert resp.status_code == 410, body
 
 
 @pytest.mark.asyncio
@@ -52,3 +45,145 @@ async def test_protected_endpoint_invalid_token(client: AsyncClient):
     headers = {"Authorization": "Bearer not-a-real-jwt-token"}
     resp = await client.get("/habits/", headers=headers)
     assert resp.status_code == 401
+
+
+# ── The token subject must name a real account (issue #125) ─────────────
+
+
+def _token_for(subject: str) -> dict[str, str]:
+    token = jwt.encode(
+        {"sub": subject, "exp": datetime.now(timezone.utc) + timedelta(hours=1)},
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_subject_cannot_read(client: AsyncClient):
+    """A correctly signed token is not enough; the subject must exist."""
+    resp = await client.get("/habits/", headers=_token_for("user"))
+    assert resp.status_code == 401
+    assert "not a known account" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_subject_cannot_write(client: AsyncClient, db_session: AsyncSession):
+    headers = _token_for("user")
+
+    created = await client.post("/habits/", json={"name": "Orphan"}, headers=headers)
+    synced = await client.post(
+        "/habits/sync",
+        json={"habits": [{"id": "h-orphan", "name": "Orphan", "created_at_ms": 0}]},
+        headers=headers,
+    )
+
+    assert created.status_code == 401
+    assert synced.status_code == 401
+    # The whole point: nothing was written under an owner that does not exist.
+    assert await db_session.scalar(select(func.count()).select_from(Habit)) == 0
+
+
+@pytest.mark.asyncio
+async def test_database_rejects_a_habit_whose_owner_does_not_exist(
+    db_session: AsyncSession,
+):
+    """Belt to the dependency's braces -- migration 007's foreign key."""
+    db_session.add(Habit(id="h-orphan", user_id="user", name="Orphan"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+# ── Every minted token names a real account ─────────────────────────────
+
+
+async def _subject_of(resp) -> str:
+    return jwt.decode(
+        resp.json()["access_token"],
+        settings.jwt_secret,
+        algorithms=[settings.jwt_algorithm],
+    )["sub"]
+
+
+@pytest.mark.asyncio
+async def test_register_mints_a_token_for_a_real_account(
+    client: AsyncClient, db_session: AsyncSession
+):
+    resp = await client.post(
+        "/auth/register", json={"email": "New@Example.com", "password": "correct horse"}
+    )
+
+    assert resp.status_code == 201
+    subject = await _subject_of(resp)
+    user = await db_session.scalar(select(User).where(User.id == subject))
+    assert user is not None
+    assert user.email == "new@example.com"
+    assert user.username == "new"  # derived from the normalised email
+
+    # And that token actually works end to end.
+    created = await client.post(
+        "/habits/", json={"name": "Read"}, headers={"Authorization": f"Bearer {resp.json()['access_token']}"}
+    )
+    assert created.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_login_mints_a_token_for_the_same_account(
+    client: AsyncClient, db_session: AsyncSession
+):
+    registered = await client.post(
+        "/auth/register", json={"email": "me@example.com", "password": "correct horse"}
+    )
+
+    logged_in = await client.post(
+        "/auth/login", json={"email": "  Me@Example.com ", "password": "correct horse"}
+    )
+
+    assert logged_in.status_code == 200
+    assert await _subject_of(logged_in) == await _subject_of(registered)
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_a_bad_password(client: AsyncClient):
+    await client.post(
+        "/auth/register", json={"email": "me@example.com", "password": "correct horse"}
+    )
+
+    resp = await client.post(
+        "/auth/login", json={"email": "me@example.com", "password": "wrong horse"}
+    )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_requires_both_fields(client: AsyncClient):
+    resp = await client.post("/auth/login", json={"email": "me@example.com"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_a_malformed_email(client: AsyncClient):
+    resp = await client.post(
+        "/auth/register", json={"email": "not-an-email", "password": "correct horse"}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_a_duplicate_email_or_username(client: AsyncClient):
+    await client.post(
+        "/auth/register",
+        json={"email": "me@example.com", "password": "correct horse", "username": "Taken"},
+    )
+
+    same_email = await client.post(
+        "/auth/register", json={"email": "Me@example.com", "password": "correct horse"}
+    )
+    same_username = await client.post(
+        "/auth/register",
+        json={"email": "other@example.com", "password": "correct horse", "username": "Taken"},
+    )
+
+    assert same_email.status_code == 409
+    assert same_username.status_code == 409

--- a/backend/tests/test_claim_legacy.py
+++ b/backend/tests/test_claim_legacy.py
@@ -104,12 +104,20 @@ def _register(db_path: pathlib.Path, email: str) -> str:
     return asyncio.run(_create())
 
 
-def _claim(db_path: pathlib.Path, email: str, *, dry_run: bool = False):
+def _claim(
+    db_path: pathlib.Path,
+    email: str,
+    *,
+    dry_run: bool = False,
+    include_orphans: bool = False,
+):
     async def _run():
         engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
         async with factory() as session:
-            result = await claim_legacy_data(session, email, dry_run=dry_run)
+            result = await claim_legacy_data(
+                session, email, dry_run=dry_run, include_orphans=include_orphans
+            )
         await engine.dispose()
         return result
 
@@ -296,3 +304,134 @@ def test_cli_dry_run_writes_nothing(cli_db, capsys):
     assert exit_code == 0
     assert "dry run" in capsys.readouterr().out
     assert _owners(cli_db, "habits") == {LEGACY_USER_ID: len(PRE_004_HABITS)}
+
+
+# ── Orphans left by the retired shared-secret token (issue #125) ────────
+
+
+ORPHAN_OWNER = "user"
+
+
+def _insert_orphan(db_path: pathlib.Path, owner: str = ORPHAN_OWNER) -> None:
+    """Write a habit and a log owned by an account that does not exist.
+
+    This is exactly what the shared-secret ``/auth/token`` path produced: its
+    token subject was the literal string "user". A plain sqlite3 connection
+    leaves ``PRAGMA foreign_keys`` off, which is what lets this reproduce rows
+    written before migration 007 added the constraint.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO habits (id, name, created_at, is_active, user_id, "
+        "impact, friction, keystone, time_cost) VALUES (?, ?, ?, 1, ?, 3, 3, 3, 3)",
+        ("orphan-h", "Orphaned", "2026-08-15 00:00:00", owner),
+    )
+    conn.execute(
+        "INSERT INTO habit_logs (id, habit_id, completed_date, synced_at, user_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("orphan-l", "orphan-h", "2026-08-15", "2026-08-15 00:00:00", owner),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_default_claim_leaves_orphans_alone(migrated_db):
+    """Without the flag the sweep stays exactly as #119 documented it."""
+    _insert_orphan(migrated_db)
+    user_id = _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "owner@example.com")
+
+    assert (result.orphan_habits, result.orphan_habit_logs) == (0, 0)
+    assert _owners(migrated_db, "habits") == {
+        user_id: len(PRE_004_HABITS),
+        ORPHAN_OWNER: 1,
+    }
+
+
+def test_include_orphans_dry_run_reports_without_writing(migrated_db):
+    _insert_orphan(migrated_db)
+    _register(migrated_db, "owner@example.com")
+
+    result = _claim(
+        migrated_db, "owner@example.com", dry_run=True, include_orphans=True
+    )
+
+    assert (result.orphan_habits, result.orphan_habit_logs) == (1, 1)
+    rendered = format_result(result)
+    assert "orphans (user_id names no account)" in rendered
+    assert "dry run" in rendered
+    assert _owners(migrated_db, "habits") == {
+        LEGACY_USER_ID: len(PRE_004_HABITS),
+        ORPHAN_OWNER: 1,
+    }
+
+
+def test_include_orphans_claims_sentinel_and_orphan_rows_without_double_counting(
+    migrated_db,
+):
+    _insert_orphan(migrated_db)
+    user_id = _register(migrated_db, "owner@example.com")
+
+    result = _claim(migrated_db, "owner@example.com", include_orphans=True)
+
+    # The sentinel has a users row until this command deletes it, so the two
+    # sweeps are disjoint and neither count includes the other's rows.
+    assert (result.habits, result.habit_logs) == (len(PRE_004_HABITS), len(PRE_004_LOGS))
+    assert (result.orphan_habits, result.orphan_habit_logs) == (1, 1)
+    assert _owners(migrated_db, "habits") == {user_id: len(PRE_004_HABITS) + 1}
+    assert _owners(migrated_db, "habit_logs") == {user_id: len(PRE_004_LOGS) + 1}
+
+
+def test_include_orphans_is_idempotent(migrated_db):
+    _insert_orphan(migrated_db)
+    _register(migrated_db, "owner@example.com")
+    _claim(migrated_db, "owner@example.com", include_orphans=True)
+
+    second = _claim(migrated_db, "owner@example.com", include_orphans=True)
+
+    assert (second.orphan_habits, second.orphan_habit_logs) == (0, 0)
+
+
+def test_migration_007_refuses_to_run_while_orphans_exist(tmp_path, monkeypatch):
+    """The foreign key cannot be added over rows it would immediately violate."""
+    db_path = tmp_path / "orphaned.db"
+    cfg = _alembic_config(db_path, monkeypatch)
+    command.upgrade(cfg, "003")
+    _seed_pre_004(db_path)
+    command.upgrade(cfg, "006_usernames")
+    _insert_orphan(db_path)
+
+    with pytest.raises(RuntimeError, match="names no account"):
+        command.upgrade(cfg, "head")
+
+    # It named the repair rather than performing one behind the operator's back.
+    assert _owners(db_path, "habits") == {
+        LEGACY_USER_ID: len(PRE_004_HABITS),
+        ORPHAN_OWNER: 1,
+    }
+
+
+def test_migration_007_adds_the_ownership_foreign_keys(migrated_db):
+    conn = sqlite3.connect(migrated_db)
+    try:
+        for table in ("habits", "habit_logs"):
+            referenced = {row[2] for row in conn.execute(f"PRAGMA foreign_key_list({table})")}
+            assert "users" in referenced, table
+    finally:
+        conn.close()
+
+
+def test_cli_include_orphans_claims_them(cli_db, capsys):
+    from app import claim_legacy
+
+    _insert_orphan(cli_db)
+    user_id = _register(cli_db, "owner@example.com")
+
+    exit_code = claim_legacy.main(
+        ["--email", "owner@example.com", "--include-orphans"]
+    )
+
+    assert exit_code == 0
+    assert "orphans (user_id names no account)" in capsys.readouterr().out
+    assert _owners(cli_db, "habits") == {user_id: len(PRE_004_HABITS) + 1}

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -11,10 +11,13 @@ def epoch_ms(value: str) -> int:
 
 @pytest.mark.asyncio
 async def test_head_to_head_aggregates_habit_scores_and_marks_current_user(client, db_session, auth_header):
-    db_session.add_all([
-        User(id="user", email="me@example.com", username="Me", password_hash="x"),
-        User(id="opponent", email="them@example.com", username="Them", password_hash="x"),
-    ])
+    # The auth_header fixture already created "user"; merge gives it the display
+    # name this test asserts on without colliding on the primary key.
+    await db_session.merge(User(id="user", email="me@example.com", username="Me", password_hash="x"))
+    db_session.add(User(id="opponent", email="them@example.com", username="Them", password_hash="x"))
+    # Habit/HabitLog have no relationship() to User, only a raw foreign key, so
+    # the unit of work will not order the inserts for us.
+    await db_session.flush()
     db_session.add_all([
         Habit(id="my-high", user_id="user", name="High", impact=5, friction=1, keystone=5, time_cost=1),
         Habit(id="their-neutral", user_id="opponent", name="Neutral", impact=3, friction=3, keystone=3, time_cost=3),

--- a/backend/tests/test_logs.py
+++ b/backend/tests/test_logs.py
@@ -9,7 +9,9 @@ from sqlalchemy.pool import StaticPool
 
 from app.database import get_db
 from app.main import app
-from app.models import Base
+from app.models import Base, User
+
+from tests.conftest import TEST_USER_ID
 
 
 # ── Helper ──────────────────────────────────────────────
@@ -252,6 +254,19 @@ async def concurrent_client():
     session_factory = async_sessionmaker(
         engine, class_=AsyncSession, expire_on_commit=False
     )
+    # This fixture builds its own engine, so the account the auth_header token
+    # names has to exist here too -- the API rejects a token whose subject is
+    # not a real users row.
+    async with session_factory() as session:
+        session.add(
+            User(
+                id=TEST_USER_ID,
+                email="user@test.invalid",
+                username="user",
+                password_hash="x",
+            )
+        )
+        await session.commit()
 
     async def _override_get_db():
         async with session_factory() as session:

--- a/src/__tests__/context/AuthContext.test.tsx
+++ b/src/__tests__/context/AuthContext.test.tsx
@@ -99,4 +99,35 @@ describe('AuthContext', () => {
     expect(result.current.token).toBeNull();
     expect(result.current.isAuthenticated).toBe(false);
   });
+
+  it('sessionExpired ends the session but keeps local data', async () => {
+    // A background 401 can no longer re-authenticate on the user's behalf
+    // (issue #125), so it ends the session — but wiping the database here
+    // would destroy logs recorded offline and never pushed.
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhY2NvdW50LTEifQ.sig',
+    );
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+    expect(result.current.userId).toBe('account-1');
+
+    await act(async () => {
+      await result.current.sessionExpired();
+    });
+
+    expect(setAuthToken).toHaveBeenCalledWith(null);
+    expect(result.current.token).toBeNull();
+    expect(result.current.userId).toBeNull();
+    // Back at the sign-in screen with everything still on the device.
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(database.unsafeResetDatabase).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/navigation/AppNavigator.test.tsx
+++ b/src/__tests__/navigation/AppNavigator.test.tsx
@@ -3,10 +3,17 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
 import { RootNavigator } from '../../navigation/AppNavigator';
 import { useAuth } from '../../context/AuthContext';
+import { useServices } from '../../services/ServicesContext';
 
 // Mock AuthContext hook
 jest.mock('../../context/AuthContext', () => ({
   useAuth: jest.fn(),
+}));
+
+// Mock ServicesContext: importing it for real pulls in SyncService and, with
+// it, the AsyncStorage native module this suite has no need for.
+jest.mock('../../services/ServicesContext', () => ({
+  useServices: jest.fn(() => null),
 }));
 
 // Mock HabitsProvider using inline require for View
@@ -84,5 +91,32 @@ describe('AppNavigator Conditional Routing', () => {
     await waitFor(() => {
       expect(getByText('DashboardScreenMock')).toBeTruthy();
     });
+  });
+
+  it('gives SyncService a way to end the session when the server rejects our token', async () => {
+    // SyncService sits above AuthProvider and can no longer mint a token of
+    // its own (issue #125), so the navigator hands it the session's own exit.
+    const sessionExpired = jest.fn();
+    const setOnSessionExpired = jest.fn();
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      sessionExpired,
+    });
+    (useServices as jest.Mock).mockReturnValue({
+      syncService: { setOnSessionExpired },
+    });
+
+    const { unmount } = render(<RootNavigator />);
+
+    await waitFor(() => {
+      expect(setOnSessionExpired).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    setOnSessionExpired.mock.calls[0][0]();
+    expect(sessionExpired).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(setOnSessionExpired).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/__tests__/screens/SettingsScreen.test.tsx
+++ b/src/__tests__/screens/SettingsScreen.test.tsx
@@ -3,7 +3,7 @@ import {Alert} from 'react-native';
 import {render, fireEvent, waitFor, act} from '@testing-library/react-native';
 import SettingsScreen from '../../screens/SettingsScreen';
 import HabitService from '../../services/HabitService';
-import SyncService, {AuthenticationError} from '../../services/SyncService';
+import SyncService from '../../services/SyncService';
 import NotificationService from '../../services/NotificationService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {of} from 'rxjs';
@@ -128,7 +128,6 @@ function createMockNotificationService() {
 function createMockSyncService(pendingCount = 0) {
   return {
     pushUnsyncedLogs: jest.fn().mockResolvedValue({pushed: 0, failed: 0}),
-    authenticate: jest.fn().mockResolvedValue(undefined),
     startBackgroundSync: jest.fn(),
     stopBackgroundSync: jest.fn(),
     debouncedSync: jest.fn(),
@@ -266,149 +265,46 @@ describe('SettingsScreen', () => {
     expect(getByText(/1.*log.*pending sync/)).toBeTruthy();
   });
 
-  it('authenticates and shows success alert when Connect is tapped with a secret', async () => {
+  it('offers no way to paste a shared secret', async () => {
+    // The sync secret bought a token owned by nobody (issue #125). Sync now
+    // rides on the signed-in account, so there is nothing to connect here.
     const service = createMockHabitService([]);
     const syncService = createMockSyncService();
     const notificationService = createMockNotificationService();
 
-    const {getByTestId} = render(
+    const {queryByTestId, getByTestId} = render(
       <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
+      expect(getByTestId('sync-now-button')).toBeTruthy();
     });
 
-    fireEvent.changeText(getByTestId('sync-secret-input'), 'my-secret');
-    await act(async () => {
-      fireEvent.press(getByTestId('connect-button'));
-    });
-
-    expect(syncService.authenticate).toHaveBeenCalledWith('my-secret');
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Connected',
-      expect.stringContaining('Sync is now enabled'),
-    );
+    expect(queryByTestId('sync-secret-input')).toBeNull();
+    expect(queryByTestId('connect-button')).toBeNull();
+    expect(queryByTestId('toggle-secret-visibility')).toBeNull();
   });
 
-  it('trims whitespace from the secret before calling authenticate', async () => {
+  it('tells the user to sign in again when sync reports auth_failed', async () => {
     const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
+    const syncService = createMockSyncService(2);
+    (syncService.getSyncStatus as jest.Mock).mockResolvedValue({
+      status: 'auth_failed',
+      pendingCount: 2,
+    });
     const notificationService = createMockNotificationService();
 
-    const {getByTestId} = render(
+    const {getByTestId, getByText} = render(
       <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
     );
 
     await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
+      expect(getByTestId('sync-status')).toBeTruthy();
     });
 
-    fireEvent.changeText(getByTestId('sync-secret-input'), '  padded-secret  ');
-    await act(async () => {
-      fireEvent.press(getByTestId('connect-button'));
-    });
-
-    expect(syncService.authenticate).toHaveBeenCalledWith('padded-secret');
-  });
-
-  it('shows an error alert when authenticate rejects with AuthenticationError', async () => {
-    const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
-    (syncService.authenticate as jest.Mock).mockRejectedValueOnce(
-      new AuthenticationError('Invalid secret'),
-    );
-    const notificationService = createMockNotificationService();
-
-    const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
-    });
-
-    fireEvent.changeText(getByTestId('sync-secret-input'), 'wrong');
-    await act(async () => {
-      fireEvent.press(getByTestId('connect-button'));
-    });
-
-    expect(Alert.alert).toHaveBeenCalledWith('Connection failed', 'Invalid secret');
-  });
-
-  it('shows a generic error message when authenticate rejects with a non-Authentication error', async () => {
-    const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
-    (syncService.authenticate as jest.Mock).mockRejectedValueOnce(
-      new Error('boom'),
-    );
-    const notificationService = createMockNotificationService();
-
-    const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
-    });
-
-    fireEvent.changeText(getByTestId('sync-secret-input'), 'anything');
-    await act(async () => {
-      fireEvent.press(getByTestId('connect-button'));
-    });
-
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Connection failed',
-      expect.stringContaining('Could not reach the server'),
-    );
-  });
-
-  it('does not call authenticate when the input is empty', async () => {
-    const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
-    const notificationService = createMockNotificationService();
-
-    const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('connect-button')).toBeTruthy();
-    });
-
-    await act(async () => {
-      fireEvent.press(getByTestId('connect-button'));
-    });
-
-    expect(syncService.authenticate).not.toHaveBeenCalled();
-  });
-
-  it('toggles secureTextEntry when the Show/Hide control is tapped', async () => {
-    const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
-    const notificationService = createMockNotificationService();
-
-    const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
-    });
-
-    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(true);
-
-    await act(async () => {
-      fireEvent.press(getByTestId('toggle-secret-visibility'));
-    });
-
-    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(false);
-
-    await act(async () => {
-      fireEvent.press(getByTestId('toggle-secret-visibility'));
-    });
-
-    expect(getByTestId('sync-secret-input').props.secureTextEntry).toBe(true);
+    // With no way to re-connect in Settings, this status is the only prompt
+    // the user gets before the app returns them to the sign-in screen.
+    expect(getByText(/Authentication required/)).toBeTruthy();
   });
 
   // ─── Per-habit notifications ─────────────────────────────────────────
@@ -1075,29 +971,4 @@ describe('SettingsScreen', () => {
     expect(notificationService.cancelHabitReminder).toHaveBeenCalledWith('h1');
   });
 
-  it('does not crash when the secret input gains focus (scroll-to-end handler)', async () => {
-    jest.useFakeTimers();
-    const service = createMockHabitService([]);
-    const syncService = createMockSyncService();
-    const notificationService = createMockNotificationService();
-
-    const {getByTestId} = render(
-      <SettingsScreen habitService={service} syncService={syncService} notificationService={notificationService} />,
-    );
-
-    await waitFor(() => {
-      expect(getByTestId('sync-secret-input')).toBeTruthy();
-    });
-
-    // The handler schedules scrollRef.current?.scrollToEnd inside a 50ms
-    // setTimeout. We can't hook the ScrollView ref from outside the
-    // component, but firing focus + advancing timers exercises the path
-    // and asserts it doesn't throw on a null/undefined ref.
-    expect(() => {
-      fireEvent(getByTestId('sync-secret-input'), 'focus');
-      jest.advanceTimersByTime(60);
-    }).not.toThrow();
-
-    jest.useRealTimers();
-  });
 });

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -1,10 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient, {AUTH_TOKEN_KEY} from '../../services/api';
-import SyncService, {
-  AuthenticationError,
-  SYNC_SECRET_KEY,
-  SYNC_AUTH_FAILED_KEY,
-} from '../../services/SyncService';
+import SyncService, {SYNC_AUTH_FAILED_KEY} from '../../services/SyncService';
 import type HabitService from '../../services/HabitService';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -15,6 +11,9 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 jest.mock('../../services/api', () => {
   const mockPost = jest.fn();
+  // The pull is best-effort and irrelevant to these scenarios; default it to a
+  // network failure so it stays a no-op unless a test says otherwise.
+  const mockGet = jest.fn(() => Promise.reject({message: 'Network Error'}));
   const mockInterceptors = {
     request: {use: jest.fn(), eject: jest.fn()},
     response: {use: jest.fn(), eject: jest.fn()},
@@ -31,6 +30,7 @@ jest.mock('../../services/api', () => {
     __esModule: true,
     default: {
       post: mockPost,
+      get: mockGet,
       interceptors: mockInterceptors,
     },
     AUTH_TOKEN_KEY: 'auth_token',
@@ -90,6 +90,7 @@ function createMockHabitService(logs: ReturnType<typeof createMockLog>[] = []) {
 describe('SyncService Hardening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (apiClient.get as jest.Mock).mockRejectedValue({message: 'Network Error'});
     // Default: no auth failed flag
     (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
       if (key === SYNC_AUTH_FAILED_KEY) {
@@ -416,167 +417,121 @@ describe('SyncService Hardening', () => {
   // Scenario 4: Token expired mid-session
   // ---------------------------------------------------------------
   describe('Scenario 4: Token expired mid-session (401)', () => {
-    it('attempts re-auth with stored secret on 401 response', async () => {
+    it('flags auth failure and ends the session on a 401, without re-minting', async () => {
       const logs = [createMockLog('habit-1', '2025-01-01')];
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
 
-      // First call: 401, triggers re-auth
-      const authError = {
+      (apiClient.post as jest.Mock).mockRejectedValueOnce({
         response: {status: 401, data: {detail: 'Token expired'}},
         message: 'Unauthorized',
-      };
-      // Second call (to /auth/token): success
-      // Third call (retry /logs/sync): success
-      (apiClient.post as jest.Mock)
-        .mockRejectedValueOnce(authError)
-        .mockResolvedValueOnce({
-          data: {access_token: 'new-jwt-token', token_type: 'bearer'},
-        })
-        .mockResolvedValueOnce({
-          data: {synced: 1, errors: []},
-        });
-
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_SECRET_KEY) {
-          return Promise.resolve('my-secret');
-        }
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
       });
-
-      const result = await syncService.pushUnsyncedLogs();
-
-      // Re-auth was attempted
-      expect(apiClient.post).toHaveBeenCalledWith('/auth/token', {secret: 'my-secret'});
-      // New token was stored
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(AUTH_TOKEN_KEY, 'new-jwt-token');
-      // Sync succeeded after re-auth
-      expect(result.pushed).toBe(1);
-      expect(logs[0].markSynced).toHaveBeenCalled();
-    });
-
-    it('sets auth_failed flag and stops retrying when re-auth fails', async () => {
-      const logs = [createMockLog('habit-1', '2025-01-01')];
-      const habitService = createMockHabitService(logs);
-      const syncService = new SyncService(habitService);
-
-      const authError = {
-        response: {status: 401, data: {detail: 'Token expired'}},
-        message: 'Unauthorized',
-      };
-      (apiClient.post as jest.Mock)
-        .mockRejectedValueOnce(authError)
-        .mockRejectedValueOnce({
-          response: {status: 401, data: {detail: 'Invalid secret'}},
-        });
-
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_SECRET_KEY) {
-          return Promise.resolve('wrong-secret');
-        }
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
-      });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
       const result = await syncService.pushUnsyncedLogs();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
       expect(result).toEqual({pushed: 0, failed: 0});
       expect(logs[0].markSynced).not.toHaveBeenCalled();
     });
 
-    it('does NOT set auth_failed flag when re-auth fails with a network error', async () => {
+    it('never mints a token of its own on a 401', async () => {
+      // The whole defect in #125: sync used to POST /auth/token with a shared
+      // secret and overwrite the signed-in user's real token with the result.
       const logs = [createMockLog('habit-1', '2025-01-01')];
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      const authError = {
+      (apiClient.post as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
         message: 'Unauthorized',
-      };
-      const networkError = {message: 'Network Error'};
-      (apiClient.post as jest.Mock)
-        .mockRejectedValueOnce(authError)
-        .mockRejectedValueOnce(networkError);
-
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_SECRET_KEY) {
-          return Promise.resolve('my-secret');
-        }
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
       });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      const result = await syncService.pushUnsyncedLogs();
+      await syncService.pushUnsyncedLogs();
 
-      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
-      expect(result).toEqual({pushed: 0, failed: 0});
+      const posted = (apiClient.post as jest.Mock).mock.calls.map(call => call[0]);
+      expect(posted).not.toContain('/auth/token');
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        AUTH_TOKEN_KEY,
+        expect.anything(),
+      );
     });
 
-    it('does NOT set auth_failed flag when re-auth fails with a 5xx error', async () => {
+    it('notifies the app only once while the session stays expired', async () => {
       const logs = [createMockLog('habit-1', '2025-01-01')];
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
 
-      const authError = {
+      (apiClient.post as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
         message: 'Unauthorized',
-      };
-      const serverError = {
-        response: {status: 502, data: {detail: 'Bad Gateway'}},
-        message: 'Server Error',
-      };
-      (apiClient.post as jest.Mock)
-        .mockRejectedValueOnce(authError)
-        .mockRejectedValueOnce(serverError);
-
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_SECRET_KEY) {
-          return Promise.resolve('my-secret');
-        }
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
       });
+      // The flag is already set from an earlier failure.
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        Promise.resolve(key === SYNC_AUTH_FAILED_KEY ? 'true' : null),
+      );
 
-      const result = await syncService.pushUnsyncedLogs();
+      await syncService.pushUnsyncedLogs();
 
-      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
-      expect(result).toEqual({pushed: 0, failed: 0});
+      expect(onSessionExpired).not.toHaveBeenCalled();
     });
 
-    it('sets auth_failed flag when no stored secret exists for re-auth', async () => {
-      const logs = [createMockLog('habit-1', '2025-01-01')];
-      const habitService = createMockHabitService(logs);
+    it('ends the session on a 401 from the pull, with nothing pending to push', async () => {
+      // A user whose backlog is empty never reaches the push, so the pull is
+      // the only place their expired session can surface.
+      const habitService = createMockHabitService();
       const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
 
-      const authError = {
+      (apiClient.get as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
-        message: 'Unauthorized',
-      };
-      (apiClient.post as jest.Mock).mockRejectedValueOnce(authError);
-
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_SECRET_KEY) {
-          return Promise.resolve(null); // No secret stored
-        }
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
       });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      const result = await syncService.pushUnsyncedLogs();
+      await syncService.pushUnsyncedLogs();
 
       expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT set auth_failed flag on a network error', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
+
+      (apiClient.post as jest.Mock).mockRejectedValueOnce({message: 'Network Error'});
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(onSessionExpired).not.toHaveBeenCalled();
+      expect(result).toEqual({pushed: 0, failed: 0});
+    });
+
+    it('does NOT set auth_failed flag on a 5xx error', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      (apiClient.post as jest.Mock).mockRejectedValueOnce({
+        response: {status: 502, data: {detail: 'Bad Gateway'}},
+        message: 'Server Error',
+      });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
       expect(result).toEqual({pushed: 0, failed: 0});
     });
 
@@ -597,33 +552,6 @@ describe('SyncService Hardening', () => {
       expect(result).toEqual({pushed: 0, failed: 0});
       // Should not even check for unsynced logs
       expect(apiClient.post).not.toHaveBeenCalled();
-    });
-
-    it('authenticate() stores the secret for future re-auth attempts', async () => {
-      const habitService = createMockHabitService();
-      const syncService = new SyncService(habitService);
-
-      (apiClient.post as jest.Mock).mockResolvedValueOnce({
-        data: {access_token: 'test-jwt-token', token_type: 'bearer'},
-      });
-
-      await syncService.authenticate('my-secret');
-
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_SECRET_KEY, 'my-secret');
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(AUTH_TOKEN_KEY, 'test-jwt-token');
-    });
-
-    it('authenticate() clears auth_failed flag on success', async () => {
-      const habitService = createMockHabitService();
-      const syncService = new SyncService(habitService);
-
-      (apiClient.post as jest.Mock).mockResolvedValueOnce({
-        data: {access_token: 'test-jwt-token', token_type: 'bearer'},
-      });
-
-      await syncService.authenticate('my-secret');
-
-      expect(AsyncStorage.removeItem).toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY);
     });
 
     it('getSyncStatus returns auth_failed when flag is set', async () => {
@@ -904,37 +832,31 @@ describe('SyncService Hardening', () => {
   });
 
   // ---------------------------------------------------------------
-  // Cross-cutting: authenticate stores secret
+  // Cross-cutting: no credential minting anywhere in this service
   // ---------------------------------------------------------------
-  describe('authenticate stores secret for re-auth', () => {
-    it('stores both token and secret on successful authentication', async () => {
-      const habitService = createMockHabitService();
-      const syncService = new SyncService(habitService);
+  describe('sync never authenticates on the user\'s behalf', () => {
+    it('exposes no way to trade a shared secret for a token', () => {
+      const syncService = new SyncService(createMockHabitService());
 
-      (apiClient.post as jest.Mock).mockResolvedValueOnce({
-        data: {access_token: 'jwt-token-123', token_type: 'bearer'},
-      });
-
-      await syncService.authenticate('my-app-secret');
-
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(AUTH_TOKEN_KEY, 'jwt-token-123');
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_SECRET_KEY, 'my-app-secret');
+      expect(
+        (syncService as unknown as {authenticate?: unknown}).authenticate,
+      ).toBeUndefined();
     });
 
-    it('does NOT store secret on failed authentication', async () => {
-      const habitService = createMockHabitService();
+    it('does not write the auth token during a successful push', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      (apiClient.post as jest.Mock).mockRejectedValueOnce({
-        response: {status: 401, data: {detail: 'Invalid secret'}},
+      (apiClient.post as jest.Mock).mockResolvedValue({
+        data: {synced: 1, errors: []},
       });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      await expect(syncService.authenticate('bad-secret')).rejects.toThrow(
-        AuthenticationError,
-      );
+      await syncService.pushUnsyncedLogs();
 
       expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
-        SYNC_SECRET_KEY,
+        AUTH_TOKEN_KEY,
         expect.anything(),
       );
     });

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -1,7 +1,7 @@
 import {AppState} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient, {AUTH_TOKEN_KEY} from '../../services/api';
-import SyncService, {AuthenticationError} from '../../services/SyncService';
+import SyncService, {SYNC_AUTH_FAILED_KEY} from '../../services/SyncService';
 import type HabitService from '../../services/HabitService';
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -435,37 +435,49 @@ describe('SyncService', () => {
     });
   });
 
-  describe('authenticate', () => {
-    it('stores the token in AsyncStorage on success', async () => {
-      const habitService = createMockHabitService();
+  describe('session expiry', () => {
+    it('reports auth_failed and hands the session back to the app on a 401', async () => {
+      const habitService = createMockHabitService([
+        createMockLog('habit-1', '2025-01-01'),
+      ]);
       const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
 
-      (apiClient.post as jest.Mock).mockResolvedValueOnce({
-        data: {access_token: 'test-jwt-token', token_type: 'bearer'},
+      (apiClient.post as jest.Mock).mockRejectedValue({
+        response: {status: 401, data: {detail: 'Token expired'}},
       });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      await syncService.authenticate('my-secret');
+      const result = await syncService.pushUnsyncedLogs();
 
-      expect(apiClient.post).toHaveBeenCalledWith('/auth/token', {
-        secret: 'my-secret',
-      });
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      expect(result).toEqual({pushed: 0, failed: 0});
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+      // It cannot mint a replacement token any more (issue #125).
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
         AUTH_TOKEN_KEY,
-        'test-jwt-token',
+        expect.anything(),
       );
     });
 
-    it('throws AuthenticationError on failure', async () => {
-      const habitService = createMockHabitService();
+    it('stops calling back once the callback is cleared', async () => {
+      const habitService = createMockHabitService([
+        createMockLog('habit-1', '2025-01-01'),
+      ]);
       const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
+      syncService.setOnSessionExpired(null);
 
-      (apiClient.post as jest.Mock).mockRejectedValueOnce({
-        response: {status: 401, data: {detail: 'Invalid secret'}},
+      (apiClient.post as jest.Mock).mockRejectedValue({
+        response: {status: 401, data: {detail: 'Token expired'}},
       });
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      await expect(syncService.authenticate('wrong-secret')).rejects.toThrow(
-        AuthenticationError,
-      );
+      await syncService.pushUnsyncedLogs();
+
+      expect(onSessionExpired).not.toHaveBeenCalled();
     });
   });
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
   isLoading: boolean;
   login: (newToken: string) => Promise<void>;
   logout: () => Promise<void>;
+  sessionExpired: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -46,6 +47,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setUserId(decodeSubject(newToken));
   };
 
+  // End the session without touching local data. A background sync that gets a
+  // 401 has no way to re-authenticate any more (see issue #125), so it calls
+  // this — and it must not behave like `logout`, whose database reset would
+  // destroy logs the user has recorded but not yet pushed.
+  const sessionExpired = async () => {
+    await setAuthToken(null);
+    setTokenState(null);
+    setUserId(null);
+  };
+
   const logout = async () => {
     try {
       // 1. Clear token in persistent storage & Axios interceptor memory
@@ -71,6 +82,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         isLoading,
         login,
         logout,
+        sessionExpired,
       }}
     >
       {children}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -6,6 +6,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { AuthProvider, useAuth } from '../context/AuthContext';
+import { useServices } from '../services/ServicesContext';
 import { HabitsProvider } from '../hooks/useHabitsContext';
 import type HabitService from '../services/HabitService';
 import type { AuthStackParamList } from './types';
@@ -42,7 +43,17 @@ const MainTabNavigator = () => {
 export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
   habitService,
 }) => {
-  const { isAuthenticated, isLoading, userId } = useAuth();
+  const { isAuthenticated, isLoading, userId, sessionExpired } = useAuth();
+  const services = useServices();
+
+  // SyncService lives above AuthProvider, so it cannot reach the session
+  // itself. Hand it the one thing it needs when the server rejects our token.
+  React.useEffect(() => {
+    services?.syncService.setOnSessionExpired(() => {
+      sessionExpired();
+    });
+    return () => services?.syncService.setOnSessionExpired(null);
+  }, [services, sessionExpired]);
 
   // Set ownership before the provider mounts so its first query cannot expose
   // the previous account's local rows during an account switch.

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -2,12 +2,10 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {
   View,
   Text,
-  TextInput,
   Pressable,
   StyleSheet,
   Alert,
   ScrollView,
-  TouchableOpacity,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {format} from 'date-fns';
@@ -15,9 +13,9 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
 import {spacing} from '../theme/spacing';
-import {radii, borders, shadowOffsets} from '../theme';
+import {radii, borders} from '../theme';
 import HabitService from '../services/HabitService';
-import SyncService, {AuthenticationError} from '../services/SyncService';
+import SyncService from '../services/SyncService';
 import NotificationService from '../services/NotificationService';
 import {API_BASE_URL} from '../services/api';
 import {useServices} from '../services/ServicesContext';
@@ -28,7 +26,6 @@ import NBCard from '../components/atoms/NBCard';
 import NBChip from '../components/atoms/NBChip';
 import NBToggle from '../components/atoms/NBToggle';
 import NBButton from '../components/atoms/NBButton';
-import NBShadow from '../components/atoms/NBShadow';
 import NBSettingsRow from '../components/atoms/NBSettingsRow';
 import {getAppReleaseString} from '../utils/appVersion';
 
@@ -90,10 +87,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   >('online');
   const [lastSyncTime, setLastSyncTime] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
-  const [secretInput, setSecretInput] = useState('');
-  const [connecting, setConnecting] = useState(false);
-  const [showSecret, setShowSecret] = useState(false);
-  const scrollRef = useRef<ScrollView>(null);
   const insets = useSafeAreaInsets();
   // Clear the system status bar so the first row ("Your Habits") and any
   // content the user scrolls to (e.g. the Version row) don't slide under it.
@@ -448,29 +441,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
     }
   }, [sService]);
 
-  const handleConnect = useCallback(async () => {
-    const secret = secretInput.trim();
-    if (!secret) {
-      return;
-    }
-    setConnecting(true);
-    try {
-      await sService.authenticate(secret);
-      setSecretInput('');
-      const status = await sService.getSyncStatus();
-      setSyncStatus(status.status);
-      Alert.alert('Connected', 'Sync is now enabled on this device.');
-    } catch (err: unknown) {
-      const message =
-        err instanceof AuthenticationError
-          ? err.message
-          : 'Could not reach the server. Check your connection and try again.';
-      Alert.alert('Connection failed', message);
-    } finally {
-      setConnecting(false);
-    }
-  }, [sService, secretInput]);
-
   const hours = useMemo(() => Array.from({length: 24}, (_, i) => i), []);
 
   const renderHabitRow = (item: Habit, index: number) => {
@@ -570,7 +540,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
   return (
     <NBSurface testID="settings-screen">
       <ScrollView
-        ref={scrollRef}
         contentContainerStyle={[styles.content, {paddingTop: contentPaddingTop}]}
         keyboardShouldPersistTaps="handled">
         {/* Header */}
@@ -683,56 +652,6 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
               </Text>
             )}
 
-            <View style={styles.connectBlock}>
-              <View style={styles.connectLabelRow}>
-                <Text style={styles.connectLabel}>SYNC SECRET</Text>
-                <TouchableOpacity
-                  onPress={() => setShowSecret(s => !s)}
-                  testID="toggle-secret-visibility">
-                  <Text style={styles.connectToggle}>
-                    {showSecret ? 'HIDE' : 'SHOW'}
-                  </Text>
-                </TouchableOpacity>
-              </View>
-              <NBShadow
-                offsetX={shadowOffsets.xs}
-                offsetY={shadowOffsets.xs}
-                color={colors.shadow}
-                borderRadius={radii.pill}>
-                <TextInput
-                  testID="sync-secret-input"
-                  style={styles.connectInput}
-                  value={secretInput}
-                  onChangeText={setSecretInput}
-                  placeholder="Paste your server secret"
-                  placeholderTextColor={colors.textSoft}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  secureTextEntry={!showSecret}
-                  editable={!connecting}
-                  // Android's adjustResize shrinks the window but doesn't
-                  // scroll the ScrollView. Without this, the focused input
-                  // sits behind the keyboard on tall keyboards (e.g.
-                  // Pixel 10a).
-                  onFocus={() => {
-                    // Delay one tick so layout settles after the keyboard appears.
-                    setTimeout(
-                      () => scrollRef.current?.scrollToEnd({animated: true}),
-                      50,
-                    );
-                  }}
-                />
-              </NBShadow>
-              <NBButton
-                variant="secondary"
-                testID="connect-button"
-                onPress={handleConnect}
-                disabled={connecting || secretInput.trim().length === 0}
-                loading={connecting}
-                style={styles.connectButton}>
-                CONNECT
-              </NBButton>
-            </View>
           </View>
         </NBCard>
 
@@ -766,7 +685,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({
             variant="secondary"
             testID="logout-button"
             onPress={onLogout}
-            style={styles.connectButton}>
+            style={styles.logoutButton}>
             LOG OUT
           </NBButton>
         )}
@@ -901,47 +820,7 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: colors.textSoft,
   },
-  connectBlock: {
-    marginTop: spacing.md,
-    paddingTop: spacing.md,
-    borderTopWidth: borders.thin,
-    borderTopColor: colors.regaliaSoft,
-  },
-  connectLabelRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: spacing.sm,
-  },
-  connectLabel: {
-    fontFamily: fontFamily.mono,
-    fontSize: 11,
-    fontWeight: '700',
-    color: colors.text,
-    letterSpacing: 0.5,
-  },
-  connectToggle: {
-    fontFamily: fontFamily.mono,
-    fontSize: 11,
-    fontWeight: '700',
-    color: colors.tiger,
-    letterSpacing: 0.5,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-  },
-  connectInput: {
-    fontFamily: fontFamily.mono,
-    fontSize: 13,
-    color: colors.text,
-    backgroundColor: colors.card,
-    borderRadius: radii.pill,
-    borderWidth: borders.thick,
-    borderColor: colors.line,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    marginBottom: spacing.sm,
-  },
-  connectButton: {
+  logoutButton: {
     alignSelf: 'stretch',
   },
   bottomSpacer: {

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -6,22 +6,13 @@ import apiClient, {
   AUTH_TOKEN_KEY,
   CircuitOpenError,
   isCircuitOpen,
-  setAuthToken,
 } from './api';
 import type HabitService from './HabitService';
 
-export const SYNC_SECRET_KEY = 'sync_secret';
 export const SYNC_AUTH_FAILED_KEY = 'sync_auth_failed';
 
 const BATCH_SIZE = 100;
 const MAX_UNBATCHED = 500;
-
-export class AuthenticationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'AuthenticationError';
-  }
-}
 
 export interface SyncResult {
   pushed: number;
@@ -80,23 +71,34 @@ export default class SyncService {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null;
   private inFlight = false;
+  private onSessionExpired: (() => void) | null = null;
 
   constructor(habitService: HabitService) {
     this.habitService = habitService;
   }
 
-  async authenticate(secret: string): Promise<void> {
-    try {
-      const response = await apiClient.post('/auth/token', {secret});
-      const {access_token} = response.data;
-      await setAuthToken(access_token);
-      await AsyncStorage.setItem(SYNC_SECRET_KEY, secret);
-      await AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY);
-    } catch (error: unknown) {
-      const syncErr = error as SyncError;
-      const message =
-        syncErr.response?.data?.detail || syncErr.message || 'Authentication failed';
-      throw new AuthenticationError(message);
+  /**
+   * Register what to do when the server rejects our token.
+   *
+   * Sync used to re-mint one itself from a shared secret, which returned a
+   * token owned by nobody and silently replaced the signed-in user's real one
+   * (issue #125). It cannot mint credentials any more, so a 401 is now the
+   * app's problem: the callback is expected to end the session and route the
+   * user back to sign-in, without discarding unsynced local data.
+   */
+  setOnSessionExpired(callback: (() => void) | null): void {
+    this.onSessionExpired = callback;
+  }
+
+  /**
+   * Records a permanently-failed authentication and notifies the app once.
+   * Never writes a token — that is the clobbering bug this replaced.
+   */
+  private async handleAuthFailure(): Promise<void> {
+    const alreadyFailed = await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY);
+    await AsyncStorage.setItem(SYNC_AUTH_FAILED_KEY, 'true');
+    if (alreadyFailed !== 'true') {
+      this.onSessionExpired?.();
     }
   }
 
@@ -149,8 +151,13 @@ export default class SyncService {
       await this.habitService.applyPulledHabits(response.data?.habits ?? []);
       const logs = await apiClient.get('/logs/sync');
       await this.habitService.applyPulledLogs(logs.data ?? []);
-    } catch {
-      // Pull is best-effort; local-first writes remain available offline.
+    } catch (error: unknown) {
+      // Pull is best-effort; local-first reads remain available offline. A 401
+      // is the exception: it is the only signal a user with nothing pending
+      // would ever get that their session has ended.
+      if (is401Error(error as SyncError)) {
+        await this.handleAuthFailure();
+      }
     }
   }
 
@@ -179,28 +186,16 @@ export default class SyncService {
       })),
     };
 
-    let response: AxiosResponse | undefined;
+    let response: AxiosResponse;
     try {
       response = await apiClient.post('/habits/sync', payload);
     } catch (error: unknown) {
       const syncErr = error as SyncError;
       if (is401Error(syncErr)) {
-        const reauthed = await this.attemptReauth();
-        if (!reauthed) {
-          return false;
-        }
-        try {
-          response = await apiClient.post('/habits/sync', payload);
-        } catch {
-          return false;
-        }
-      } else {
-        // Network or 5xx — give up for this cycle, retry later.
-        return false;
+        await this.handleAuthFailure();
       }
-    }
-
-    if (!response) {
+      // 401, network or 5xx — give up for this cycle. A 401 needs the user to
+      // sign in again; the rest retry later.
       return false;
     }
 
@@ -224,29 +219,19 @@ export default class SyncService {
       })),
     };
 
-    let response;
+    let response: AxiosResponse;
     try {
       response = await apiClient.post('/logs/sync', payload);
     } catch (error: unknown) {
       const syncErr = error as SyncError;
       if (is401Error(syncErr)) {
-        const reauthed = await this.attemptReauth();
-        if (reauthed) {
-          // Retry once after re-auth
-          try {
-            response = await apiClient.post('/logs/sync', payload);
-          } catch (retryError: unknown) {
-            return this.handleSyncError(retryError as SyncError);
-          }
-        } else {
-          return {pushed: 0, failed: 0};
-        }
-      } else {
-        return this.handleSyncError(syncErr);
+        await this.handleAuthFailure();
+        return {pushed: 0, failed: 0};
       }
+      return this.handleSyncError(syncErr);
     }
 
-    const {synced, errors: syncErrors} = response!.data;
+    const {synced, errors: syncErrors} = response.data;
 
     const errorSet = new Set(
       (syncErrors || []).map(
@@ -301,6 +286,11 @@ export default class SyncService {
       if (isCircuitOpen()) {
         break;
       }
+      // A rejected token will reject every remaining batch too, and the
+      // breaker deliberately ignores 4xx, so stop on our own.
+      if ((await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY)) === 'true') {
+        break;
+      }
     }
 
     return {
@@ -322,27 +312,6 @@ export default class SyncService {
       }
     }
     return {pushed: 0, failed: 0};
-  }
-
-  private async attemptReauth(): Promise<boolean> {
-    const secret = await AsyncStorage.getItem(SYNC_SECRET_KEY);
-    if (!secret) {
-      await AsyncStorage.setItem(SYNC_AUTH_FAILED_KEY, 'true');
-      return false;
-    }
-
-    try {
-      const response = await apiClient.post('/auth/token', {secret});
-      const {access_token} = response.data;
-      await setAuthToken(access_token);
-      await AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY);
-      return true;
-    } catch (e) {
-      if (is401Error(e as SyncError)) {
-        await AsyncStorage.setItem(SYNC_AUTH_FAILED_KEY, 'true');
-      }
-      return false;
-    }
   }
 
   async isOffline(): Promise<boolean> {


### PR DESCRIPTION
Closes #125

## Problem

Two authentication paths disagreed about who the user is.

`/auth/login` and `/auth/register` mint a token whose `sub` is the account's UUID. Sync used the legacy shared secret instead: `SyncService.authenticate` and `SyncService.attemptReauth` both posted to `/auth/token`, which returned `_token("user")` — a literal string subject that names no row in `users`, checked by nothing.

Two consequences:

1. **Orphan rows.** Every habit and log synced under that token was owned by an account that does not exist, and so was invisible to every real account.
2. **Session clobbering.** `attemptReauth` called `setAuthToken` unconditionally, so a background sync 401 replaced a signed-in user's real token with a `sub="user"` one. The user kept browsing, now writing as nobody.

That undid the claim step added for #119: rows were rescued, then the next shared-secret sync started orphaning again.

## Changes

**Backend**

- `/auth/token` returns **410 Gone**, kept as a route for one release so builds still in the field get a diagnosable answer rather than a bare 404. `TokenRequest.secret` removed.
- New `current_user` dependency (`app/middleware/auth.py`) resolves the token subject against `users` and 401s if it names no account. Every authenticated route in `habits.py`, `logs.py` and `leaderboards.py` now takes it instead of reading `sub` directly.
- Migration `007` adds foreign keys from `habits.user_id` and `habit_logs.user_id` to `users.id`. It refuses to run while orphans exist and names the counts, rather than silently deleting or reassigning anyone's data.
- `claim_legacy --include-orphans` sweeps rows whose owner is absent from `users`, not just migration 004's sentinel. `--dry-run` is the report half.
- Dropped the `default="user"` placeholders from `Habit.user_id`, `HabitLog.user_id` and `User.username`.

**Mobile**

- `SyncService` can no longer mint credentials: `authenticate`, `attemptReauth` and `SYNC_SECRET_KEY` are gone, and nothing in the file writes the auth token. A 401 sets the auth-failed flag and hands the session back to the app exactly once.
- New `AuthContext.sessionExpired` clears the token **without** `unsafeResetDatabase` — unlike `logout`, which would destroy logs recorded offline and never pushed. `RootNavigator` bridges it to `SyncService`.
- Removed the sync-secret UI from Settings. The existing "Authentication required" status is now the honest signal.

## Verification

- Backend: 83 passed, 95% coverage (gate is 85%).
- Frontend: 318 passed, `tsc --noEmit` clean, `eslint src` 0 errors.
- The full `003 → head` migration chain on a throwaway MariaDB seeded with pre-existing rows — production's exact path — plus downgrade and re-upgrade.
- The foreign key rejecting an unknown owner on both MariaDB and SQLite; `007` refusing over an orphan and succeeding once claimed.
- End to end: a hand-minted `sub="user"` token gets 401 from both a read and `/habits/sync`, and writes nothing.

## Deploy notes — read before merging

**This is a breaking change for any client that authenticates with the shared secret.** The installed app build cannot sync after this deploys until a new build is installed and the user signs in. Sequence the rollout: migrate → register → claim → ship the new build.

Production is still at Alembic revision `003` with 14 habits and 150 logs, and has never issued a `sub="user"` token against a `004` schema, so it holds no orphans. The sequencing and the `--include-orphans` repair are documented in `backend/README.md`.

## Out of scope

Filed #129 while working on this: `App.tsx` and `AppNavigator.tsx` each mount a `NavigationContainer`, and React Navigation 7 throws on the nesting. Pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
