### PR TITLE
feat: add client rating controls and score reconciliation

### DIFF
--- a/src/__tests__/components/RatingEditor.test.tsx
+++ b/src/__tests__/components/RatingEditor.test.tsx
@@ -97,4 +97,96 @@ describe('RatingEditor', () => {
 
     expect(getByTestId('rating-impact').props.children).toBe(1);
   });
+
+  // ─── Failed saves (#127) ───────────────────────────────────────────
+
+  it('shows the failure, keeps the draft, and re-enables the button when onSave rejects', async () => {
+    const onSave = jest
+      .fn()
+      .mockRejectedValue(new Error('Habit ratings must be integers from 1 to 5.'));
+    const {getByLabelText, getByTestId} = renderEditor({}, onSave);
+
+    fireEvent.press(getByLabelText('Increase keystone'));
+    await act(async () => {
+      fireEvent.press(getByLabelText('Save habit ratings'));
+    });
+
+    await waitFor(() =>
+      expect(getByTestId('rating-save-error').props.children).toBe(
+        'Habit ratings must be integers from 1 to 5.',
+      ),
+    );
+    // The edit is the only copy of the user's intent — discarding it would
+    // present unsaved numbers as saved.
+    expect(getByTestId('rating-keystone').props.children).toBe(4);
+    expect(
+      getByLabelText('Save habit ratings').props.accessibilityState?.disabled,
+    ).toBe(false);
+  });
+
+  it('falls back to a generic message when the rejection carries none', async () => {
+    const onSave = jest.fn().mockRejectedValue(new Error(''));
+    const {getByLabelText, getByTestId} = renderEditor({}, onSave);
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Save habit ratings'));
+    });
+
+    await waitFor(() =>
+      expect(getByTestId('rating-save-error').props.children).toBe(
+        'Could not save your ratings. Please try again.',
+      ),
+    );
+  });
+
+  it('clears a previous failure once the user edits again', async () => {
+    const onSave = jest.fn().mockRejectedValue(new Error('nope'));
+    const {getByLabelText, getByTestId, queryByTestId} = renderEditor({}, onSave);
+
+    await act(async () => {
+      fireEvent.press(getByLabelText('Save habit ratings'));
+    });
+    await waitFor(() => expect(getByTestId('rating-save-error')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Increase impact'));
+
+    expect(queryByTestId('rating-save-error')).toBeNull();
+  });
+
+  // ─── Controlled mode (create flow) ─────────────────────────────────
+
+  it('reports every change and draws no save button when controlled', () => {
+    const onChange = jest.fn();
+    const {getByLabelText, queryByLabelText} = render(
+      <RatingEditor ratings={RATINGS} onChange={onChange} />,
+    );
+
+    expect(queryByLabelText('Save habit ratings')).toBeNull();
+
+    fireEvent.press(getByLabelText('Increase impact'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      impact: 4,
+      friction: 3,
+      keystone: 3,
+      timeCost: 3,
+    });
+
+    fireEvent.press(getByLabelText('Decrease time cost'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      impact: 4,
+      friction: 3,
+      keystone: 3,
+      timeCost: 2,
+    });
+  });
+
+  // ─── Accessibility ─────────────────────────────────────────────────
+
+  it('exposes each rating as an adjustable with its value', () => {
+    const {getByLabelText} = renderEditor({impact: 5});
+
+    const impact = getByLabelText('impact');
+    expect(impact.props.accessibilityRole).toBe('adjustable');
+    expect(impact.props.accessibilityValue).toEqual({min: 1, max: 5, now: 5});
+  });
 });

--- a/src/__tests__/models/models.test.ts
+++ b/src/__tests__/models/models.test.ts
@@ -1,8 +1,10 @@
 import {Database} from '@nozbe/watermelondb';
 import LokiJSAdapter from '@nozbe/watermelondb/adapters/lokijs';
 import {schema} from '../../models/schema';
+import {migrations} from '../../models/migrations';
 import Habit from '../../models/Habit';
 import HabitLog from '../../models/HabitLog';
+import {calculateHabitScore} from '../../utils/habitScoring';
 
 function createTestDatabase(): Database {
   const adapter = new LokiJSAdapter({schema, useWebWorker: false, useIncrementalIndexedDB: false});
@@ -98,5 +100,70 @@ describe('HabitLog model', () => {
     await log.markSynced();
 
     expect(log.synced).toBe(true);
+  });
+});
+
+// ─── Schema v7: the score column (#115) ──────────────────────────────
+
+describe('habits schema v7', () => {
+  const habitColumns = schema.tables.habits.columns;
+
+  it('is at version 7 and the migrations reach it', () => {
+    expect(schema.version).toBe(7);
+    const versions = migrations.sortedMigrations.map(m => m.toVersion);
+    expect(versions).toContain(7);
+    // A schema version with no migration bricks every existing install.
+    expect(Math.max(...versions)).toBe(schema.version);
+  });
+
+  it('stores score as an optional number', () => {
+    // Optional so an unwritten column reads as null. A non-optional number
+    // column reads as 0, and 0 is a legitimate score (ratings 1/5/1/5), so
+    // "never synced" and "genuinely zero" would be indistinguishable.
+    expect(habitColumns.score).toEqual({
+      name: 'score',
+      type: 'number',
+      isOptional: true,
+    });
+  });
+
+  it('backfills score with the same arithmetic as calculateHabitScore', () => {
+    const step = migrations.sortedMigrations
+      .find(m => m.toVersion === 7)!
+      .steps.find(
+        (st): st is {type: 'sql'; sql: string} =>
+          (st as {type: string}).type === 'sql',
+      );
+    expect(step).toBeDefined();
+
+    // The exact expression the migration runs. Pinned as a string so an edit
+    // to the SQL has to come with an edit to the equivalence check below.
+    const expression =
+      '(100 * (impact + (6 - friction) + keystone + (6 - time_cost) - 4) + 8) / 16';
+    expect(step!.sql).toContain(expression);
+
+    // SQLite integer division truncates toward zero, and the numerator is
+    // always non-negative for ratings in 1-5, so it matches Math.floor.
+    const sqlite = (
+      impact: number,
+      friction: number,
+      keystone: number,
+      timeCost: number,
+    ) =>
+      Math.trunc(
+        (100 * (impact + (6 - friction) + keystone + (6 - timeCost) - 4) + 8) / 16,
+      );
+
+    for (let impact = 1; impact <= 5; impact++) {
+      for (let friction = 1; friction <= 5; friction++) {
+        for (let keystone = 1; keystone <= 5; keystone++) {
+          for (let timeCost = 1; timeCost <= 5; timeCost++) {
+            expect(sqlite(impact, friction, keystone, timeCost)).toBe(
+              calculateHabitScore(impact, friction, keystone, timeCost),
+            );
+          }
+        }
+      }
+    }
   });
 });

--- a/src/__tests__/screens/CreateHabitModal.test.tsx
+++ b/src/__tests__/screens/CreateHabitModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent, act} from '@testing-library/react-native';
+import {render, fireEvent, act, waitFor} from '@testing-library/react-native';
 import CreateHabitModal from '../../screens/CreateHabitModal';
 import HabitService from '../../services/HabitService';
 
@@ -61,7 +61,12 @@ describe('CreateHabitModal', () => {
       fireEvent.press(getByTestId('create-button'));
     });
 
-    expect(service.createHabit).toHaveBeenCalledWith('Drink Water');
+    expect(service.createHabit).toHaveBeenCalledWith('Drink Water', {
+      impact: 3,
+      friction: 3,
+      keystone: 3,
+      timeCost: 3,
+    });
     expect(navigation.goBack).toHaveBeenCalled();
   });
 
@@ -141,5 +146,66 @@ describe('CreateHabitModal', () => {
     expect(input.props.placeholder).toBe(
       'e.g., Drink Water, Read 10 Pages',
     );
+  });
+
+  // ─── Ratings on create (#115) ──────────────────────────────────────
+
+  it('exposes all four rating controls at the neutral default', async () => {
+    const service = createMockHabitService();
+    const {getByTestId} = render(<CreateHabitModal habitService={service} />);
+
+    expect(getByTestId('rating-editor')).toBeTruthy();
+    expect(getByTestId('rating-impact').props.children).toBe(3);
+    expect(getByTestId('rating-friction').props.children).toBe(3);
+    expect(getByTestId('rating-keystone').props.children).toBe(3);
+    expect(getByTestId('rating-timeCost').props.children).toBe(3);
+  });
+
+  it('creates the habit with the ratings the user chose', async () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+    const {getByTestId, getByLabelText} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.changeText(getByTestId('habit-name-input'), 'Read');
+    fireEvent.press(getByLabelText('Increase impact'));
+    fireEvent.press(getByLabelText('Increase impact'));
+    fireEvent.press(getByLabelText('Decrease friction'));
+
+    await act(async () => {
+      fireEvent.press(getByTestId('create-button'));
+    });
+
+    expect(service.createHabit).toHaveBeenCalledWith('Read', {
+      impact: 5,
+      friction: 2,
+      keystone: 3,
+      timeCost: 3,
+    });
+  });
+
+  it('shows an error instead of silently swallowing a failed create', async () => {
+    const service = createMockHabitService();
+    const navigation = {goBack: jest.fn()};
+    (service.createHabit as jest.Mock).mockRejectedValue(
+      new Error('Habit name must be 50 characters or fewer.'),
+    );
+    const {getByTestId} = render(
+      <CreateHabitModal habitService={service} navigation={navigation} />,
+    );
+
+    fireEvent.changeText(getByTestId('habit-name-input'), 'Read');
+    await act(async () => {
+      fireEvent.press(getByTestId('create-button'));
+    });
+
+    await waitFor(() =>
+      expect(getByTestId('create-habit-error').props.children).toBe(
+        'Habit name must be 50 characters or fewer.',
+      ),
+    );
+    // The modal stays open so the user can correct and retry.
+    expect(navigation.goBack).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/screens/StatsScreen.test.tsx
+++ b/src/__tests__/screens/StatsScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, fireEvent, waitFor} from '@testing-library/react-native';
+import {act, render, fireEvent, waitFor} from '@testing-library/react-native';
 import StatsScreen from '../../screens/StatsScreen';
 import MonthCalendar from '../../components/MonthCalendar';
 import HabitService from '../../services/HabitService';
@@ -24,12 +24,20 @@ function createMockHabitService(overrides: {
   createdAt?: number;
   streak?: number;
   logs?: Array<{completedDate: string; habitId: string}>;
+  ratings?: {impact: number; friction: number; keystone: number; timeCost: number};
+  setHabitRatings?: jest.Mock;
+  getHabitMetrics?: jest.Mock;
 } = {}) {
   const {
     name = 'Exercise',
     createdAt = new Date('2025-01-01T00:00:00').getTime(),
     streak = 0,
     logs = [],
+    ratings = {impact: 3, friction: 3, keystone: 3, timeCost: 3},
+    setHabitRatings = jest.fn().mockResolvedValue(undefined),
+    // Undefined by default: no metrics endpoint, so the screen falls back to
+    // the provisional local score, which is what most of these tests assert.
+    getHabitMetrics = undefined,
   } = overrides;
 
   return {
@@ -38,6 +46,7 @@ function createMockHabitService(overrides: {
       name,
       createdAt,
       isActive: true,
+      ...ratings,
     }),
     calculateStreak: jest.fn().mockResolvedValue(streak),
     getLogsForHabit: jest.fn().mockResolvedValue(
@@ -47,6 +56,8 @@ function createMockHabitService(overrides: {
     toggleHabitCompletion: jest.fn(),
     createHabit: jest.fn(),
     getUnsyncedLogs: jest.fn(),
+    setHabitRatings,
+    getHabitMetrics,
   } as unknown as jest.Mocked<HabitService>;
 }
 
@@ -144,6 +155,131 @@ describe('StatsScreen', () => {
   });
 
   // ─── Snapshot test ─────────────────────────────────────────────────
+
+  // ─── Rating editor and score provenance (#115) ─────────────────────
+
+  describe('ratings and score provenance', () => {
+    it('renders the rating editor with the habit\'s stored ratings', async () => {
+      const service = createMockHabitService({
+        ratings: {impact: 5, friction: 2, keystone: 4, timeCost: 1},
+      });
+
+      const {getByTestId} = render(
+        <StatsScreen route={defaultRoute} habitService={service} />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('rating-impact').props.children).toBe(5),
+      );
+      expect(getByTestId('rating-friction').props.children).toBe(2);
+      expect(getByTestId('rating-keystone').props.children).toBe(4);
+      expect(getByTestId('rating-timeCost').props.children).toBe(1);
+    });
+
+    it('saves an edited rating through the service', async () => {
+      const setHabitRatings = jest.fn().mockResolvedValue(undefined);
+      const service = createMockHabitService({setHabitRatings});
+
+      const {getByLabelText, getByTestId} = render(
+        <StatsScreen route={defaultRoute} habitService={service} />,
+      );
+
+      // Wait for the habit's own ratings to land, or the press would edit the
+      // seed values and be overwritten when the load resolves.
+      await waitFor(() =>
+        expect(getByTestId('habit-name').props.children).toBe('Exercise'),
+      );
+      fireEvent.press(getByLabelText('Increase impact'));
+      await act(async () => {
+        fireEvent.press(getByLabelText('Save habit ratings'));
+      });
+
+      expect(setHabitRatings).toHaveBeenCalledWith('habit-1', {
+        impact: 4,
+        friction: 3,
+        keystone: 3,
+        timeCost: 3,
+      });
+    });
+
+    it('surfaces a failed rating save and keeps the draft (#127)', async () => {
+      const setHabitRatings = jest
+        .fn()
+        .mockRejectedValue(new Error('Habit ratings must be integers from 1 to 5.'));
+      const service = createMockHabitService({setHabitRatings});
+
+      const {getByLabelText, getByTestId} = render(
+        <StatsScreen route={defaultRoute} habitService={service} />,
+      );
+
+      // Wait for the habit's own ratings to land, or the press would edit the
+      // seed values and be overwritten when the load resolves.
+      await waitFor(() =>
+        expect(getByTestId('habit-name').props.children).toBe('Exercise'),
+      );
+      fireEvent.press(getByLabelText('Increase impact'));
+      await act(async () => {
+        fireEvent.press(getByLabelText('Save habit ratings'));
+      });
+
+      await waitFor(() =>
+        expect(getByTestId('rating-save-error').props.children).toBe(
+          'Habit ratings must be integers from 1 to 5.',
+        ),
+      );
+      // The edit is the only copy of the user's intent — it must survive.
+      expect(getByTestId('rating-impact').props.children).toBe(4);
+      expect(getByLabelText('Save habit ratings').props.accessibilityState?.disabled).toBe(false);
+    });
+
+    it('labels the score provisional when the metrics request fails', async () => {
+      const service = createMockHabitService({
+        ratings: {impact: 4, friction: 2, keystone: 3, timeCost: 4},
+        getHabitMetrics: jest.fn().mockRejectedValue(new Error('offline')),
+      });
+
+      const {getByTestId} = render(
+        <StatsScreen route={defaultRoute} habitService={service} />,
+      );
+
+      // The contract's worked example: (4,2,3,4) -> 56. Waiting on the score
+      // rather than the caption, because the caption is already provisional on
+      // the first pass, before the habit's ratings have loaded.
+      await waitFor(() =>
+        expect(getByTestId('score-value').props.children).toBe(56),
+      );
+      expect(getByTestId('score-caption').props.children).toBe(
+        'PROVISIONAL — NOT YET CONFIRMED BY THE SERVER',
+      );
+    });
+
+    it('shows the server score and says so once metrics arrive', async () => {
+      const service = createMockHabitService({
+        ratings: {impact: 4, friction: 2, keystone: 3, timeCost: 4},
+        getHabitMetrics: jest.fn().mockResolvedValue({
+          habit_id: 'habit-1',
+          score: 81,
+          completed_days: 3,
+          eligible_days: 7,
+          completion_rate: 43,
+          current_streak: 2,
+        }),
+      });
+
+      const {getByTestId} = render(
+        <StatsScreen route={defaultRoute} habitService={service} />,
+      );
+
+      await waitFor(() =>
+        expect(getByTestId('score-caption').props.children).toBe(
+          'SERVER-AUTHORITATIVE WEIGHTED SCORE',
+        ),
+      );
+      // The server value wins over the local 56 the ratings would produce.
+      expect(getByTestId('score-value').props.children).toBe(81);
+      expect(getByTestId('streak-count').props.children).toBe(2);
+    });
+  });
 
   it('matches snapshot', async () => {
     // Pin "today" so the calendar header renders March 2026 deterministically.

--- a/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/DashboardScreen.test.tsx.snap
@@ -340,6 +340,7 @@ exports[`DashboardScreen matches snapshot 1`] = `
             "id": "1",
             "name": "Exercise",
             "score": 50,
+            "scoreIsProvisional": true,
             "streak": 7,
           },
           {
@@ -347,6 +348,7 @@ exports[`DashboardScreen matches snapshot 1`] = `
             "id": "2",
             "name": "Read",
             "score": 50,
+            "scoreIsProvisional": true,
             "streak": 0,
           },
         ]
@@ -648,10 +650,19 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 7 days
               </Text>
               <Text
+                accessibilityLabel="Score 50, not yet synced"
+                style={
+                  {
+                    "color": "#5B544B",
+                    "fontFamily": "Space Mono",
+                    "fontSize": 10,
+                  }
+                }
                 testID="score-1"
               >
                 SCORE 
                 50
+                 ·
               </Text>
             </View>
           </View>
@@ -868,10 +879,19 @@ exports[`DashboardScreen matches snapshot 1`] = `
                 0 days
               </Text>
               <Text
+                accessibilityLabel="Score 50, not yet synced"
+                style={
+                  {
+                    "color": "#5B544B",
+                    "fontFamily": "Space Mono",
+                    "fontSize": 10,
+                  }
+                }
                 testID="score-2"
               >
                 SCORE 
                 50
+                 ·
               </Text>
             </View>
           </View>

--- a/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
+++ b/src/__tests__/screens/__snapshots__/StatsScreen.test.tsx.snap
@@ -2125,6 +2125,765 @@ exports[`StatsScreen matches snapshot 1`] = `
         </Text>
         <View
           style={
+            {
+              "backgroundColor": "#FAF5EA",
+              "borderColor": "#6A5A86",
+              "borderRadius": 22,
+              "borderWidth": 2,
+              "marginBottom": 16,
+              "padding": 16,
+            }
+          }
+          testID="rating-editor"
+        >
+          <Text
+            style={
+              {
+                "color": "#5B544B",
+                "fontFamily": "Space Mono",
+                "fontSize": 11,
+                "letterSpacing": 0.7,
+                "marginBottom": 8,
+              }
+            }
+          >
+            RATE THIS HABIT
+          </Text>
+          <View
+            accessibilityLabel="impact"
+            accessibilityRole="adjustable"
+            accessibilityValue={
+              {
+                "max": 5,
+                "min": 1,
+                "now": 3,
+              }
+            }
+            style={
+              {
+                "alignItems": "center",
+                "borderTopColor": "#6A5A86",
+                "borderTopWidth": 1.5,
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "minHeight": 42,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#2E2A26",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 11,
+                }
+              }
+            >
+              IMPACT
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Decrease impact"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  −
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#6A5A86",
+                    "fontFamily": "Archivo Black",
+                    "fontSize": 20,
+                    "minWidth": 18,
+                    "textAlign": "center",
+                  }
+                }
+                testID="rating-impact"
+              >
+                3
+              </Text>
+              <View
+                accessibilityLabel="Increase impact"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  +
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityLabel="friction"
+            accessibilityRole="adjustable"
+            accessibilityValue={
+              {
+                "max": 5,
+                "min": 1,
+                "now": 3,
+              }
+            }
+            style={
+              {
+                "alignItems": "center",
+                "borderTopColor": "#6A5A86",
+                "borderTopWidth": 1.5,
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "minHeight": 42,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#2E2A26",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 11,
+                }
+              }
+            >
+              FRICTION
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Decrease friction"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  −
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#6A5A86",
+                    "fontFamily": "Archivo Black",
+                    "fontSize": 20,
+                    "minWidth": 18,
+                    "textAlign": "center",
+                  }
+                }
+                testID="rating-friction"
+              >
+                3
+              </Text>
+              <View
+                accessibilityLabel="Increase friction"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  +
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityLabel="keystone"
+            accessibilityRole="adjustable"
+            accessibilityValue={
+              {
+                "max": 5,
+                "min": 1,
+                "now": 3,
+              }
+            }
+            style={
+              {
+                "alignItems": "center",
+                "borderTopColor": "#6A5A86",
+                "borderTopWidth": 1.5,
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "minHeight": 42,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#2E2A26",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 11,
+                }
+              }
+            >
+              KEYSTONE
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Decrease keystone"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  −
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#6A5A86",
+                    "fontFamily": "Archivo Black",
+                    "fontSize": 20,
+                    "minWidth": 18,
+                    "textAlign": "center",
+                  }
+                }
+                testID="rating-keystone"
+              >
+                3
+              </Text>
+              <View
+                accessibilityLabel="Increase keystone"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  +
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityLabel="time cost"
+            accessibilityRole="adjustable"
+            accessibilityValue={
+              {
+                "max": 5,
+                "min": 1,
+                "now": 3,
+              }
+            }
+            style={
+              {
+                "alignItems": "center",
+                "borderTopColor": "#6A5A86",
+                "borderTopWidth": 1.5,
+                "flexDirection": "row",
+                "justifyContent": "space-between",
+                "minHeight": 42,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#2E2A26",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 11,
+                }
+              }
+            >
+              TIME COST
+            </Text>
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                accessibilityLabel="Decrease time cost"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  −
+                </Text>
+              </View>
+              <Text
+                style={
+                  {
+                    "color": "#6A5A86",
+                    "fontFamily": "Archivo Black",
+                    "fontSize": 20,
+                    "minWidth": 18,
+                    "textAlign": "center",
+                  }
+                }
+                testID="rating-timeCost"
+              >
+                3
+              </Text>
+              <View
+                accessibilityLabel="Increase time cost"
+                accessibilityRole="button"
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": false,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                hitSlop={8}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "backgroundColor": "#3D2F52",
+                    "borderRadius": 22,
+                    "height": 30,
+                    "justifyContent": "center",
+                    "width": 30,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    {
+                      "color": "#FAF5EA",
+                      "fontSize": 20,
+                      "lineHeight": 22,
+                    }
+                  }
+                >
+                  +
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            accessibilityLabel="Save habit ratings"
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "busy": false,
+                "checked": undefined,
+                "disabled": false,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "#C7754A",
+                "borderColor": "#8E4F2E",
+                "borderRadius": 22,
+                "borderWidth": 2,
+                "marginTop": 16,
+                "paddingVertical": 8,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#3D2F52",
+                  "fontFamily": "Space Mono",
+                  "fontSize": 11,
+                }
+              }
+            >
+              SAVE RATINGS
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
             [
               {
                 "position": "relative",
@@ -4493,6 +5252,7 @@ exports[`StatsScreen matches snapshot 1`] = `
                   "marginTop": 8,
                 }
               }
+              testID="score-value"
             >
               50
             </Text>
@@ -4504,8 +5264,9 @@ exports[`StatsScreen matches snapshot 1`] = `
                   "fontSize": 10,
                 }
               }
+              testID="score-caption"
             >
-              SERVER-AUTHORITATIVE WEIGHTED SCORE
+              PROVISIONAL — NOT YET CONFIRMED BY THE SERVER
             </Text>
           </View>
         </View>

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -474,6 +474,110 @@ describe('HabitService', () => {
       expect(alicesRow.name).toBe('Alice habit');
       expect(alicesRow.userId).toBe(ALICE);
     });
+
+    // ─── Score reconciliation (#115) ─────────────────────────────────
+
+    it('stores the score the server computed rather than discarding it', async () => {
+      await service.applyPulledHabits([
+        {
+          id: 'remote-1',
+          name: 'Remote habit',
+          created_at: new Date().toISOString(),
+          is_active: true,
+          impact: 4,
+          friction: 2,
+          keystone: 3,
+          time_cost: 4,
+          score: 56,
+        },
+      ]);
+
+      const row = await database.get<Habit>('habits').find('remote-1');
+      expect(row.score).toBe(56);
+      expect(row.synced).toBe(true);
+      expect(service.getHabitScore(row)).toBe(56);
+      expect(service.isScoreProvisional(row)).toBe(false);
+    });
+
+    it('reconciles an existing synced habit to the server score', async () => {
+      const habit = await createTestHabit(database, 'Exercise', true);
+      await database.write(async () => {
+        await habit.update(h => {
+          h.impact = 3;
+          h.friction = 3;
+          h.keystone = 3;
+          h.timeCost = 3;
+          h.score = 50;
+        });
+      });
+
+      await service.applyPulledHabits([
+        {
+          id: habit.id,
+          name: 'Exercise',
+          created_at: new Date().toISOString(),
+          is_active: true,
+          impact: 5,
+          friction: 1,
+          keystone: 5,
+          time_cost: 1,
+          score: 100,
+        },
+      ]);
+
+      const row = await database.get<Habit>('habits').find(habit.id);
+      expect(row.score).toBe(100);
+    });
+
+    it('derives the score when the server omits it', async () => {
+      await service.applyPulledHabits([
+        {
+          id: 'remote-2',
+          name: 'Legacy server',
+          created_at: new Date().toISOString(),
+          is_active: true,
+          impact: 4,
+          friction: 2,
+          keystone: 3,
+          time_cost: 4,
+        },
+      ]);
+
+      const row = await database.get<Habit>('habits').find('remote-2');
+      // Identical formula to the server's, so the fallback is the same number.
+      expect(row.score).toBe(56);
+    });
+
+    it('leaves a locally edited habit alone, server score included', async () => {
+      const habit = await createTestHabit(database, 'Exercise', true);
+      await service.setHabitRatings(habit.id, {
+        impact: 5,
+        friction: 1,
+        keystone: 5,
+        timeCost: 1,
+      });
+
+      await service.applyPulledHabits([
+        {
+          id: habit.id,
+          name: 'Server name',
+          created_at: new Date().toISOString(),
+          is_active: true,
+          impact: 1,
+          friction: 5,
+          keystone: 1,
+          time_cost: 5,
+          score: 0,
+        },
+      ]);
+
+      const row = await database.get<Habit>('habits').find(habit.id);
+      expect(row.name).toBe('Exercise');
+      expect(row.impact).toBe(5);
+      expect(row.score).toBe(100);
+      expect(row.synced).toBe(false);
+      expect(service.isScoreProvisional(row)).toBe(true);
+    });
   });
 
   // ─── Legacy row claiming (#123) ────────────────────────────────────
@@ -806,6 +910,116 @@ describe('HabitService', () => {
 
     it('is a no-op for an empty batch', async () => {
       await expect(service.markHabitsSynced([])).resolves.toBeUndefined();
+    });
+
+    // ─── In-flight edits must not be lost (#115) ───────────────────
+
+    it('leaves a habit dirty when its ratings changed after the push started', async () => {
+      const habit = await createTestHabit(database, 'Exercise', false);
+      await service.setHabitRatings(habit.id, {
+        impact: 3,
+        friction: 3,
+        keystone: 3,
+        timeCost: 3,
+      });
+
+      // What SyncService put on the wire.
+      const pushed = new Map([
+        [
+          habit.id,
+          {
+            name: 'Exercise',
+            is_active: true,
+            impact: 3,
+            friction: 3,
+            keystone: 3,
+            time_cost: 3,
+          },
+        ],
+      ]);
+
+      // The user edits while the request is still in flight.
+      await service.setHabitRatings(habit.id, {
+        impact: 5,
+        friction: 1,
+        keystone: 5,
+        timeCost: 1,
+      });
+
+      await service.markHabitsSynced([habit], pushed);
+
+      const row = await database.get<Habit>('habits').find(habit.id);
+      // Clearing it here would strand the newer ratings: they were never sent.
+      expect(row.synced).toBe(false);
+      expect(row.impact).toBe(5);
+      expect(await service.getUnsyncedHabits()).toHaveLength(1);
+    });
+
+    it('marks a habit synced when it still matches what was pushed', async () => {
+      const habit = await createTestHabit(database, 'Exercise', false);
+      await service.setHabitRatings(habit.id, {
+        impact: 4,
+        friction: 2,
+        keystone: 3,
+        timeCost: 4,
+      });
+
+      const pushed = new Map([
+        [
+          habit.id,
+          {
+            name: 'Exercise',
+            is_active: true,
+            impact: 4,
+            friction: 2,
+            keystone: 3,
+            time_cost: 4,
+          },
+        ],
+      ]);
+
+      await service.markHabitsSynced([habit], pushed);
+
+      const row = await database.get<Habit>('habits').find(habit.id);
+      expect(row.synced).toBe(true);
+      expect(await service.getUnsyncedHabits()).toHaveLength(0);
+    });
+
+    it('holds back only the habits that moved', async () => {
+      const stable = await createTestHabit(database, 'Stable', false);
+      const edited = await createTestHabit(database, 'Edited', false);
+      const fields = (name: string) => ({
+        name,
+        is_active: true,
+        impact: 3,
+        friction: 3,
+        keystone: 3,
+        time_cost: 3,
+      });
+      for (const h of [stable, edited]) {
+        await service.setHabitRatings(h.id, {
+          impact: 3,
+          friction: 3,
+          keystone: 3,
+          timeCost: 3,
+        });
+      }
+      const pushed = new Map([
+        [stable.id, fields('Stable')],
+        [edited.id, fields('Edited')],
+      ]);
+
+      await service.setHabitRatings(edited.id, {
+        impact: 1,
+        friction: 1,
+        keystone: 1,
+        timeCost: 1,
+      });
+
+      await service.markHabitsSynced([stable, edited], pushed);
+
+      expect((await database.get<Habit>('habits').find(stable.id)).synced).toBe(true);
+      expect((await database.get<Habit>('habits').find(edited.id)).synced).toBe(false);
     });
   });
 

--- a/src/__tests__/services/SyncService.test.ts
+++ b/src/__tests__/services/SyncService.test.ts
@@ -70,6 +70,14 @@ function createMockHabit(id: string, name: string = 'Habit') {
     createdAt: 1_700_000_000_000,
     isActive: true,
     synced: false,
+    // Non-neutral on purpose: with the ratings left unset the payload carried
+    // `impact: undefined`, and toHaveBeenCalledWith's toEqual semantics treat
+    // an undefined property as absent — so the four rating lines could be
+    // deleted from SyncService and this suite would stay green.
+    impact: 5,
+    friction: 2,
+    keystone: 4,
+    timeCost: 1,
     markSynced: jest.fn().mockResolvedValue(undefined),
   };
 }
@@ -228,6 +236,10 @@ describe('SyncService', () => {
             name: 'Drink water',
             created_at_ms: 1_700_000_000_000,
             is_active: true,
+            impact: 5,
+            friction: 2,
+            keystone: 4,
+            time_cost: 1,
           },
         ],
       });

--- a/src/__tests__/utils/habitScoring.test.ts
+++ b/src/__tests__/utils/habitScoring.test.ts
@@ -17,4 +17,45 @@ describe('calculateHabitScore', () => {
     expect(calculateHabitScore(3, 4, 3, 3)).toBeLessThan(neutral);
     expect(calculateHabitScore(3, 3, 3, 4)).toBeLessThan(neutral);
   });
+
+  // ─── Parity with the backend (#115) ────────────────────────────────
+  //
+  // The server computes the score independently in
+  // backend/app/schemas.py::habit_score as `(100 * r * 2 + 16) // 32`, using
+  // exact integer arithmetic. This client uses `floor((100 * r + 8) / 16)` on
+  // floats. Both reduce to `floor((25r + 2) / 4)`; a drift between them would
+  // make the score jump when a habit syncs, so pin the whole input space
+  // rather than the four contract anchors alone.
+  it('matches the backend formula across every valid rating combination', () => {
+    for (let impact = 1; impact <= 5; impact++) {
+      for (let friction = 1; friction <= 5; friction++) {
+        for (let keystone = 1; keystone <= 5; keystone++) {
+          for (let timeCost = 1; timeCost <= 5; timeCost++) {
+            const raw =
+              impact + (6 - friction) + keystone + (6 - timeCost) - 4;
+            const backend = Math.floor((100 * raw * 2 + 16) / 32);
+            expect(calculateHabitScore(impact, friction, keystone, timeCost)).toBe(
+              backend,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it('spans exactly 0 to 100 over the valid range', () => {
+    const scores: number[] = [];
+    for (let impact = 1; impact <= 5; impact++) {
+      for (let friction = 1; friction <= 5; friction++) {
+        for (let keystone = 1; keystone <= 5; keystone++) {
+          for (let timeCost = 1; timeCost <= 5; timeCost++) {
+            scores.push(calculateHabitScore(impact, friction, keystone, timeCost));
+          }
+        }
+      }
+    }
+    expect(Math.min(...scores)).toBe(0);
+    expect(Math.max(...scores)).toBe(100);
+    expect(scores.every(Number.isInteger)).toBe(true);
+  });
 });

--- a/src/components/HabitCard.tsx
+++ b/src/components/HabitCard.tsx
@@ -15,6 +15,8 @@ interface HabitCardProps {
   completedToday: boolean;
   streak: number;
   score?: number;
+  /** Score is a local estimate the server has not confirmed yet. */
+  scoreIsProvisional?: boolean;
   onToggle: (habitId: string) => void;
   onPress?: (habitId: string) => void;
 }
@@ -28,6 +30,7 @@ function areEqual(prev: HabitCardProps, next: HabitCardProps): boolean {
     prev.completedToday === next.completedToday &&
     prev.streak === next.streak &&
     prev.score === next.score &&
+    prev.scoreIsProvisional === next.scoreIsProvisional &&
     prev.onToggle === next.onToggle &&
     prev.onPress === next.onPress
   );
@@ -39,6 +42,7 @@ const HabitCard: React.FC<HabitCardProps> = ({
   completedToday,
   streak,
   score,
+  scoreIsProvisional = false,
   onToggle,
   onPress,
 }) => {
@@ -108,7 +112,17 @@ const HabitCard: React.FC<HabitCardProps> = ({
           🔥 {streakLabel}
         </Text>
         {score !== undefined && (
-          <Text testID={`score-${habitId}`}>SCORE {score}</Text>
+          <Text
+            style={styles.scoreText}
+            testID={`score-${habitId}`}
+            accessibilityLabel={
+              scoreIsProvisional
+                ? `Score ${score}, not yet synced`
+                : `Score ${score}`
+            }>
+            SCORE {score}
+            {scoreIsProvisional ? ' ·' : ''}
+          </Text>
         )}
       </View>
     </Pressable>
@@ -166,6 +180,11 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '700',
     color: colors.text,
+  },
+  scoreText: {
+    fontFamily: fontFamily.mono,
+    fontSize: 10,
+    color: colors.textSoft,
   },
 });
 

--- a/src/components/RatingEditor.tsx
+++ b/src/components/RatingEditor.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Pressable, StyleSheet, Text, View} from 'react-native';
 import {colors} from '../theme/colors';
 import {fontFamily} from '../theme/typography';
@@ -14,7 +14,17 @@ export interface HabitRatings {
 
 interface RatingEditorProps {
   ratings: HabitRatings;
-  onSave: (ratings: HabitRatings) => Promise<void>;
+  /**
+   * Uncontrolled mode: the editor keeps its own draft and renders a save
+   * button. Used by the habit detail screen, where ratings are saved on their
+   * own. A rejection is caught and shown to the user, and the draft is kept.
+   */
+  onSave?: (ratings: HabitRatings) => Promise<void>;
+  /**
+   * Controlled mode: every change is reported up and no save button is drawn.
+   * Used by the create modal, which saves through its own CREATE button.
+   */
+  onChange?: (ratings: HabitRatings) => void;
 }
 
 const fields: Array<{key: keyof HabitRatings; label: string}> = [
@@ -24,39 +34,82 @@ const fields: Array<{key: keyof HabitRatings; label: string}> = [
   {key: 'timeCost', label: 'TIME COST'},
 ];
 
-const RatingEditor: React.FC<RatingEditorProps> = ({ratings, onSave}) => {
+const MIN_RATING = 1;
+const MAX_RATING = 5;
+
+const RatingEditor: React.FC<RatingEditorProps> = ({
+  ratings,
+  onSave,
+  onChange,
+}) => {
   const [draft, setDraft] = useState(ratings);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => setDraft(ratings), [ratings]);
 
-  const change = (key: keyof HabitRatings, delta: number) => {
-    setDraft(current => ({
-      ...current,
-      [key]: Math.max(1, Math.min(5, current[key] + delta)),
-    }));
-  };
+  const change = useCallback(
+    (key: keyof HabitRatings, delta: number) => {
+      setDraft(current => {
+        const next = {
+          ...current,
+          [key]: Math.max(
+            MIN_RATING,
+            Math.min(MAX_RATING, current[key] + delta),
+          ),
+        };
+        onChange?.(next);
+        return next;
+      });
+      // A new edit supersedes whatever the last failed save said.
+      setError(null);
+    },
+    [onChange],
+  );
 
-  const save = async () => {
+  const save = useCallback(async () => {
+    if (!onSave) {
+      return;
+    }
     setSaving(true);
+    setError(null);
     try {
       await onSave(draft);
+    } catch (err) {
+      // Keep `draft` as it is: the user's edit is the only copy of their
+      // intent, and discarding it would present unsaved numbers as saved
+      // (issue #127).
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Could not save your ratings. Please try again.',
+      );
     } finally {
       setSaving(false);
     }
-  };
+  }, [draft, onSave]);
 
   return (
     <View testID="rating-editor" style={styles.container}>
       <Text style={styles.heading}>RATE THIS HABIT</Text>
       {fields.map(({key, label}) => (
-        <View key={key} style={styles.row}>
+        <View
+          key={key}
+          style={styles.row}
+          accessibilityRole="adjustable"
+          accessibilityLabel={label.toLowerCase()}
+          accessibilityValue={{
+            min: MIN_RATING,
+            max: MAX_RATING,
+            now: draft[key],
+          }}>
           <Text style={styles.label}>{label}</Text>
           <View style={styles.controls}>
             <Pressable
               accessibilityLabel={`Decrease ${label.toLowerCase()}`}
               accessibilityRole="button"
-              disabled={draft[key] <= 1 || saving}
+              disabled={draft[key] <= MIN_RATING || saving}
+              hitSlop={8}
               onPress={() => change(key, -1)}
               style={styles.button}>
               <Text style={styles.buttonText}>−</Text>
@@ -67,7 +120,8 @@ const RatingEditor: React.FC<RatingEditorProps> = ({ratings, onSave}) => {
             <Pressable
               accessibilityLabel={`Increase ${label.toLowerCase()}`}
               accessibilityRole="button"
-              disabled={draft[key] >= 5 || saving}
+              disabled={draft[key] >= MAX_RATING || saving}
+              hitSlop={8}
               onPress={() => change(key, 1)}
               style={styles.button}>
               <Text style={styles.buttonText}>+</Text>
@@ -75,14 +129,27 @@ const RatingEditor: React.FC<RatingEditorProps> = ({ratings, onSave}) => {
           </View>
         </View>
       ))}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Save habit ratings"
-        disabled={saving}
-        onPress={save}
-        style={styles.saveButton}>
-        <Text style={styles.saveText}>{saving ? 'SAVING…' : 'SAVE RATINGS'}</Text>
-      </Pressable>
+      {error !== null && (
+        <Text
+          accessibilityLiveRegion="polite"
+          style={styles.error}
+          testID="rating-save-error">
+          {error}
+        </Text>
+      )}
+      {onSave && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save habit ratings"
+          accessibilityState={{busy: saving, disabled: saving}}
+          disabled={saving}
+          onPress={save}
+          style={styles.saveButton}>
+          <Text style={styles.saveText}>
+            {saving ? 'SAVING…' : 'SAVE RATINGS'}
+          </Text>
+        </Pressable>
+      )}
     </View>
   );
 };
@@ -128,6 +195,12 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.display,
     fontSize: 20,
     color: colors.regalia,
+  },
+  error: {
+    marginTop: spacing.sm,
+    fontFamily: fontFamily.mono,
+    fontSize: 11,
+    color: colors.error,
   },
   saveButton: {
     marginTop: spacing.md,

--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -13,6 +13,12 @@ export interface HabitDisplayData {
   completedToday: boolean;
   streak: number;
   score: number;
+  /**
+   * True while the score is a local estimate whose ratings have not reached
+   * the server yet. Comes from HabitService.isScoreProvisional, which is the
+   * single source of the distinction.
+   */
+  scoreIsProvisional: boolean;
 }
 
 export function useHabits(habitService: HabitService) {
@@ -64,6 +70,8 @@ export function useHabits(habitService: HabitService) {
               habit.keystone || 3,
               habit.timeCost || 3,
             ),
+            scoreIsProvisional:
+              habitService.isScoreProvisional?.(habit) ?? !habit.synced,
           };
         }),
       );

--- a/src/models/Habit.ts
+++ b/src/models/Habit.ts
@@ -21,6 +21,10 @@ export default class Habit extends Model {
   @field('friction') friction!: number;
   @field('keystone') keystone!: number;
   @field('time_cost') timeCost!: number;
+  // Server-authoritative score once `synced` is true; a locally derived
+  // provisional value while there are unsynced rating edits. Null on a row
+  // that predates the column and has not been pulled since.
+  @field('score') score!: number | null;
 
   @children('habit_logs') habitLogs!: Query<HabitLog>;
 

--- a/src/models/migrations.ts
+++ b/src/models/migrations.ts
@@ -76,5 +76,23 @@ export const migrations = schemaMigrations({
         ),
       ],
     },
+    {
+      toVersion: 7,
+      steps: [
+        addColumns({
+          table: 'habits',
+          columns: [{name: 'score', type: 'number', isOptional: true}],
+        }),
+        // Seed the column with the contract score derived from the ratings
+        // already stored, so no habit shows a 0 between this migration and the
+        // first pull that reconciles it against the server. SQLite `/` on
+        // integers truncates, which is exactly the half-up rounding the
+        // contract specifies once the +8 is applied
+        // (docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md).
+        unsafeExecuteSql(
+          'UPDATE habits SET score = (100 * (impact + (6 - friction) + keystone + (6 - time_cost) - 4) + 8) / 16;',
+        ),
+      ],
+    },
   ],
 });

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,7 +1,7 @@
 import {appSchema, tableSchema} from '@nozbe/watermelondb';
 
 export const schema = appSchema({
-  version: 6,
+  version: 7,
   tables: [
     tableSchema({
       name: 'habits',
@@ -21,6 +21,14 @@ export const schema = appSchema({
         {name: 'friction', type: 'number'},
         {name: 'keystone', type: 'number'},
         {name: 'time_cost', type: 'number'},
+        // Last score the server told us about, reconciled on every pull.
+        // Provisional (locally derived) while `synced` is false — see
+        // HabitService.getHabitScore / isScoreProvisional.
+        //
+        // Optional so "never written" reads as null: an unset number column
+        // reads as 0, and 0 is a legitimate score (ratings 1/5/1/5), so
+        // without this the two are indistinguishable.
+        {name: 'score', type: 'number', isOptional: true},
       ],
     }),
     tableSchema({

--- a/src/screens/CreateHabitModal.tsx
+++ b/src/screens/CreateHabitModal.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import {
+  ScrollView,
   View,
   Text,
   TextInput,
@@ -13,10 +14,19 @@ import {radii, borders, shadowOffsets} from '../theme';
 import NBCard from '../components/atoms/NBCard';
 import NBButton from '../components/atoms/NBButton';
 import NBShadow from '../components/atoms/NBShadow';
+import RatingEditor, {type HabitRatings} from '../components/RatingEditor';
 import HabitService from '../services/HabitService';
 import {getDefaultHabitService} from '../services/defaultHabitService';
 
 const MAX_LENGTH = 50;
+
+// The contract's neutral starting point: a habit nobody has rated scores 50.
+const NEUTRAL_RATINGS: HabitRatings = {
+  impact: 3,
+  friction: 3,
+  keystone: 3,
+  timeCost: 3,
+};
 
 interface CreateHabitModalProps {
   navigation?: {goBack: () => void};
@@ -30,6 +40,8 @@ const CreateHabitModal: React.FC<CreateHabitModalProps> = ({
   const service = habitService ?? getDefaultHabitService();
   const [name, setName] = useState('');
   const [creating, setCreating] = useState(false);
+  const [ratings, setRatings] = useState<HabitRatings>(NEUTRAL_RATINGS);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const trimmedName = name.trim();
   const isValid = trimmedName.length > 0;
@@ -39,15 +51,22 @@ const CreateHabitModal: React.FC<CreateHabitModalProps> = ({
       return;
     }
     setCreating(true);
+    setErrorMessage(null);
     try {
-      await service.createHabit(trimmedName);
+      await service.createHabit(trimmedName, ratings);
       navigation?.goBack();
-    } catch {
-      // ignore; user can retry
+    } catch (error) {
+      // Previously swallowed, which left the modal open with no explanation
+      // and the habit uncreated.
+      setErrorMessage(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Could not create the habit. Please try again.',
+      );
     } finally {
       setCreating(false);
     }
-  }, [isValid, creating, service, trimmedName, navigation]);
+  }, [isValid, creating, service, trimmedName, ratings, navigation]);
 
   const handleCancel = useCallback(() => {
     navigation?.goBack();
@@ -90,6 +109,23 @@ const CreateHabitModal: React.FC<CreateHabitModalProps> = ({
           <Text style={styles.counter} testID="char-counter">
             {name.length}/{MAX_LENGTH}
           </Text>
+
+          {/* Ratings are set here rather than only after creation, so a habit
+              never has to be created at the neutral default and edited. */}
+          <ScrollView
+            style={styles.ratingsScroll}
+            keyboardShouldPersistTaps="handled">
+            <RatingEditor ratings={ratings} onChange={setRatings} />
+          </ScrollView>
+
+          {errorMessage !== null && (
+            <Text
+              accessibilityLiveRegion="polite"
+              style={styles.error}
+              testID="create-habit-error">
+              {errorMessage}
+            </Text>
+          )}
 
           <View style={styles.buttons}>
             <NBButton
@@ -141,6 +177,18 @@ const styles = StyleSheet.create({
   },
   body: {
     padding: spacing.lg,
+  },
+  ratingsScroll: {
+    // Bounded so the card cannot grow past the screen on small devices once
+    // the keyboard is up.
+    maxHeight: 260,
+    marginTop: spacing.md,
+  },
+  error: {
+    marginTop: spacing.sm,
+    fontFamily: fontFamily.mono,
+    fontSize: 11,
+    color: colors.error,
   },
   title: {
     fontFamily: fontFamily.display,

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -137,6 +137,7 @@ const DashboardScreenBody: React.FC<DashboardScreenBodyProps> = ({
         completedToday={item.completedToday}
         streak={item.streak}
         score={item.score}
+        scoreIsProvisional={item.scoreIsProvisional}
         onToggle={handleToggle}
         onPress={handleHabitPress}
       />

--- a/src/screens/StatsListScreen.tsx
+++ b/src/screens/StatsListScreen.tsx
@@ -82,7 +82,17 @@ const StatsListScreenBody: React.FC<StatsListScreenBodyProps> = ({
               {' '}
               {String(item.streak).padStart(3, '0')} DAYS
             </Text>
-            <Text style={styles.scoreText}> · SCORE {item.score}</Text>
+            <Text
+              style={styles.scoreText}
+              accessibilityLabel={
+                item.scoreIsProvisional
+                  ? `Score ${item.score}, not yet synced`
+                  : `Score ${item.score}`
+              }>
+              {' '}
+              · SCORE {item.score}
+              {item.scoreIsProvisional ? ' ·' : ''}
+            </Text>
           </View>
         </View>
         <NBChevron color={colors.regalia} />

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -35,7 +35,6 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
   habitService,
 }) => {
   const service = habitService ?? getDefaultHabitService();
-  const canEditRatings = typeof (service as unknown as {setHabitRatings?: unknown}).setHabitRatings === 'function';
   const habitId = route?.params?.habitId ?? '';
   const insets = useSafeAreaInsets();
   // Clear the system status bar before laying out the back button + title.
@@ -44,6 +43,9 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
   const [habitName, setHabitName] = useState('');
   const [streak, setStreak] = useState(0);
   const [score, setScore] = useState(50);
+  // False until a metrics response actually lands, so the card cannot claim a
+  // server-authoritative number while showing a local estimate.
+  const [scoreIsAuthoritative, setScoreIsAuthoritative] = useState(false);
   const [completionRate, setCompletionRate] = useState(0);
   const [ratings, setRatings] = useState<HabitRatings>({
     impact: 3,
@@ -82,88 +84,105 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
     };
   }, [streak, animatedStreak]);
 
+  // Owns the habit's own fields only. Score, streak and completion rate are
+  // owned by the metrics effect below: both used to write them, with no
+  // ordering guarantee, so a slow local read could clobber a server value that
+  // had already arrived.
   useEffect(() => {
     if (!habitId) return;
+    let ignore = false;
     (async () => {
       const habit = await service.getHabitById(habitId);
+      if (ignore) return;
       setHabitName(habit.name);
-      const nextRatings = {
+      setRatings({
         impact: habit.impact ?? 3,
         friction: habit.friction ?? 3,
         keystone: habit.keystone ?? 3,
         timeCost: habit.timeCost ?? 3,
-      };
-      setRatings(nextRatings);
-      setScore(
-        service.getHabitScore?.(habit) ?? calculateHabitScore(
-          nextRatings.impact,
-          nextRatings.friction,
-          nextRatings.keystone,
-          nextRatings.timeCost,
-        ),
-      );
-      const today = getTodayString();
-      const currentStreak = await service.calculateStreak(habitId, today);
-      setStreak(currentStreak);
+      });
     })();
+    return () => {
+      ignore = true;
+    };
   }, [habitId, service]);
 
+  // The sole owner of score, streak and completion rate. `ratings` is a
+  // dependency so saving an edit re-reconciles against the server instead of
+  // leaving the provisional value on screen until the month changes.
   useEffect(() => {
     if (!habitId) return;
+    let ignore = false;
     (async () => {
-      const startDate = format(
-        new Date(calendarYear, calendarMonth, 1),
-        'yyyy-MM-dd',
-      );
-      const daysInMonth = getDaysInMonth(
-        new Date(calendarYear, calendarMonth),
-      );
+      const monthStart = new Date(calendarYear, calendarMonth, 1);
+      const daysInMonth = getDaysInMonth(new Date(calendarYear, calendarMonth));
+      const startDate = format(monthStart, 'yyyy-MM-dd');
       const endDate = format(
         new Date(calendarYear, calendarMonth, daysInMonth),
         'yyyy-MM-dd',
       );
+      const today = getTodayString();
+
       const logs = await service.getLogsForHabit(habitId, startDate, endDate);
-      setCompletedDates(new Set(logs.map(log => log.completedDate)));
+      if (ignore) return;
+      const completed = new Set(logs.map(log => log.completedDate));
+      setCompletedDates(completed);
+
       let metrics;
       try {
         metrics = await service.getHabitMetrics?.(
           habitId,
           startDate,
           endDate,
-          getTodayString(),
+          today,
         );
       } catch {
         // The calendar remains useful offline; local values are provisional
         // until the server metrics request succeeds.
         metrics = undefined;
       }
+      if (ignore) return;
+
       if (metrics) {
         setCompletionRate(metrics.completion_rate);
         setScore(metrics.score);
         setStreak(metrics.current_streak);
-      } else {
-        const daysInMonth = getDaysInMonth(new Date(calendarYear, calendarMonth));
-        setCompletionRate(
-          daysInMonth > 0 ? Math.round((new Set(logs.map(log => log.completedDate)).size * 100) / daysInMonth) : 0,
-        );
+        setScoreIsAuthoritative(true);
+        return;
       }
-    })();
-  }, [habitId, calendarYear, calendarMonth, service]);
 
+      // Offline fallback: the same formula the server would apply, so the
+      // number does not jump when the request later succeeds.
+      setScoreIsAuthoritative(false);
+      setScore(
+        calculateHabitScore(
+          ratings.impact,
+          ratings.friction,
+          ratings.keystone,
+          ratings.timeCost,
+        ),
+      );
+      setCompletionRate(
+        daysInMonth > 0
+          ? Math.round((completed.size * 100) / daysInMonth)
+          : 0,
+      );
+      const localStreak = await service.calculateStreak(habitId, today);
+      if (ignore) return;
+      setStreak(localStreak);
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [habitId, calendarYear, calendarMonth, service, ratings]);
+
+  // Deliberately not caught: RatingEditor owns the failure message and keeps
+  // the user's draft (issue #127). setRatings only runs on success, and it
+  // re-triggers the metrics effect, which reconciles the score.
   const handleSaveRatings = useCallback(
     async (nextRatings: HabitRatings) => {
-      const saveRatings = (service as unknown as {
-        setHabitRatings?: HabitService['setHabitRatings'];
-      }).setHabitRatings;
-      if (!saveRatings) return;
-      await saveRatings.call(service, habitId, nextRatings);
+      await service.setHabitRatings(habitId, nextRatings);
       setRatings(nextRatings);
-      setScore(calculateHabitScore(
-        nextRatings.impact,
-        nextRatings.friction,
-        nextRatings.keystone,
-        nextRatings.timeCost,
-      ));
     },
     [habitId, service],
   );
@@ -211,9 +230,7 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
           {habitName}
         </Text>
 
-        {canEditRatings && (
-          <RatingEditor ratings={ratings} onSave={handleSaveRatings} />
-        )}
+        <RatingEditor ratings={ratings} onSave={handleSaveRatings} />
 
         <NBCard style={styles.streakCard} testID="streak-section">
           <View style={styles.streakStrip}>
@@ -265,8 +282,14 @@ const StatsScreen: React.FC<StatsScreenProps> = ({
             <Text style={styles.summaryStripText}>HABIT SCORE</Text>
             <Text style={styles.summaryStripText}>0—100</Text>
           </View>
-          <Text style={styles.scoreNumber}>{score}</Text>
-          <Text style={styles.scoreCaption}>SERVER-AUTHORITATIVE WEIGHTED SCORE</Text>
+          <Text style={styles.scoreNumber} testID="score-value">
+            {score}
+          </Text>
+          <Text style={styles.scoreCaption} testID="score-caption">
+            {scoreIsAuthoritative
+              ? 'SERVER-AUTHORITATIVE WEIGHTED SCORE'
+              : 'PROVISIONAL — NOT YET CONFIRMED BY THE SERVER'}
+          </Text>
         </NBCard>
 
         <View style={styles.bottomSpacer} />

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -60,6 +60,49 @@ export function backoffMsFor(retryCount: number): number {
   return Math.min(BACKOFF_BASE_MS * 2 ** exp, BACKOFF_CAP_MS);
 }
 
+export interface HabitRatingValues {
+  impact: number;
+  friction: number;
+  keystone: number;
+  timeCost: number;
+}
+
+// The neutral rating every habit starts at, and what migration 006 backfilled
+// onto rows that predate the columns. Matches the API's own default.
+export const NEUTRAL_RATINGS: HabitRatingValues = {
+  impact: 3,
+  friction: 3,
+  keystone: 3,
+  timeCost: 3,
+};
+
+/**
+ * Enforce the contract's 1-5 integer range before anything is persisted.
+ *
+ * The server rejects out-of-range values with a 422, so failing here keeps a
+ * doomed edit out of the sync queue rather than letting it retry forever.
+ */
+export function validateRatings(ratings: HabitRatingValues): void {
+  for (const value of Object.values(ratings)) {
+    if (!Number.isInteger(value) || value < 1 || value > 5) {
+      throw new Error('Habit ratings must be integers from 1 to 5.');
+    }
+  }
+}
+
+/**
+ * The habit fields SyncService puts on the wire, in the server's snake_case.
+ * Used to detect an edit that landed while the push was in flight.
+ */
+export interface PushedHabitFields {
+  name: string;
+  is_active: boolean;
+  impact: number;
+  friction: number;
+  keystone: number;
+  time_cost: number;
+}
+
 // Owner values that mean "nobody yet": '' is what schema v5 left on rows that
 // predate the user_id column, 'user' is the placeholder this service holds
 // before the first login. Both are claimed on sign-in; see claimLegacyRows.
@@ -121,6 +164,11 @@ export default class HabitService {
         'friction',
         'keystone',
         'time_cost',
+        // `score` changes when a pull reconciles it; `synced` is what flips a
+        // score between provisional and authoritative, so a list that ignored
+        // it would keep showing the provisional marker after a successful sync.
+        'score',
+        'synced',
       ]);
   }
 
@@ -141,6 +189,8 @@ export default class HabitService {
         'friction',
         'keystone',
         'time_cost',
+        'score',
+        'synced',
       ]);
   }
 
@@ -154,7 +204,10 @@ export default class HabitService {
     });
   }
 
-  async createHabit(name: string): Promise<Habit> {
+  async createHabit(
+    name: string,
+    ratings: HabitRatingValues = NEUTRAL_RATINGS,
+  ): Promise<Habit> {
     const trimmed = name.trim();
     if (trimmed.length === 0) {
       throw new Error('Habit name cannot be empty.');
@@ -165,6 +218,8 @@ export default class HabitService {
       );
     }
 
+    validateRatings(ratings);
+
     return this.database.write(async () => {
       return this.database.get<Habit>('habits').create(habit => {
         habit.name = trimmed;
@@ -174,23 +229,27 @@ export default class HabitService {
         habit.synced = false;
         habit.notificationsEnabled = false;
         habit.notificationTime = '08:00';
-        habit.impact = 3;
-        habit.friction = 3;
-        habit.keystone = 3;
-        habit.timeCost = 3;
+        habit.impact = ratings.impact;
+        habit.friction = ratings.friction;
+        habit.keystone = ratings.keystone;
+        habit.timeCost = ratings.timeCost;
+        // Provisional until the first push comes back and a pull reconciles
+        // the server's own value into this column.
+        habit.score = calculateHabitScore(
+          ratings.impact,
+          ratings.friction,
+          ratings.keystone,
+          ratings.timeCost,
+        );
       });
     });
   }
 
   async setHabitRatings(
     habitId: string,
-    ratings: {impact: number; friction: number; keystone: number; timeCost: number},
+    ratings: HabitRatingValues,
   ): Promise<void> {
-    for (const value of Object.values(ratings)) {
-      if (!Number.isInteger(value) || value < 1 || value > 5) {
-        throw new Error('Habit ratings must be integers from 1 to 5.');
-      }
-    }
+    validateRatings(ratings);
     const habit = await this.getHabitById(habitId);
     await this.database.write(async () => {
       await habit.update(h => {
@@ -198,18 +257,47 @@ export default class HabitService {
         h.friction = ratings.friction;
         h.keystone = ratings.keystone;
         h.timeCost = ratings.timeCost;
+        // Provisional: the server recomputes the score from these ratings and
+        // the next pull overwrites this with the authoritative value.
+        h.score = calculateHabitScore(
+          ratings.impact,
+          ratings.friction,
+          ratings.keystone,
+          ratings.timeCost,
+        );
         h.synced = false;
       });
     });
   }
 
+  /**
+   * The score to display for a habit.
+   *
+   * A synced habit shows the column, which the last pull filled from the
+   * server. An unsynced habit's ratings have not reached the server yet, so
+   * its score is recomputed locally from those ratings — the client and server
+   * formulas are the same, so this is the value the server will confirm.
+   * Pair with `isScoreProvisional` to label which of the two is on screen.
+   */
   getHabitScore(habit: Habit): number {
+    if (habit.synced && habit.score != null) {
+      return habit.score;
+    }
     return calculateHabitScore(
       habit.impact || 3,
       habit.friction || 3,
       habit.keystone || 3,
       habit.timeCost || 3,
     );
+  }
+
+  /**
+   * True when the displayed score is a local estimate rather than a value the
+   * server has confirmed. The single source of this distinction — do not
+   * re-derive it at a call site.
+   */
+  isScoreProvisional(habit: Habit): boolean {
+    return !habit.synced;
   }
 
   async getHabitMetrics(
@@ -424,20 +512,54 @@ export default class HabitService {
     });
   }
 
-  async markHabitsSynced(habits: Habit[]): Promise<void> {
+  /**
+   * Mark pushed habits as synced.
+   *
+   * `pushed` is what actually went on the wire, keyed by id. A habit is only
+   * cleared if its current values still match: WatermelonDB hands out one live
+   * instance per record, so an edit made while the request was in flight is
+   * already visible here. Without that check a rating saved mid-push would be
+   * marked synced and never sent — a silent lost update. Rows that moved stay
+   * dirty and go out on the next cycle.
+   *
+   * Omitting `pushed` keeps the previous unconditional behaviour.
+   */
+  async markHabitsSynced(
+    habits: Habit[],
+    pushed?: Map<string, PushedHabitFields>,
+  ): Promise<void> {
     if (habits.length === 0) {
       return;
     }
+    // The push succeeded, so every one of these habits now exists server-side
+    // regardless of whether it has since been edited again locally. Their
+    // backlogged logs deserve a retry either way.
     const habitIds = habits.map(h => h.id);
-    await this.database.write(async () => {
-      await this.database.batch(
-        ...habits.map(habit =>
-          habit.prepareUpdate(h => {
-            h.synced = true;
-          }),
-        ),
+    const unchanged = habits.filter(habit => {
+      const sent = pushed?.get(habit.id);
+      if (!sent) {
+        return true;
+      }
+      return (
+        habit.name === sent.name &&
+        habit.isActive === sent.is_active &&
+        habit.impact === sent.impact &&
+        habit.friction === sent.friction &&
+        habit.keystone === sent.keystone &&
+        habit.timeCost === sent.time_cost
       );
     });
+    if (unchanged.length > 0) {
+      await this.database.write(async () => {
+        await this.database.batch(
+          ...unchanged.map(habit =>
+            habit.prepareUpdate(h => {
+              h.synced = true;
+            }),
+          ),
+        );
+      });
+    }
 
     // The most common cause of per-log "Habit not found" is that the habit
     // hadn't been pushed yet. Now that the habit is on the server, give its
@@ -468,7 +590,19 @@ export default class HabitService {
     }
   }
 
-  async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean; impact: number; friction: number; keystone: number; time_cost: number}>): Promise<void> {
+  async applyPulledHabits(habits: Array<{id: string; name: string; created_at: string; is_active: boolean; impact: number; friction: number; keystone: number; time_cost: number; score?: number}>): Promise<void> {
+    // The server computes `score` from the ratings it stores and returns it on
+    // every habit read, so this is the authoritative value. Older servers that
+    // predate the field fall back to the identical local formula.
+    const scoreOf = (remote: {impact: number; friction: number; keystone: number; time_cost: number; score?: number}) =>
+      remote.score ??
+      calculateHabitScore(
+        remote.impact ?? 3,
+        remote.friction ?? 3,
+        remote.keystone ?? 3,
+        remote.time_cost ?? 3,
+      );
+
     await this.database.write(async () => {
       for (const remote of habits) {
         // Look up by id regardless of owner. Scoping the lookup instead would
@@ -480,7 +614,7 @@ export default class HabitService {
         if (local && local.userId !== this.userId) continue;
         if (local) {
           if (!local.synced) continue; // never overwrite offline work
-          await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; h.impact = remote.impact ?? 3; h.friction = remote.friction ?? 3; h.keystone = remote.keystone ?? 3; h.timeCost = remote.time_cost ?? 3; });
+          await local.update(h => { h.name = remote.name; h.isActive = remote.is_active; h.impact = remote.impact ?? 3; h.friction = remote.friction ?? 3; h.keystone = remote.keystone ?? 3; h.timeCost = remote.time_cost ?? 3; h.score = scoreOf(remote); });
         } else {
           await this.database.get<Habit>('habits').create(h => {
             h._raw.id = remote.id;
@@ -495,6 +629,7 @@ export default class HabitService {
             h.friction = remote.friction ?? 3;
             h.keystone = remote.keystone ?? 3;
             h.timeCost = remote.time_cost ?? 3;
+            h.score = scoreOf(remote);
           });
         }
       }

--- a/src/services/SyncService.ts
+++ b/src/services/SyncService.ts
@@ -8,6 +8,7 @@ import apiClient, {
   isCircuitOpen,
 } from './api';
 import type HabitService from './HabitService';
+import type {PushedHabitFields} from './HabitService';
 
 export const SYNC_AUTH_FAILED_KEY = 'sync_auth_failed';
 
@@ -183,18 +184,26 @@ export default class SyncService {
       return true;
     }
 
-    const payload = {
-      habits: unsyncedHabits.map(habit => ({
-        id: habit.id,
-        name: habit.name,
-        created_at_ms: habit.createdAt,
-        is_active: habit.isActive,
-        impact: habit.impact,
-        friction: habit.friction,
-        keystone: habit.keystone,
-        time_cost: habit.timeCost,
-      })),
-    };
+    const entries = unsyncedHabits.map(habit => ({
+      id: habit.id,
+      name: habit.name,
+      created_at_ms: habit.createdAt,
+      is_active: habit.isActive,
+      impact: habit.impact,
+      friction: habit.friction,
+      keystone: habit.keystone,
+      time_cost: habit.timeCost,
+    }));
+    const payload = {habits: entries};
+    // Snapshot of exactly what goes on the wire. markHabitsSynced compares the
+    // habit against it so an edit made during the request is not cleared
+    // without ever having been sent.
+    const pushed = new Map<string, PushedHabitFields>(
+      entries.map(({id, name, is_active, impact, friction, keystone, time_cost}) => [
+        id,
+        {name, is_active, impact, friction, keystone, time_cost},
+      ]),
+    );
 
     let response: AxiosResponse;
     try {
@@ -212,7 +221,7 @@ export default class SyncService {
     const syncedIds: string[] = response.data?.synced_ids ?? [];
     const syncedSet = new Set(syncedIds);
     const syncedHabits = unsyncedHabits.filter(habit => syncedSet.has(habit.id));
-    await this.habitService.markHabitsSynced(syncedHabits);
+    await this.habitService.markHabitsSynced(syncedHabits, pushed);
     // Only proceed to logs if every habit was accepted; otherwise some logs
     // would still hit "Habit not found".
     return syncedSet.size === unsyncedHabits.length;


### PR DESCRIPTION
Stacked on #138 — **base is `fix/101-register-habit-detail-and-create-routes`**, since the rating UI is unreachable without those routes. Retarget to `main` once #138 merges.

Completes the Android half of #105. The server side (#112, #113, #114) is already live in production: `https://habit-api.darling.solutions` serves ratings as `StrictInt` 1–5 defaulting to 3, a computed `score` on every habit read, and `GET /habits/{id}/metrics`. No backend change was needed.

## Ratings in the create flow

`createHabit` now takes the four ratings instead of hardcoding 3/3/3/3, and `CreateHabitModal` renders `RatingEditor` in a new **controlled mode** (`onChange`, no save button of its own) so a habit is created with the ratings the user picked rather than at neutral-then-edit. The 1–5 integer check moves into a shared `validateRatings` helper used by both `createHabit` and `setHabitRatings`.

## Score reconciliation (schema v7)

The server returns a computed `score` on every habit read and `applyPulledHabits` was silently discarding it. This adds a `score` column, stores the server's value on pull, and seeds a locally derived provisional value on create and on rating edits.

`getHabitScore` returns the stored value for a synced habit and the derived one otherwise; `isScoreProvisional` is the single source of that distinction, surfaced through `useHabits` to `HabitCard` and `StatsListScreen`.

The column is **optional on purpose**: an unset WatermelonDB number column reads as `0`, and 0 is a legitimate score (ratings 1/5/1/5), so without it "never synced" and "genuinely zero" would be indistinguishable. The v7 migration backfills from the ratings already stored.

## Failed saves are no longer silent — closes #127

`RatingEditor.save` caught nothing and its promise was dropped by `onPress`, so a rejection surfaced as an unhandled rejection while the button returned to `SAVE RATINGS` as though it had worked. It now catches, shows the message in an `accessibilityLiveRegion`, **keeps the user's draft**, and re-enables. `CreateHabitModal`'s `catch { // ignore }` gets the same treatment.

## StatsScreen

- Two effects both wrote `score` and `streak` with no ordering guarantee, so a slow local read could clobber a server value that had already arrived. The metrics effect is now their sole owner, re-runs when ratings change, and both effects ignore out-of-order resolution.
- The caption read `SERVER-AUTHORITATIVE` even when the metrics call had failed and the number was a local estimate. It now reflects which one is actually on screen.
- Removed the `canEditRatings` duck-type guard — it was why `RatingEditor` rendered in **no** StatsScreen test, and it silently hid the editor on any partial service.

## Lost update on push

`markHabitsSynced` flipped `synced = true` on habits read *before* the POST, so a rating saved while the request was in flight was marked synced and never sent. `SyncService` now passes exactly what it put on the wire and only still-matching habits are cleared. (`markLogsSynced` has the same shape; filed separately.)

## Accessibility

Each rating row is now `accessibilityRole="adjustable"` with `accessibilityValue` — the value was previously announced as a bare number. Steppers get `hitSlop` (they are 30×30, under the 44×44 target). Existing labels are unchanged so the current tests still query them.

## Tests

The `SyncService` mock habits had no ratings, so the payload carried `impact: undefined` and `toEqual` semantics read that as absent — **the four rating lines could be deleted from `SyncService.ts` and the suite stayed green.** Now pinned, and verified to fail when a field is dropped.

Also adds: a full 625-combination parity test against the backend formula, the migration backfill arithmetic, pull-merge reconciliation (including that a dirty row is left alone), the lost-update guard, the rejecting-`onSave` path #127 asked for, and rating coverage on both screens.

## Verification

- `npx tsc --noEmit` clean; `npm run lint` 0 errors.
- `npx jest --coverage --ci --forceExit` — 23 suites, **376 tests**, 86.3% lines / 71% branches, above the 80/55 gates.
- `pytest --cov=app --cov-fail-under=85` — 83 passed, 95% coverage, confirming no contract drift.
- New guard tests were each confirmed to fail against the unfixed code.

Not yet done on-device: the v7 migration and the offline→sync round trip still want a manual pass on a real handset before release.

Closes #115
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Zu5hkrfrgrbTyP5w4t2Dn