### PR TITLE
fix: surface an error when sign-in or registration fails

### DIFF
--- a/src/__tests__/screens/LoginScreen.test.tsx
+++ b/src/__tests__/screens/LoginScreen.test.tsx
@@ -27,9 +27,8 @@ describe('auth screens', () => {
 
   // These two screens are the only way into the app now that the shared-secret
   // token endpoint is retired (#125), so the token they hand to AuthContext is
-  // what every later request is scoped by. The rejecting path is deliberately
-  // not covered here: neither screen handles it today, and a test would have to
-  // encode that silence as correct. Tracked in #131.
+  // what every later request is scoped by, and a failure has to say so out loud
+  // rather than doing nothing (#131).
   it('signs in and hands the returned token to AuthContext', async () => {
     (apiClient.post as jest.Mock).mockResolvedValue({
       data: {access_token: 'jwt-for-real-account', token_type: 'bearer'},
@@ -82,5 +81,154 @@ describe('auth screens', () => {
     const {getByText} = render(<LoginScreen navigation={navigation} route={route} />);
     fireEvent.press(getByText('Need an account? Register'));
     expect(navigate).toHaveBeenCalledWith('Register');
+  });
+
+  it('tells the user when the credentials are rejected, and keeps their email', async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue({
+      response: {status: 401, data: {detail: 'Invalid email or password'}},
+    });
+
+    const {getByPlaceholderText, getByTestId, getByText} = render(
+      <LoginScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'me@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'wrong horse');
+    await act(async () => {
+      fireEvent.press(getByText('Sign In'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('login-error').props.children).toBe('Invalid email or password');
+    });
+    expect(login).not.toHaveBeenCalled();
+    // Retyping the email after every failed attempt is its own small cruelty.
+    expect(getByPlaceholderText('Email').props.value).toBe('me@example.com');
+  });
+
+  it('distinguishes an unreachable server from a rejected credential', async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue({message: 'Network Error'});
+
+    const {getByPlaceholderText, getByTestId, getByText} = render(
+      <LoginScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'me@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'correct horse');
+    await act(async () => {
+      fireEvent.press(getByText('Sign In'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('login-error').props.children).toMatch(/Could not reach the server/);
+    });
+  });
+
+  it('clears a previous error when the user tries again', async () => {
+    (apiClient.post as jest.Mock).mockRejectedValueOnce({
+      response: {status: 401, data: {detail: 'Invalid email or password'}},
+    });
+
+    const {getByPlaceholderText, queryByTestId, getByText} = render(
+      <LoginScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'me@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'wrong horse');
+    await act(async () => {
+      fireEvent.press(getByText('Sign In'));
+    });
+    await waitFor(() => expect(queryByTestId('login-error')).toBeTruthy());
+
+    (apiClient.post as jest.Mock).mockResolvedValueOnce({
+      data: {access_token: 'jwt-after-retry', token_type: 'bearer'},
+    });
+    fireEvent.changeText(getByPlaceholderText('Password'), 'correct horse');
+    await act(async () => {
+      fireEvent.press(getByText('Sign In'));
+    });
+
+    await waitFor(() => {
+      expect(login).toHaveBeenCalledWith('jwt-after-retry');
+    });
+    expect(queryByTestId('login-error')).toBeNull();
+  });
+
+  it('surfaces a duplicate-account rejection on register', async () => {
+    (apiClient.post as jest.Mock).mockRejectedValue({
+      response: {status: 409, data: {detail: 'Email already registered'}},
+    });
+
+    const {getByPlaceholderText, getByTestId, getByText} = render(
+      <RegisterScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'taken@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'correct horse');
+    await act(async () => {
+      fireEvent.press(getByText('Create Account'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('register-error').props.children).toBe('Email already registered');
+    });
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it('renders a validation failure as a sentence, not raw JSON', async () => {
+    // FastAPI returns `detail` as a list of objects for a 422 — e.g. a password
+    // under the 8-character minimum on RegisterRequest.
+    (apiClient.post as jest.Mock).mockRejectedValue({
+      response: {
+        status: 422,
+        data: {
+          detail: [
+            {loc: ['body', 'password'], msg: 'String should have at least 8 characters', type: 'too_short'},
+          ],
+        },
+      },
+    });
+
+    const {getByPlaceholderText, getByTestId, getByText} = render(
+      <RegisterScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'new@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'short');
+    await act(async () => {
+      fireEvent.press(getByText('Create Account'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('register-error').props.children).toBe(
+        'String should have at least 8 characters',
+      );
+    });
+  });
+
+  it('ignores a second press while a sign-in is already in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    (apiClient.post as jest.Mock).mockReturnValue(
+      new Promise(resolve => {
+        release = resolve;
+      }),
+    );
+
+    const {getByPlaceholderText, getByText} = render(
+      <LoginScreen navigation={navigation} route={route} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'me@example.com');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'correct horse');
+    await act(async () => {
+      fireEvent.press(getByText('Sign In'));
+      fireEvent.press(getByText('Sign In'));
+    });
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release({data: {access_token: 'jwt', token_type: 'bearer'}});
+    });
   });
 });

--- a/src/__tests__/utils/authError.test.ts
+++ b/src/__tests__/utils/authError.test.ts
@@ -1,0 +1,39 @@
+import {authErrorMessage} from '../../utils/authError';
+
+describe('authErrorMessage', () => {
+  it('prefers the server-supplied reason', () => {
+    expect(
+      authErrorMessage({response: {status: 401, data: {detail: 'Invalid email or password'}}}),
+    ).toBe('Invalid email or password');
+  });
+
+  it('takes the first message out of a FastAPI validation list', () => {
+    expect(
+      authErrorMessage({
+        response: {
+          status: 422,
+          data: {detail: [{loc: ['body', 'password'], msg: 'String should have at least 8 characters'}]},
+        },
+      }),
+    ).toBe('String should have at least 8 characters');
+  });
+
+  it.each([
+    ['no response at all', {message: 'Network Error'}, /Could not reach the server/],
+    ['a 401 with no detail', {response: {status: 401, data: {}}}, /Invalid email or password/],
+    ['a 409 with no detail', {response: {status: 409, data: {}}}, /already registered/],
+    ['a 500 with no detail', {response: {status: 503, data: {}}}, /server is having trouble/],
+    ['an unmapped status', {response: {status: 418, data: {}}}, /Something went wrong/],
+  ])('falls back to a sentence for %s', (_label, error, expected) => {
+    expect(authErrorMessage(error)).toMatch(expected);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a blank detail', {response: {status: 400, data: {detail: '   '}}}],
+    ['an unusable detail list', {response: {status: 422, data: {detail: [{loc: ['body']}]}}}],
+  ])('never renders %s as an empty message', (_label, error) => {
+    expect(authErrorMessage(error).length).toBeGreaterThan(0);
+  });
+});

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,8 +1,9 @@
 // src/screens/LoginScreen.tsx
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../services/api';
+import {authErrorMessage} from '../utils/authError';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../navigation/types';
 
@@ -11,11 +12,33 @@ type LoginScreenProps = NativeStackScreenProps<AuthStackParamList, 'Login'>;
 export const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  // A ref, not the state above: two taps in the same frame both read the same
+  // closure before React re-renders, so `submitting` is still false for the
+  // second one and `disabled` has not taken effect yet. Same reason
+  // SyncService guards with `inFlight`.
+  const inFlight = useRef(false);
   const { login } = useAuth();
 
   const handleLogin = async () => {
-    const response = await apiClient.post('/auth/login', {email, password});
-    await login(response.data.access_token);
+    if (inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const response = await apiClient.post('/auth/login', {email, password});
+      await login(response.data.access_token);
+    } catch (err: unknown) {
+      // The email is deliberately left in place so a rejected attempt does not
+      // cost the user their typing.
+      setError(authErrorMessage(err));
+    } finally {
+      inFlight.current = false;
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -35,7 +58,12 @@ export const LoginScreen: React.FC<LoginScreenProps> = ({ navigation }) => {
         onChangeText={setPassword}
         secureTextEntry
       />
-      <Button title="Sign In" onPress={handleLogin} />
+      {error && (
+        <Text style={styles.error} testID="login-error">
+          {error}
+        </Text>
+      )}
+      <Button title="Sign In" onPress={handleLogin} disabled={submitting} />
       <Button
         title="Need an account? Register"
         onPress={() => navigation.navigate('Register')}
@@ -48,4 +76,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 20 },
   title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
   input: { borderWidth: 1, borderColor: '#ccc', padding: 10, borderRadius: 6, marginBottom: 12 },
+  error: { color: '#b00020', marginBottom: 12, textAlign: 'center' },
 });

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -1,8 +1,9 @@
 // src/screens/RegisterScreen.tsx
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../services/api';
+import {authErrorMessage} from '../utils/authError';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { AuthStackParamList } from '../navigation/types';
 
@@ -11,11 +12,31 @@ type RegisterScreenProps = NativeStackScreenProps<AuthStackParamList, 'Register'
 export const RegisterScreen: React.FC<RegisterScreenProps> = ({ navigation }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  // A ref, not the state above: two taps in the same frame both read the same
+  // closure before React re-renders, so `submitting` is still false for the
+  // second one and `disabled` has not taken effect yet. Same reason
+  // SyncService guards with `inFlight`.
+  const inFlight = useRef(false);
   const { login } = useAuth();
 
   const handleRegister = async () => {
-    const response = await apiClient.post('/auth/register', {email, password});
-    await login(response.data.access_token);
+    if (inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const response = await apiClient.post('/auth/register', {email, password});
+      await login(response.data.access_token);
+    } catch (err: unknown) {
+      setError(authErrorMessage(err));
+    } finally {
+      inFlight.current = false;
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -35,7 +56,12 @@ export const RegisterScreen: React.FC<RegisterScreenProps> = ({ navigation }) =>
         onChangeText={setPassword}
         secureTextEntry
       />
-      <Button title="Create Account" onPress={handleRegister} />
+      {error && (
+        <Text style={styles.error} testID="register-error">
+          {error}
+        </Text>
+      )}
+      <Button title="Create Account" onPress={handleRegister} disabled={submitting} />
       <Button
         title="Already have an account? Login"
         onPress={() => navigation.navigate('Login')}
@@ -48,4 +74,5 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', padding: 20 },
   title: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, textAlign: 'center' },
   input: { borderWidth: 1, borderColor: '#ccc', padding: 10, borderRadius: 6, marginBottom: 12 },
+  error: { color: '#b00020', marginBottom: 12, textAlign: 'center' },
 });

--- a/src/utils/authError.ts
+++ b/src/utils/authError.ts
@@ -1,0 +1,67 @@
+/**
+ * Turn a failed /auth request into something worth showing a user.
+ *
+ * These two screens are the only way into the app now that the shared-secret
+ * token path is retired (#125), so "nothing happened" is not an acceptable
+ * answer to a failed sign-in — the user cannot otherwise tell a typo from an
+ * outage. See #131.
+ */
+
+interface AuthErrorShape {
+  message?: string;
+  code?: string;
+  request?: unknown;
+  response?: {status?: number; data?: {detail?: unknown}};
+}
+
+const UNREACHABLE =
+  'Could not reach the server. Check your connection and try again.';
+const GENERIC = 'Something went wrong. Please try again.';
+
+/**
+ * FastAPI sends `detail` as a string for explicit HTTPExceptions, but as a list
+ * of error objects for request-validation failures (422) — e.g. a password
+ * shorter than the 8-character minimum. Rendering the list verbatim would show
+ * the user a lump of JSON.
+ */
+function detailToMessage(detail: unknown): string | null {
+  if (typeof detail === 'string' && detail.trim()) {
+    return detail;
+  }
+  if (Array.isArray(detail)) {
+    const first = detail.find(
+      (entry): entry is {msg: string} =>
+        typeof entry === 'object' && entry !== null && typeof (entry as {msg?: unknown}).msg === 'string',
+    );
+    if (first) {
+      return first.msg;
+    }
+  }
+  return null;
+}
+
+export function authErrorMessage(error: unknown): string {
+  const err = (error ?? {}) as AuthErrorShape;
+
+  // No response at all: DNS, timeout, tunnel down, aeroplane mode.
+  if (!err.response) {
+    return UNREACHABLE;
+  }
+
+  const fromDetail = detailToMessage(err.response.data?.detail);
+  if (fromDetail) {
+    return fromDetail;
+  }
+
+  const status = err.response.status ?? 0;
+  if (status === 401) {
+    return 'Invalid email or password.';
+  }
+  if (status === 409) {
+    return 'That email or username is already registered.';
+  }
+  if (status >= 500) {
+    return 'The server is having trouble. Please try again shortly.';
+  }
+  return GENERIC;
+}


### PR DESCRIPTION
Closes #131

> **Stacked on #132.** Based on `fix/129-nested-navigation-container`, so the diff shown here is just this change. GitHub retargets the base to `main` once #132 merges.

## Problem

`handleLogin` and `handleRegister` had no `try`/`catch` and were passed straight to a `Button` `onPress`, which discards the returned promise. A wrong password, an unregistered email, a duplicate account, a validation failure and an unreachable server all produced the same thing on screen — **nothing** — plus an unhandled rejection in the log.

Since #125 retired the shared-secret token path, these two screens are the only way into the app. A user who cannot tell a typo from an outage has no diagnostic and no fallback credential.

## Changes

Both screens catch, render the reason inline, and **keep the entered email** so a rejected attempt does not cost the user their typing.

The message comes from a shared `authErrorMessage` helper (`src/utils/authError.ts`). Two details worth review:

- It prefers the server's own `detail`, but FastAPI sends that as a **list of error objects** for a 422 — a password under the 8-character minimum, say. The helper lifts the first `msg` rather than rendering a lump of JSON at the user.
- An error with **no response at all** is reported as unreachable, not as a rejected credential. Those need very different reactions, and conflating them is most of what made the old silence hard to diagnose.

Presses are guarded with a **ref**, not the `submitting` state. Two taps in the same frame both read the same closure before React re-renders, so the state is still `false` for the second one and `disabled` has not taken effect — I confirmed this by writing the state-based version first and watching the double-press test fail with two calls. Without the ref, a double-tap on a slow connection sends two registrations and the user is told their brand-new account is already taken. `SyncService.inFlight` guards its own re-entrancy the same way.

## Tests

Adds the rejecting paths #132 deliberately left uncovered, plus unit tests for the helper:

- credentials rejected → message shown, `login` never called, email preserved
- unreachable server → distinct message from a rejected credential
- a retry clears the previous error
- duplicate account (409) on register
- 422 validation list → rendered as a sentence
- a second press while in flight sends only one request
- helper: server detail preferred, validation list unwrapped, per-status fallbacks, and never an empty string for `undefined`/`null`/blank detail

| | before | after |
| :--- | :--- | :--- |
| lines | 83.33% | 83.89% |
| functions | 85.43% | 85.57% |
| tests | 330 | 347 |

`LoginScreen.tsx` and `authError.ts` are at 100% line coverage.

## Related

Same class of defect as #127 (a rejected promise reaching an `onPress` and vanishing), which is still open for `RatingEditor`/`StatsScreen`. `authErrorMessage` is auth-specific, but the catch-and-surface shape here is the pattern that would fix that one too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
