### PR TITLE
refactor: extract the shared streak walk into one helper

### DIFF
--- a/backend/app/routers/habits.py
+++ b/backend/app/routers/habits.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
@@ -16,6 +16,7 @@ from app.schemas import (
     HabitUpdate,
     HabitMetricsRead,
     habit_score,
+    streak_days,
 )
 
 router = APIRouter(prefix="/habits", tags=["habits"])
@@ -169,12 +170,7 @@ async def get_habit_metrics(
         HabitLog.completed_date <= as_of,
         HabitLog.deleted_at.is_(None),
     ))
-    date_set = set(streak_dates)
-    current = as_of if as_of in date_set else as_of - timedelta(days=1)
-    current_streak = 0
-    while current in date_set:
-        current_streak += 1
-        current -= timedelta(days=1)
+    current_streak = streak_days(set(streak_dates), as_of)
 
     return HabitMetricsRead(
         habit_id=habit.id,

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -13,6 +13,7 @@ from app.schemas import (
     LeaderboardRanking,
     LeaderboardTieBreakers,
     habit_score,
+    streak_days,
 )
 
 router = APIRouter(prefix="/v1/leaderboards", tags=["leaderboards"])
@@ -26,21 +27,6 @@ def _epoch_datetime(value: int) -> datetime:
         return datetime.fromtimestamp(seconds, tz=timezone.utc)
     except (OverflowError, OSError, ValueError) as exc:
         raise HTTPException(status_code=422, detail="Invalid epoch boundary") from exc
-
-
-def _streak_days(completed: set[date], as_of: date) -> int:
-    """Consecutive completed days ending at or immediately before ``as_of``.
-
-    Implements section 5 of the scoring contract: start at ``as_of``, or at the
-    previous day when ``as_of`` is not completed, so a user who has completed
-    yesterday but not yet today still sees the active streak.
-    """
-    current = as_of if as_of in completed else as_of - timedelta(days=1)
-    streak = 0
-    while current in completed:
-        streak += 1
-        current -= timedelta(days=1)
-    return streak
 
 
 @router.get("/head-to-head", response_model=HeadToHeadResponse)
@@ -133,7 +119,7 @@ async def head_to_head(
             "display_name": users_by_id[user_id].username,
             "is_current_user": user_id == current_user_id,
             "score": points[user_id],
-            "streak_days": _streak_days(streak_dates[user_id], streak_as_of),
+            "streak_days": streak_days(streak_dates[user_id], streak_as_of),
             "completion_rate_pct": round(completion_rate, 2),
             "last_authoritative_sync": last_sync[user_id],
         })

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Annotated
 
 from pydantic import BaseModel, Field, StrictInt, field_validator
@@ -13,6 +13,26 @@ def habit_score(impact: int, friction: int, keystone: int, time_cost: int) -> in
     """Return the contract score using exact integer half-up rounding."""
     raw_minus_minimum = impact + (6 - friction) + keystone + (6 - time_cost) - 4
     return (100 * raw_minus_minimum * 2 + 16) // (16 * 2)
+
+
+def streak_days(completed: set[date], as_of: date) -> int:
+    """Consecutive completed days ending at or immediately before ``as_of``.
+
+    Implements section 5 of the scoring contract: start at ``as_of``, or at the
+    previous day when ``as_of`` is not completed, so a user who has completed
+    yesterday but not yet today still sees the active streak.
+
+    The candidate set is the caller's decision — the metrics endpoint floors it
+    at the habit's creation date, the leaderboard does not — so the scope stays
+    visible at each call site rather than being fixed here.
+    """
+    current = as_of if as_of in completed else as_of - timedelta(days=1)
+    streak = 0
+    while current in completed:
+        streak += 1
+        current -= timedelta(days=1)
+    return streak
+
 
 class HabitCreate(BaseModel):
     name: str = Field(..., max_length=50)

--- a/backend/tests/test_scoring.py
+++ b/backend/tests/test_scoring.py
@@ -1,4 +1,6 @@
-from app.schemas import habit_score
+from datetime import date
+
+from app.schemas import habit_score, streak_days
 
 
 def test_score_contract_examples():
@@ -14,3 +16,21 @@ def test_score_directionality():
     assert habit_score(3, 3, 4, 3) > neutral
     assert habit_score(3, 4, 3, 3) < neutral
     assert habit_score(3, 3, 3, 4) < neutral
+
+
+# Contract section 5 worked examples, as of Friday 2026-08-28.
+FRIDAY = date(2026, 8, 28)
+THURSDAY = date(2026, 8, 27)
+WEDNESDAY = date(2026, 8, 26)
+TUESDAY = date(2026, 8, 25)
+
+
+def test_streak_contract_examples():
+    assert streak_days({WEDNESDAY, THURSDAY, FRIDAY}, FRIDAY) == 3
+    assert streak_days({TUESDAY, WEDNESDAY, THURSDAY}, FRIDAY) == 3
+    assert streak_days({TUESDAY, THURSDAY, FRIDAY}, FRIDAY) == 2
+    assert streak_days(set(), FRIDAY) == 0
+
+
+def test_streak_is_zero_when_the_run_ended_before_yesterday():
+    assert streak_days({TUESDAY, WEDNESDAY}, FRIDAY) == 0


### PR DESCRIPTION
Closes #154.

## What

The consecutive-day streak walk from §5 of the scoring contract existed twice in `backend/app/` — as `_streak_days` in the leaderboard router and inline in the metrics endpoint — differing only in identifiers (`completed`/`streak` versus `date_set`/`current_streak`).

#154 deliberately blocked on #148, because the two copies are fed differently scoped candidate sets and extracting before that was settled would have cemented #148's bug behind an abstraction. #148 is now merged (#165), so both scopes are deliberate and the extraction can proceed on the issue's own terms.

`streak_days` now lives in `app/schemas.py` beside `habit_score`, which is where the repo already keeps pure contract math and which both routers already import from. It takes an explicit `(completed, as_of)` pair, so the candidate set stays the caller's decision — the metrics endpoint floors it at the habit's creation date, the leaderboard does not — and both scopes remain visible at their call sites.

## Acceptance criteria

- [x] Both routers call one shared streak helper; no second copy of the walk remains in `backend/app/` — `grep -rn "timedelta(days=1)" backend/app/` matches `schemas.py` only.
- [x] External behaviour unchanged — `test_habit_metrics.py` and `test_leaderboards.py` are not touched by this diff and pass as-is.
- [x] The candidate date set is supplied by the caller, so the metrics and leaderboard scopes stay visibly different at each call site.

## Out of scope

- The metrics `completed_date >= creation_date` floor is #164. Extracting first reduces that to a one-line query change.
- The client-side walk in `src/services/HabitService.ts` stays; its query bound is #153.

## Verification

`pytest --cov=app --cov-report=term-missing --cov-fail-under=85` → **91 passed**, coverage 95.06%. The new `test_scoring.py` cases pin the contract's four worked §5 examples directly, matching how that file already pins `habit_score`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3Qhvrn4EgWLshM9VV46MV