### PR TITLE
fix: restore sync after a 401 by clearing sync_auth_failed on sign-in

### DIFF
--- a/src/__tests__/navigation/AppNavigator.test.tsx
+++ b/src/__tests__/navigation/AppNavigator.test.tsx
@@ -119,4 +119,120 @@ describe('AppNavigator Conditional Routing', () => {
     unmount();
     expect(setOnSessionExpired).toHaveBeenLastCalledWith(null);
   });
+
+  it('clears the auth-failure latch and pushes the backlog once a session is valid', async () => {
+    // A 401 latches sync_auth_failed and nothing else releases it, so one
+    // expired token used to kill syncing on that device permanently (issue
+    // #134). This effect is the only place that knows a real account just
+    // became active.
+    let resolveClaim: (value: number) => void = () => {};
+    const claimLegacyRows = jest.fn(
+      () => new Promise<number>(resolve => { resolveClaim = resolve; }),
+    );
+    const setUserId = jest.fn();
+    const clearAuthFailedFlag = jest.fn().mockResolvedValue(undefined);
+    const pushUnsyncedLogs = jest.fn().mockResolvedValue({pushed: 0, failed: 0});
+
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      userId: 'user-1',
+      sessionExpired: jest.fn(),
+    });
+    (useServices as jest.Mock).mockReturnValue({
+      syncService: {
+        setOnSessionExpired: jest.fn(),
+        clearAuthFailedFlag,
+        pushUnsyncedLogs,
+      },
+    });
+
+    const habitService = { setUserId, claimLegacyRows } as never;
+    render(<RootNavigator habitService={habitService} />);
+
+    await waitFor(() => {
+      expect(claimLegacyRows).toHaveBeenCalledWith('user-1');
+    });
+
+    // The unsynced queries scope on the owner, so a push that overtook
+    // claimLegacyRows would look at rows the account does not own yet and
+    // find an empty backlog.
+    expect(clearAuthFailedFlag).not.toHaveBeenCalled();
+    expect(pushUnsyncedLogs).not.toHaveBeenCalled();
+
+    resolveClaim(0);
+
+    await waitFor(() => {
+      expect(pushUnsyncedLogs).toHaveBeenCalledTimes(1);
+    });
+    expect(clearAuthFailedFlag).toHaveBeenCalledTimes(1);
+    expect(clearAuthFailedFlag.mock.invocationCallOrder[0]).toBeLessThan(
+      pushUnsyncedLogs.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('still restores sync when claiming legacy rows fails', async () => {
+    // The claim is best-effort; letting it abort the chain would leave the
+    // latch set and reinstate the very bug this effect fixes.
+    const clearAuthFailedFlag = jest.fn().mockResolvedValue(undefined);
+    const pushUnsyncedLogs = jest.fn().mockResolvedValue({pushed: 0, failed: 0});
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      userId: 'user-1',
+      sessionExpired: jest.fn(),
+    });
+    (useServices as jest.Mock).mockReturnValue({
+      syncService: {
+        setOnSessionExpired: jest.fn(),
+        clearAuthFailedFlag,
+        pushUnsyncedLogs,
+      },
+    });
+
+    const habitService = {
+      setUserId: jest.fn(),
+      claimLegacyRows: jest.fn().mockRejectedValue(new Error('db locked')),
+    } as never;
+    render(<RootNavigator habitService={habitService} />);
+
+    await waitFor(() => {
+      expect(pushUnsyncedLogs).toHaveBeenCalledTimes(1);
+    });
+    expect(clearAuthFailedFlag).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('does not clear the latch or sync while signed out', async () => {
+    const clearAuthFailedFlag = jest.fn().mockResolvedValue(undefined);
+    const pushUnsyncedLogs = jest.fn().mockResolvedValue({pushed: 0, failed: 0});
+
+    (useAuth as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: false,
+      userId: null,
+      sessionExpired: jest.fn(),
+    });
+    (useServices as jest.Mock).mockReturnValue({
+      syncService: {
+        setOnSessionExpired: jest.fn(),
+        clearAuthFailedFlag,
+        pushUnsyncedLogs,
+      },
+    });
+
+    const habitService = {
+      setUserId: jest.fn(),
+      claimLegacyRows: jest.fn().mockResolvedValue(0),
+    } as never;
+    const { getByText } = render(<RootNavigator habitService={habitService} />);
+
+    await waitFor(() => {
+      expect(getByText('LoginScreenMock')).toBeTruthy();
+    });
+    expect(clearAuthFailedFlag).not.toHaveBeenCalled();
+    expect(pushUnsyncedLogs).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/services/SyncService.hardening.test.ts
+++ b/src/__tests__/services/SyncService.hardening.test.ts
@@ -87,17 +87,31 @@ function createMockHabitService(logs: ReturnType<typeof createMockLog>[] = []) {
   } as unknown as HabitService;
 }
 
+/**
+ * Stub AsyncStorage as a signed-in device with no prior auth failure.
+ *
+ * `pushUnsyncedLogs` refuses to touch the network without a stored token, so a
+ * scenario that expects a request has to look signed in — otherwise the guard
+ * short-circuits and the assertions pass without exercising anything. Pass
+ * overrides to model the exceptions: `{[AUTH_TOKEN_KEY]: null}` for a
+ * signed-out device, `{[SYNC_AUTH_FAILED_KEY]: 'true'}` for a latched one.
+ */
+function mockStoredItems(overrides: Record<string, string | null> = {}) {
+  const store: Record<string, string | null> = {
+    [AUTH_TOKEN_KEY]: 'stored-token',
+    [SYNC_AUTH_FAILED_KEY]: null,
+    ...overrides,
+  };
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(store[key] ?? null),
+  );
+}
+
 describe('SyncService Hardening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (apiClient.get as jest.Mock).mockRejectedValue({message: 'Network Error'});
-    // Default: no auth failed flag
-    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-      if (key === SYNC_AUTH_FAILED_KEY) {
-        return Promise.resolve(null);
-      }
-      return Promise.resolve(null);
-    });
+    mockStoredItems();
   });
 
   // ---------------------------------------------------------------
@@ -149,13 +163,7 @@ describe('SyncService Hardening', () => {
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      // No token stored
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve(null);
-        }
-        return Promise.resolve(null);
-      });
+      mockStoredItems({[AUTH_TOKEN_KEY]: null});
 
       const status = await syncService.getSyncStatus();
       expect(status.status).toBe('offline');
@@ -428,7 +436,7 @@ describe('SyncService Hardening', () => {
         response: {status: 401, data: {detail: 'Token expired'}},
         message: 'Unauthorized',
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       const result = await syncService.pushUnsyncedLogs();
 
@@ -449,7 +457,7 @@ describe('SyncService Hardening', () => {
         response: {status: 401, data: {detail: 'Token expired'}},
         message: 'Unauthorized',
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       await syncService.pushUnsyncedLogs();
 
@@ -473,9 +481,7 @@ describe('SyncService Hardening', () => {
         message: 'Unauthorized',
       });
       // The flag is already set from an earlier failure.
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
-        Promise.resolve(key === SYNC_AUTH_FAILED_KEY ? 'true' : null),
-      );
+      mockStoredItems({[SYNC_AUTH_FAILED_KEY]: 'true'});
 
       await syncService.pushUnsyncedLogs();
 
@@ -493,7 +499,7 @@ describe('SyncService Hardening', () => {
       (apiClient.get as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       await syncService.pushUnsyncedLogs();
 
@@ -509,7 +515,7 @@ describe('SyncService Hardening', () => {
       syncService.setOnSessionExpired(onSessionExpired);
 
       (apiClient.post as jest.Mock).mockRejectedValueOnce({message: 'Network Error'});
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       const result = await syncService.pushUnsyncedLogs();
 
@@ -527,7 +533,7 @@ describe('SyncService Hardening', () => {
         response: {status: 502, data: {detail: 'Bad Gateway'}},
         message: 'Server Error',
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       const result = await syncService.pushUnsyncedLogs();
 
@@ -540,12 +546,7 @@ describe('SyncService Hardening', () => {
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve('true');
-        }
-        return Promise.resolve(null);
-      });
+      mockStoredItems({[SYNC_AUTH_FAILED_KEY]: 'true'});
 
       const result = await syncService.pushUnsyncedLogs();
 
@@ -559,16 +560,120 @@ describe('SyncService Hardening', () => {
       const habitService = createMockHabitService(logs);
       const syncService = new SyncService(habitService);
 
-      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-        if (key === SYNC_AUTH_FAILED_KEY) {
-          return Promise.resolve('true');
-        }
-        return Promise.resolve(null);
-      });
+      mockStoredItems({[SYNC_AUTH_FAILED_KEY]: 'true'});
 
       const status = await syncService.getSyncStatus();
       expect(status.status).toBe('auth_failed');
       expect(status.pendingCount).toBe(1);
+    });
+
+    // The pairing the suite was missing (issue #134): every assertion that the
+    // latch is *set* needs its counterpart that it can be *released*, or a
+    // regression that strands sync forever keeps the suite green.
+    it('releases the latch on clearAuthFailedFlag, and the next push reaches the network', async () => {
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+
+      // A real backing store, not a per-step stub: the point of this test is
+      // that clearAuthFailedFlag's own write is what unblocks the next push,
+      // which a re-stubbed getItem would fake for it.
+      const store: Record<string, string | null> = {
+        [AUTH_TOKEN_KEY]: 'stored-token',
+      };
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        Promise.resolve(store[key] ?? null),
+      );
+      (AsyncStorage.setItem as jest.Mock).mockImplementation(
+        async (key: string, value: string) => {
+          store[key] = value;
+        },
+      );
+      (AsyncStorage.removeItem as jest.Mock).mockImplementation(
+        async (key: string) => {
+          delete store[key];
+        },
+      );
+
+      // 1. A 401 latches the flag.
+      (apiClient.post as jest.Mock).mockRejectedValueOnce({
+        response: {status: 401, data: {detail: 'Token expired'}},
+        message: 'Unauthorized',
+      });
+      await syncService.pushUnsyncedLogs();
+      expect(store[SYNC_AUTH_FAILED_KEY]).toBe('true');
+
+      // 2. While it is latched, sync makes no request at all — this is the
+      //    state a device used to be stuck in permanently.
+      (apiClient.post as jest.Mock).mockClear();
+      (apiClient.post as jest.Mock).mockResolvedValue({
+        data: {synced: 1, errors: []},
+      });
+      await syncService.pushUnsyncedLogs();
+      expect(apiClient.post).not.toHaveBeenCalled();
+      expect(logs[0].markSynced).not.toHaveBeenCalled();
+
+      // 3. Signing in again releases it, with no other stubbing...
+      await syncService.clearAuthFailedFlag();
+      expect(store[SYNC_AUTH_FAILED_KEY]).toBeUndefined();
+
+      // 4. ...and the backlog the flag was stranding goes out.
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(apiClient.post).toHaveBeenCalledWith('/logs/sync', {
+        logs: [{habit_id: 'habit-1', completed_date: '2025-01-01', deleted: false}],
+      });
+      expect(result.pushed).toBe(1);
+      expect(logs[0].markSynced).toHaveBeenCalled();
+    });
+
+    it('still ends the session when the latch survived a previous run', async () => {
+      // handleAuthFailure suppresses the callback when the flag is already
+      // 'true', so a latch that outlived a restart used to leave the user on
+      // the main tabs — signed in, syncing nothing, never prompted. The
+      // navigator clears the flag as soon as userId resolves, which is what
+      // makes this 401 notify; the assertion pins that ordering.
+      const habitService = createMockHabitService();
+      const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
+
+      // The state right after the navigator's clearAuthFailedFlag(): a stale
+      // token still stored, latch released.
+      mockStoredItems();
+      (apiClient.get as jest.Mock).mockRejectedValue({
+        response: {status: 401, data: {detail: 'Invalid or expired token'}},
+      });
+
+      await syncService.pushUnsyncedLogs();
+
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(SYNC_AUTH_FAILED_KEY, 'true');
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+
+    it('makes no request and sets no flag when no token is stored', async () => {
+      // The launch sync runs before anyone has signed in. Production answers a
+      // tokenless request with 401 "Not authenticated", so without the guard
+      // a fresh install latches the flag and strands the account about to be
+      // created on it.
+      const logs = [createMockLog('habit-1', '2025-01-01')];
+      const habitService = createMockHabitService(logs);
+      const syncService = new SyncService(habitService);
+      const onSessionExpired = jest.fn();
+      syncService.setOnSessionExpired(onSessionExpired);
+
+      mockStoredItems({[AUTH_TOKEN_KEY]: null});
+
+      const result = await syncService.pushUnsyncedLogs();
+
+      expect(apiClient.get).not.toHaveBeenCalled();
+      expect(apiClient.post).not.toHaveBeenCalled();
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(
+        SYNC_AUTH_FAILED_KEY,
+        'true',
+      );
+      expect(onSessionExpired).not.toHaveBeenCalled();
+      expect(result).toEqual({pushed: 0, failed: 0});
     });
   });
 
@@ -851,7 +956,7 @@ describe('SyncService Hardening', () => {
       (apiClient.post as jest.Mock).mockResolvedValue({
         data: {synced: 1, errors: []},
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      mockStoredItems();
 
       await syncService.pushUnsyncedLogs();
 

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -109,6 +109,13 @@ function createTestJwt(exp: number): string {
 describe('SyncService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // pushUnsyncedLogs skips the whole cycle without a stored token, so the
+    // default has to look signed in or every push test short-circuits before
+    // it reaches the network. Tests needing another shape override this, and
+    // mockResolvedValueOnce still takes precedence over the implementation.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === AUTH_TOKEN_KEY ? 'stored-token' : null),
+    );
   });
 
   describe('pushUnsyncedLogs', () => {
@@ -447,7 +454,10 @@ describe('SyncService', () => {
       (apiClient.post as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      // Signed in with a token the server is about to reject.
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        Promise.resolve(key === AUTH_TOKEN_KEY ? 'stored-token' : null),
+      );
 
       const result = await syncService.pushUnsyncedLogs();
 
@@ -473,7 +483,10 @@ describe('SyncService', () => {
       (apiClient.post as jest.Mock).mockRejectedValue({
         response: {status: 401, data: {detail: 'Token expired'}},
       });
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      // Signed in with a token the server is about to reject.
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        Promise.resolve(key === AUTH_TOKEN_KEY ? 'stored-token' : null),
+      );
 
       await syncService.pushUnsyncedLogs();
 

--- a/src/__tests__/services/SyncService.untoggle.test.ts
+++ b/src/__tests__/services/SyncService.untoggle.test.ts
@@ -7,7 +7,7 @@ import Habit from '../../models/Habit';
 import HabitLog from '../../models/HabitLog';
 import HabitService from '../../services/HabitService';
 import SyncService, {SYNC_AUTH_FAILED_KEY} from '../../services/SyncService';
-import apiClient from '../../services/api';
+import apiClient, {AUTH_TOKEN_KEY} from '../../services/api';
 
 // End-to-end coverage for the N-C1 divergence (PR#27): un-toggling a log
 // that was already synced to the server must leave a tombstone locally and
@@ -103,8 +103,10 @@ describe('SyncService — un-toggle of a synced log (N-C1 / PR#27)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (AsyncStorage.getItem as jest.Mock).mockImplementation(() =>
-      Promise.resolve(null),
+    // The sync cycle is skipped outright without a stored token, so these
+    // end-to-end push assertions need the device to look signed in.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === AUTH_TOKEN_KEY ? 'stored-token' : null),
     );
     database = createTestDatabase();
     habitService = new HabitService(database);
@@ -231,7 +233,7 @@ describe('SyncService — un-toggle of a synced log (N-C1 / PR#27)', () => {
       if (key === SYNC_AUTH_FAILED_KEY) {
         return Promise.resolve('true');
       }
-      return Promise.resolve(null);
+      return Promise.resolve(key === AUTH_TOKEN_KEY ? 'stored-token' : null);
     });
 
     const result = await syncService.pushUnsyncedLogs();

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -61,16 +61,41 @@ export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
     habitService.setUserId(userId);
   }
 
+  // Fires exactly when a session becomes valid — a sign-in, a registration, or
+  // a launch that hydrated a stored token — which is the only moment the app
+  // knows a real account is active again.
   React.useEffect(() => {
     if (!habitService || !userId) return;
+    let cancelled = false;
     habitService.setUserId(userId);
-    // Rows predating per-account ownership belong to nobody until the first
-    // account signs in and adopts them. Without this they would be invisible
-    // to every account, since queries now scope on the owner alone.
-    habitService.claimLegacyRows(userId).catch(error => {
-      console.warn('Failed to claim legacy rows:', error);
+    (async () => {
+      try {
+        // Rows predating per-account ownership belong to nobody until the
+        // first account signs in and adopts them. Without this they would be
+        // invisible to every account, since queries now scope on the owner
+        // alone.
+        await habitService.claimLegacyRows(userId);
+      } catch (error) {
+        // Isolated deliberately: a failed claim must not stop the sync
+        // recovery below, which is the whole reason this effect exists.
+        console.warn('Failed to claim legacy rows:', error);
+      }
+      if (cancelled) return;
+      // A 401 latches sync_auth_failed and nothing else ever releases it, so
+      // one expired token used to end syncing on that device for good (issue
+      // #134). Lift it now the session is valid, then push the backlog it was
+      // stranding — the sync has to follow claimLegacyRows, because the unsynced
+      // queries scope on the owner and would not see the adopted rows yet.
+      await services?.syncService.clearAuthFailedFlag();
+      if (cancelled) return;
+      await services?.syncService.pushUnsyncedLogs();
+    })().catch(error => {
+      console.warn('Post-sign-in sync failed:', error);
     });
-  }, [habitService, userId]);
+    return () => {
+      cancelled = true;
+    };
+  }, [habitService, userId, services]);
 
   if (isLoading) {
     return (

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -110,6 +110,16 @@ export default class SyncService {
     }
     this.inFlight = true;
     try {
+      // A request with no token 401s exactly like one with a rejected token,
+      // and nothing downstream can tell the two apart. Without this guard the
+      // launch sync on a fresh install — which runs before anyone has signed
+      // in — latches sync_auth_failed and strands the account that is about to
+      // be created. Must precede the pull, which is where that 401 is raised.
+      const token = await AsyncStorage.getItem(AUTH_TOKEN_KEY);
+      if (!token) {
+        return {pushed: 0, failed: 0};
+      }
+
       await this.pullHabits();
       // If auth previously failed permanently, don't retry
       const authFailed = await AsyncStorage.getItem(SYNC_AUTH_FAILED_KEY);


### PR DESCRIPTION
Closes #134

## Problem

`sync_auth_failed` is a latch that nothing releases.

`handleAuthFailure` sets it on a 401 and `pushUnsyncedLogs` early-returns whenever it is set, so one rejected token ended syncing on that device permanently — not fixed by signing back in, not by restarting. `clearAuthFailedFlag` had no caller anywhere in `src/`. Tokens expire after 720h (`backend/app/config.py:11`), so every device reached this state through ordinary expiry, and the only escape was reinstalling — which deletes the unsynced logs the flag was stranding.

#130 introduced it: `authenticate()` and `attemptReauth()` both called `AsyncStorage.removeItem(SYNC_AUTH_FAILED_KEY)` on success. Removing those two retired shared-secret paths was correct, but nothing replaced the flag-clearing they incidentally performed. The suite stayed green because it only ever asserted the latch was *set*.

**It is worse than "after an expiry".** Production answers a request with no `Authorization` header the same way it answers a rejected one:

```
$ curl -s https://habit-api.darling.solutions/habits/sync
{"detail":"Not authenticated"}   401
```

`SyncBootstrap` (`src/App.tsx`) calls `pushUnsyncedLogs()` on mount, and `pullHabits()` ran unconditionally at the top of it — before anyone has signed in. So on a **fresh install** the launch sync latched the flag before the user had ever held a token, stranding the account they were about to create. Every new user, not just expired ones.

## Changes

**`src/navigation/AppNavigator.tsx`**

`RootNavigator`'s `userId` effect is the one place that knows a real account just became active — it fires on sign-in, registration, and a launch that hydrated a stored token. It now clears the latch and pushes the backlog, chained **after** `claimLegacyRows`: `getUnsyncedLogs`/`getUnsyncedHabits` scope on `this.userId`, so a push that overtook the claim would look at rows the account does not own yet and find an empty backlog.

The claim is wrapped in its own `try/catch`. Letting a failed claim abort the chain would leave the latch set and reinstate the exact bug being fixed.

**`src/services/SyncService.ts`**

`pushUnsyncedLogs` returns early when no token is stored, above the pull — the pull is where the tokenless 401 is raised.

This also repairs a path nobody had filed. `handleAuthFailure` suppresses `onSessionExpired` when the flag is already `'true'`, so a latch surviving a restart meant the launch 401 never routed the user to Login: they sat on the main tabs, signed in, syncing nothing, never prompted. Clearing the flag as soon as `userId` resolves makes that 401 notify correctly.

**Tests**

The suite defaults were hiding the guard. Several Scenario 4 tests assert negatively (`not.toHaveBeenCalled`), and with `AsyncStorage.getItem` stubbed to return `null` for every key they would have passed *because* the guard short-circuited, never reaching the 401 path at all. A `mockStoredItems` helper now models a signed-in device by default, with overrides for the signed-out and latched cases.

Four new tests:

- **The round trip** the issue calls out as missing — 401 latches, `clearAuthFailedFlag` releases, the next push reaches the network. Written against a real backing store where `removeItem` actually mutates state; a re-stubbed `getItem` would have faked the release for it.
- **The restart case** — a latch that survived a previous run still fires `onSessionExpired`.
- **The tokenless launch** — no token means no request and no flag.
- **Claim/sync ordering**, including that a failed claim still restores sync.

## Verification

- 349 passed, 23 suites. `eslint` 0 errors, `tsc --noEmit` clean.
- Coverage: lines 84.7, functions 85.9, branches 68.3 — gates are 80/80/55.
- Each new test mutation-checked rather than trusted green: gutting `clearAuthFailedFlag` fails only the round-trip test; removing the guard fails only the tokenless test; unchaining the sync from `claimLegacyRows` fails only the ordering test.
- Production probed directly to confirm the server side is behaving: `/health` 200, `/auth/token` 410 (so #130 is deployed), `/habits/sync` 401 with a bogus bearer *and* with no header.

## Follow-ups filed

- #135 — make the latch self-releasing by storing the rejected token instead of a boolean, so it cannot be stranded by a future sync trigger that bypasses the navigator.
- #136 — `pullHabits()` still runs above the latch check, so a latched device makes two 401ing GETs per foreground.

Neither blocks this: sync recovers for users as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UF3es5L65P6kCZxRz34PXt
