### PR TITLE
fix: register routes for the habit detail and create screens

### DIFF
--- a/src/__tests__/navigation/AppNavigator.test.tsx
+++ b/src/__tests__/navigation/AppNavigator.test.tsx
@@ -1,6 +1,6 @@
 // src/__tests__/navigation/AppNavigator.test.tsx
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { RootNavigator } from '../../navigation/AppNavigator';
 import { useAuth } from '../../context/AuthContext';
 import { useServices } from '../../services/ServicesContext';
@@ -39,9 +39,33 @@ jest.mock('../../screens/RegisterScreen', () => {
     RegisterScreen: () => <Text>RegisterScreenMock</Text>,
   };
 });
+// Stands in for the real Dashboard, but keeps its two navigation calls so the
+// routes they target are exercised for real by the navigator under test.
 jest.mock('../../screens/DashboardScreen', () => {
-  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
-  return () => <Text>DashboardScreenMock</Text>;
+  const { Text, Pressable } = jest.requireActual('react-native') as typeof import('react-native');
+  const { useNavigation } = jest.requireActual(
+    '@react-navigation/native',
+  ) as typeof import('@react-navigation/native');
+  return () => {
+    const navigation = useNavigation<{
+      navigate: (screen: string, params?: object) => void;
+    }>();
+    return (
+      <>
+        <Text>DashboardScreenMock</Text>
+        <Pressable
+          testID="go-create-habit"
+          onPress={() => navigation.navigate('CreateHabit')}>
+          <Text>add</Text>
+        </Pressable>
+        <Pressable
+          testID="go-habit-detail"
+          onPress={() => navigation.navigate('HabitDetail', { habitId: 'h1' })}>
+          <Text>open</Text>
+        </Pressable>
+      </>
+    );
+  };
 });
 jest.mock('../../screens/StreaksScreen', () => {
   const { Text } = jest.requireActual('react-native') as typeof import('react-native');
@@ -54,6 +78,16 @@ jest.mock('../../screens/StatsListScreen', () => {
 jest.mock('../../screens/SettingsScreen', () => {
   const { Text } = jest.requireActual('react-native') as typeof import('react-native');
   return () => <Text>SettingsScreenMock</Text>;
+});
+jest.mock('../../screens/StatsScreen', () => {
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
+  return ({ route }: { route?: { params?: { habitId?: string } } }) => (
+    <Text>StatsScreenMock:{route?.params?.habitId}</Text>
+  );
+});
+jest.mock('../../screens/CreateHabitModal', () => {
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
+  return () => <Text>CreateHabitModalMock</Text>;
 });
 
 describe('AppNavigator Conditional Routing', () => {
@@ -90,6 +124,38 @@ describe('AppNavigator Conditional Routing', () => {
 
     await waitFor(() => {
       expect(getByText('DashboardScreenMock')).toBeTruthy();
+    });
+  });
+
+  // Issue #101: StatsScreen and CreateHabitModal were rendered by no navigator
+  // at all, so `navigate('CreateHabit')` hit a route that did not exist and
+  // `navigate('Stats', {habitId})` silently switched to the Stats *tab* (the
+  // habit list) instead of opening the detail screen.
+  describe('routes above the tab navigator', () => {
+    beforeEach(() => {
+      (useAuth as jest.Mock).mockReturnValue({
+        isLoading: false,
+        isAuthenticated: true,
+      });
+    });
+
+    it('opens the create-habit modal rather than throwing on an unknown route', async () => {
+      const { getByTestId, getByText } = render(<RootNavigator />);
+
+      await waitFor(() => expect(getByTestId('go-create-habit')).toBeTruthy());
+      fireEvent.press(getByTestId('go-create-habit'));
+
+      await waitFor(() => expect(getByText('CreateHabitModalMock')).toBeTruthy());
+    });
+
+    it('opens the habit detail screen, not the Stats tab, and passes the habitId', async () => {
+      const { getByTestId, getByText, queryByText } = render(<RootNavigator />);
+
+      await waitFor(() => expect(getByTestId('go-habit-detail')).toBeTruthy());
+      fireEvent.press(getByTestId('go-habit-detail'));
+
+      await waitFor(() => expect(getByText('StatsScreenMock:h1')).toBeTruthy());
+      expect(queryByText('StatsListScreenMock')).toBeNull();
     });
   });
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -9,7 +9,7 @@ import { AuthProvider, useAuth } from '../context/AuthContext';
 import { useServices } from '../services/ServicesContext';
 import { HabitsProvider } from '../hooks/useHabitsContext';
 import type HabitService from '../services/HabitService';
-import type { AuthStackParamList } from './types';
+import type { AuthStackParamList, RootStackParamList } from './types';
 
 import { LoginScreen } from '../screens/LoginScreen';
 import { RegisterScreen } from '../screens/RegisterScreen';
@@ -17,8 +17,11 @@ import DashboardScreen from '../screens/DashboardScreen';
 import StreaksScreen from '../screens/StreaksScreen';
 import StatsListScreen from '../screens/StatsListScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import StatsScreen from '../screens/StatsScreen';
+import CreateHabitModal from '../screens/CreateHabitModal';
 
 const AuthStack = createNativeStackNavigator<AuthStackParamList>();
+const RootStack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator();
 
 const AuthNavigator = () => (
@@ -39,6 +42,26 @@ const MainTabNavigator = () => {
     </Tab.Screen>
   </Tab.Navigator>;
 };
+
+/**
+ * The tab navigator sits inside a stack so the habit detail and create screens
+ * have routes at all. Before this they were rendered nowhere, which is why
+ * `navigate('CreateHabit')` threw and `navigate('Stats', {habitId})` silently
+ * landed on the Stats *tab* (the habit list) rather than the detail screen.
+ *
+ * Every screen draws its own header, so the stack's is hidden.
+ */
+const MainNavigator = () => (
+  <RootStack.Navigator screenOptions={{ headerShown: false }}>
+    <RootStack.Screen name="Tabs" component={MainTabNavigator} />
+    <RootStack.Screen name="HabitDetail" component={StatsScreen} />
+    <RootStack.Screen
+      name="CreateHabit"
+      component={CreateHabitModal}
+      options={{ presentation: 'modal' }}
+    />
+  </RootStack.Navigator>
+);
 
 export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
   habitService,
@@ -109,10 +132,10 @@ export const RootNavigator: React.FC<{habitService?: HabitService}> = ({
     <NavigationContainer>
       {isAuthenticated && habitService ? (
         <HabitsProvider key={userId ?? 'user'} habitService={habitService}>
-          <MainTabNavigator />
+          <MainNavigator />
         </HabitsProvider>
       ) : isAuthenticated ? (
-        <MainTabNavigator />
+        <MainNavigator />
       ) : (
         <AuthNavigator />
       )}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -2,3 +2,31 @@ export type AuthStackParamList = {
   Login: undefined;
   Register: undefined;
 };
+
+/**
+ * Routes above the tab navigator.
+ *
+ * `HabitDetail` deliberately does not reuse the name `Stats`: that belongs to
+ * the tab hosting StatsListScreen, so `navigate('Stats', {habitId})` used to
+ * land on the list instead of the detail screen (issue #101).
+ */
+export type RootStackParamList = {
+  Tabs: undefined;
+  HabitDetail: {habitId: string};
+  CreateHabit: undefined;
+};
+
+/**
+ * The narrow slice of the navigation object the tab screens actually use.
+ *
+ * Typed against RootStackParamList so a route name that does not exist — the
+ * #101 bug — fails to compile, while staying structurally simple enough for
+ * `{navigate: jest.fn()}` test doubles.
+ */
+export type RootNavigation = {
+  navigate<Route extends keyof RootStackParamList>(
+    ...args: RootStackParamList[Route] extends undefined
+      ? [screen: Route]
+      : [screen: Route, params: RootStackParamList[Route]]
+  ): void;
+};

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -21,9 +21,10 @@ import {useHabits} from '../hooks/useHabits';
 import type {HabitDisplayData} from '../hooks/useHabits';
 import {useHabitsContext} from '../hooks/useHabitsContext';
 import HabitService from '../services/HabitService';
+import type {RootNavigation} from '../navigation/types';
 
 interface DashboardScreenProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habitService?: HabitService;
 }
 
@@ -41,7 +42,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({
   );
 
 interface DashboardScreenWithServiceProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habitService: HabitService;
 }
 
@@ -54,14 +55,14 @@ const DashboardScreenWithService: React.FC<DashboardScreenWithServiceProps> = ({
 };
 
 const DashboardScreenFromContext: React.FC<{
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
 }> = ({navigation}) => {
   const state = useHabitsContext();
   return <DashboardScreenBody navigation={navigation} {...state} />;
 };
 
 interface DashboardScreenBodyProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habits: HabitDisplayData[];
   toggleHabit: (habitId: string) => Promise<void>;
   loading: boolean;
@@ -112,7 +113,7 @@ const DashboardScreenBody: React.FC<DashboardScreenBodyProps> = ({
 
   const handleHabitPress = useCallback(
     (habitId: string) => {
-      navigation?.navigate('Stats', {habitId});
+      navigation?.navigate('HabitDetail', {habitId});
     },
     [navigation],
   );

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -12,9 +12,10 @@ import {useHabits} from '../hooks/useHabits';
 import type {HabitDisplayData} from '../hooks/useHabits';
 import {useHabitsContext} from '../hooks/useHabitsContext';
 import HabitService from '../services/HabitService';
+import type {RootNavigation} from '../navigation/types';
 
 interface StatsListScreenProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habitService?: HabitService;
 }
 
@@ -32,7 +33,7 @@ const StatsListScreen: React.FC<StatsListScreenProps> = ({
   );
 
 interface StatsListScreenWithServiceProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habitService: HabitService;
 }
 
@@ -45,14 +46,14 @@ const StatsListScreenWithService: React.FC<StatsListScreenWithServiceProps> = ({
 };
 
 const StatsListScreenFromContext: React.FC<{
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
 }> = ({navigation}) => {
   const {habits} = useHabitsContext();
   return <StatsListScreenBody navigation={navigation} habits={habits} />;
 };
 
 interface StatsListScreenBodyProps {
-  navigation?: {navigate: (screen: string, params?: Record<string, unknown>) => void};
+  navigation?: RootNavigation;
   habits: HabitDisplayData[];
 }
 
@@ -62,7 +63,7 @@ const StatsListScreenBody: React.FC<StatsListScreenBodyProps> = ({
 }) => {
   const handlePress = useCallback(
     (habitId: string) => {
-      navigation?.navigate('Stats', {habitId});
+      navigation?.navigate('HabitDetail', {habitId});
     },
     [navigation],
   );


### PR DESCRIPTION
## Problem

`StatsScreen` and `CreateHabitModal` were imported by no navigator, so neither had a route:

- `DashboardScreen.tsx:110` calls `navigate('CreateHabit')` — a route that did not exist.
- `DashboardScreen.tsx:115` and `StatsListScreen.tsx:65` call `navigate('Stats', {habitId})`, which matched the **Stats tab** (`StatsListScreen`) and switched to the habit list instead of opening the detail screen.

`RatingEditor`'s only consumer is `StatsScreen`, so the entire habit-rating UI added in `3b9d365` was unreachable in the shipped app.

## Change

- Wrap the existing `Tab.Navigator` in a root native stack (`@react-navigation/native-stack`, already a dependency), registering `HabitDetail` → `StatsScreen` and `CreateHabit` → `CreateHabitModal` (`presentation: 'modal'`) beside it.
- The detail route deliberately avoids the name `Stats`, which the tab already owns — that collision is the bug.
- Add `RootStackParamList` and a narrow `RootNavigation` helper in `src/navigation/types.ts`; the two calling screens are typed against it, so a nonexistent route name now fails to compile instead of failing at runtime.
- Only one `NavigationContainer` remains — #129 was exactly the nested-container crash.

## Verification

- `npx tsc --noEmit` clean; `npm run lint` 0 errors (46 pre-existing warnings).
- `npx jest --coverage --ci --forceExit` — 23 suites, 351 tests, coverage gate held.
- The navigator test's `DashboardScreen` mock now issues the real `navigate` calls, so the routes are exercised by the navigator under test. Both new tests were confirmed to **fail** against the previous tabs-only navigator and pass with this change.

Blocks #115, which needs both screens reachable to demonstrate its acceptance criteria.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zu5hkrfrgrbTyP5w4t2Dn