### PR TITLE
docs: mark the scoring contract as implemented

### DIFF
--- a/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
+++ b/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
@@ -1,6 +1,6 @@
 # Issue #105 — Habit weights and scoring contract
 
-Status: proposed for implementation
+Status: implemented — v1 shipped in PR #118 and PR #139; open corrections tracked in #105
 
 This document settles the data and metric semantics before UI or API coding
 starts. It is the v1 contract for habit weights, score, completion rate, and


### PR DESCRIPTION
## What

Changes one line. `docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md:3` said `Status: proposed for implementation`; v1 shipped in PR #118 and PR #139.

## Why now

Epic #105 was rewritten to cite this document as the source of truth for what shipped. Leaving the first substantive line saying the work is unstarted makes that link actively misleading.

## What this does *not* do

This is deliberately partial — the status line only. Everything else stays open on #155:

- lines 192-196 deny a leaderboard endpoint is defined; lines 198-212 define the one that shipped
- §4 line 113-114 forbids UTC conversion; line 211-212 mandates it (the contradiction behind #149)
- line 204 states `opponent_id` is required, which #151 changes
- the streak definition the leaderboard tie-breaker uses, settled by #148
- `_epoch_datetime`'s undocumented seconds-vs-milliseconds heuristic

Refs #155 — does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CFAV3nyunaYt8jVpGEmin