### PR TITLE
test: run the backend suite against MariaDB as well as SQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,26 @@ jobs:
       - name: Run pytest with coverage
         run: pytest --cov=app --cov-report=term-missing --cov-fail-under=85
 
+      # The suite above runs on in-memory SQLite. app/routers/logs.py builds a
+      # dialect-native upsert, so its MySQL/MariaDB branch -- the atomic
+      # ON DUPLICATE KEY UPDATE that stops two concurrent /logs/sync requests
+      # racing on the same (habit_id, completed_date) -- is only executed when
+      # the suite runs on that dialect. Re-run it against the MariaDB service
+      # that the migration checks above already start.
+      - name: Run pytest against MariaDB
+        env:
+          # A database of its own, so creating and dropping the schema per test
+          # cannot disturb the migration checks' `habits` / `habits_003`.
+          TEST_DATABASE_URL: mysql+asyncmy://root:secret@127.0.0.1:3306/habits_pytest
+        run: |
+          python - <<'PY'
+          import pymysql
+          conn = pymysql.connect(host="127.0.0.1", user="root", password="secret")
+          conn.cursor().execute("CREATE DATABASE IF NOT EXISTS habits_pytest")
+          conn.close()
+          PY
+          pytest -q
+
   android-build:
     name: Android Build
     runs-on: ubuntu-latest

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,7 +18,12 @@ from app.database import get_db
 from app.main import app
 from app.models import Base, User
 
-TEST_DB_URL = "sqlite+aiosqlite://"
+# In-memory SQLite by default, so a local run needs no database server. CI
+# overrides this to re-run the whole suite against MariaDB, which is what
+# production actually runs: app/routers/logs.py builds a dialect-native upsert,
+# and the branch that guards production against the concurrent-sync race is
+# only exercised when the tests run on that dialect.
+TEST_DB_URL = os.environ.get("TEST_DATABASE_URL", "sqlite+aiosqlite://")
 
 # The account every authenticated test acts as. It is a real row in ``users``:
 # habits.user_id and habit_logs.user_id are foreign keys to it, and the API
@@ -30,12 +35,15 @@ TEST_USER_ID = "user"
 async def db_session():
     engine = create_async_engine(TEST_DB_URL, echo=False)
     # SQLite ignores foreign keys unless asked, which would let the suite pass
-    # while the constraints added in migration 007 went unexercised.
-    event.listen(
-        engine.sync_engine,
-        "connect",
-        lambda dbapi_conn, _record: dbapi_conn.execute("PRAGMA foreign_keys=ON"),
-    )
+    # while the constraints added in migration 007 went unexercised. MariaDB
+    # enforces them natively and rejects the PRAGMA as a syntax error, so this
+    # is registered for SQLite only.
+    if engine.dialect.name == "sqlite":
+        event.listen(
+            engine.sync_engine,
+            "connect",
+            lambda dbapi_conn, _record: dbapi_conn.execute("PRAGMA foreign_keys=ON"),
+        )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)


### PR DESCRIPTION
Closes #168

## Why

The suite only ever ran on in-memory SQLite (`conftest.py:21`) while production runs
MariaDB, so any code branching on the SQL dialect had a production path that no test
executed.

`_upsert_habit_log_stmt` (`backend/app/routers/logs.py:18-49`) is exactly that code —
and its docstring says why it exists:

> Required because two concurrent /logs/sync requests racing on the same
> (habit_id, completed_date) both pass a SELECT existence check and then both
> INSERT, violating uq_habit_date on the second commit.

**That guard had no test coverage.** Same 19 tests in `tests/test_logs.py`, changing only
the database:

| Run | `app/routers/logs.py` missing lines |
| --- | --- |
| SQLite | **26-27**, 32-33, 49, 58, 105-110 |
| MariaDB | 32-33, 49, 58, 105-110 |

Lines 26-27 are the `ON DUPLICATE KEY UPDATE` statement. 32-33 is the PostgreSQL branch,
correctly still uncovered since Postgres isn't deployed.

## What changed

**`backend/tests/conftest.py`** — two lines of behaviour:

* `TEST_DB_URL` now reads `TEST_DATABASE_URL`, defaulting to `sqlite+aiosqlite://`. A
  local `pytest` with no environment set is unchanged and still needs no database server.
* The foreign-key PRAGMA is registered for SQLite only. MariaDB enforces foreign keys
  natively and rejects `PRAGMA foreign_keys=ON` as a syntax error.

**`.github/workflows/ci.yml`** — one new step in `backend-tests`, reusing the `mariadb:11`
service the migration checks already start. It creates `habits_pytest` first, so the
per-test schema create/drop cannot disturb the migration checks' `habits` / `habits_003`.

No test file changed. The suite passes on MariaDB unmodified.

## Verification

Run locally against a throwaway `mariadb:11` container, on this branch:

* `pytest -q` (SQLite, default) → **91 passed** in 8.4s
* `TEST_DATABASE_URL=mysql+asyncmy://… pytest -q` → **91 passed** in 58.8s
* `logs.py` coverage on MariaDB → lines 26-27 covered

## Cost

The MariaDB run takes ~60s against a real server versus ~9s on in-memory SQLite, because
the schema is created and dropped per test. The `backend-tests` job currently runs ~50s,
so expect it to roughly double. The second run is `pytest -q` without `--cov`; the
coverage gate stays on the SQLite run so the threshold keeps its existing meaning.

## Not in this PR

A full compose-stack smoke test — building the image, waiting on `/health`, driving
register → sync → leaderboard over HTTP — would catch Dockerfile and env-wiring
regressions that a dialect run cannot. That is a different kind of check and is not filed;
say the word if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
