### PR TITLE
fix: apply the habit creation date as a universal validity floor

### DIFF
--- a/backend/app/routers/habits.py
+++ b/backend/app/routers/habits.py
@@ -15,6 +15,7 @@ from app.schemas import (
     HabitSyncPullResponse,
     HabitUpdate,
     HabitMetricsRead,
+    creation_floor,
     habit_score,
     streak_days,
 )
@@ -140,14 +141,10 @@ async def get_habit_metrics(
     if not habit:
         raise HTTPException(status_code=404, detail="Habit not found")
 
-    # SQLite may return a naive value for a timezone-aware column. Stored
-    # habit timestamps are UTC by contract, so interpret a naive value as UTC
-    # rather than allowing the caller's local timezone to affect the date.
-    created_at = habit.created_at
-    if created_at.tzinfo is None:
-        creation_date = created_at.date()
-    else:
-        creation_date = created_at.astimezone(timezone.utc).date()
+    # Universal data-validity boundary: a log dated before the habit existed
+    # counts toward neither the completion rate nor the streak. See
+    # creation_floor for why it carries a one-day grace.
+    creation_date = creation_floor(habit.created_at)
 
     completed_days = await db.scalar(
         select(func.count(func.distinct(HabitLog.completed_date))).where(

--- a/backend/app/routers/leaderboards.py
+++ b/backend/app/routers/leaderboards.py
@@ -12,6 +12,7 @@ from app.schemas import (
     LeaderboardMeta,
     LeaderboardRanking,
     LeaderboardTieBreakers,
+    creation_floor,
     habit_score,
     streak_days,
 )
@@ -81,7 +82,7 @@ async def head_to_head(
     # real streak rather than the width of the selected tab. The ownership join
     # and tombstone filter mirror the windowed query above.
     streak_rows = await db.execute(
-        select(HabitLog.user_id, HabitLog.completed_date)
+        select(HabitLog.user_id, HabitLog.completed_date, Habit.created_at)
         .join(Habit, Habit.id == HabitLog.habit_id)
         .where(
             HabitLog.user_id.in_(user_ids),
@@ -100,13 +101,22 @@ async def head_to_head(
     completed_pairs: dict[str, set[tuple[str, date]]] = {user_id: set() for user_id in user_ids}
     last_sync: dict[str, datetime | None] = {user_id: None for user_id in user_ids}
     for log, habit in rows:
+        # A habit created mid-window accrues nothing for the days before it
+        # existed. Applied here rather than in SQL so one Python definition of
+        # the floor serves both dialects the suite runs on.
+        if log.completed_date < creation_floor(habit.created_at):
+            continue
         points[log.user_id] += habit_score(habit.impact, habit.friction, habit.keystone, habit.time_cost)
         completed_pairs[log.user_id].add((log.habit_id, log.completed_date))
         if last_sync[log.user_id] is None or log.synced_at > last_sync[log.user_id]:
             last_sync[log.user_id] = log.synced_at
 
     streak_dates: dict[str, set[date]] = {user_id: set() for user_id in user_ids}
-    for streak_user_id, completed_date in streak_rows:
+    for streak_user_id, completed_date, habit_created_at in streak_rows:
+        # A day counts toward the user-level streak only if the user completed a
+        # habit that already existed on it.
+        if completed_date < creation_floor(habit_created_at):
+            continue
         streak_dates[streak_user_id].add(completed_date)
 
     updated_at = max((sync for sync in last_sync.values() if sync is not None), default=datetime.now(timezone.utc))

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Annotated
 
 from pydantic import BaseModel, Field, StrictInt, field_validator
@@ -15,6 +15,31 @@ def habit_score(impact: int, friction: int, keystone: int, time_cost: int) -> in
     return (100 * raw_minus_minimum * 2 + 16) // (16 * 2)
 
 
+def creation_floor(created_at: datetime) -> date:
+    """Earliest calendar date a log may count toward any metric for this habit.
+
+    The contract treats the habit's creation as a universal data-validity
+    boundary: a log dated before the habit existed counts toward nothing.
+
+    The one-day grace is not slack, it is the closest the stored data allows.
+    ``created_at`` is an absolute UTC instant while ``completed_date`` is a
+    device-local calendar date, so the two are not directly comparable. A user
+    west of UTC creating a habit in their evening lands a UTC creation date one
+    day *ahead* of their own, and a strict comparison would discard the first
+    log they ever record. One day covers the whole UTC-12..+14 range. Carrying
+    the local creation date properly is #149.
+
+    SQLite returns a naive value for a timezone-aware column. Stored timestamps
+    are UTC by contract, so a naive value is read as UTC rather than letting the
+    server's local zone shift the date.
+    """
+    if created_at.tzinfo is None:
+        creation_date = created_at.date()
+    else:
+        creation_date = created_at.astimezone(timezone.utc).date()
+    return creation_date - timedelta(days=1)
+
+
 def streak_days(completed: set[date], as_of: date) -> int:
     """Consecutive completed days ending at or immediately before ``as_of``.
 
@@ -22,9 +47,9 @@ def streak_days(completed: set[date], as_of: date) -> int:
     previous day when ``as_of`` is not completed, so a user who has completed
     yesterday but not yet today still sees the active streak.
 
-    The candidate set is the caller's decision — the metrics endpoint floors it
-    at the habit's creation date, the leaderboard does not — so the scope stays
-    visible at each call site rather than being fixed here.
+    The candidate set is the caller's decision, but both call sites now apply
+    the same rule: dates are floored at ``creation_floor`` of the habit they
+    belong to, so a log predating its habit extends no streak.
     """
     current = as_of if as_of in completed else as_of - timedelta(days=1)
     streak = 0

--- a/backend/tests/test_habit_metrics.py
+++ b/backend/tests/test_habit_metrics.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from httpx import AsyncClient
 
@@ -61,3 +63,101 @@ async def test_metrics_rejects_reversed_range_and_invalid_rating_types(
         headers=auth_header,
     )
     assert response.status_code == 422
+
+
+async def sync_habit_created_at(
+    client: AsyncClient, headers: dict, habit_id: str, created_at_ms: int
+) -> None:
+    """Create a habit with an explicit creation instant.
+
+    POST /habits/ stamps created_at server-side, so the sync path is the only
+    way to control it — the same technique test_habits.py already uses.
+    """
+    response = await client.post(
+        "/habits/sync",
+        json={"habits": [{
+            "id": habit_id,
+            "name": "Backdated",
+            "created_at_ms": created_at_ms,
+            "is_active": True,
+            "impact": 3, "friction": 3, "keystone": 3, "time_cost": 3,
+        }]},
+        headers=headers,
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metrics_ignore_logs_predating_the_habit(
+    client: AsyncClient, auth_header: dict
+):
+    """A log dated before the habit existed counts toward nothing (contract §4)."""
+    # Created 2099-08-20T12:00Z, so the floor is 2099-08-19.
+    created_ms = int(
+        datetime(2099, 8, 20, 12, 0, tzinfo=timezone.utc).timestamp() * 1000
+    )
+    await sync_habit_created_at(client, auth_header, "backdated", created_ms)
+
+    response = await client.post(
+        "/logs/sync",
+        json={"logs": [
+            # Well before creation: must not count, and must not bridge the gap
+            # into a longer streak.
+            {"habit_id": "backdated", "completed_date": "2099-08-16"},
+            {"habit_id": "backdated", "completed_date": "2099-08-17"},
+            # From the floor onward: these count.
+            {"habit_id": "backdated", "completed_date": "2099-08-20"},
+            {"habit_id": "backdated", "completed_date": "2099-08-21"},
+        ]},
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+
+    response = await client.get(
+        "/habits/backdated/metrics?start=2099-08-16&end=2099-08-21&as_of=2099-08-21",
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # The streak walks 21st, 20th, then stops: the 19th is empty and the 17th is
+    # below the floor regardless.
+    assert body["current_streak"] == 2
+    # Completion rate sees the same two days over the six-day window.
+    assert body["completed_days"] == 2
+    assert body["eligible_days"] == 6
+
+
+@pytest.mark.asyncio
+async def test_metrics_keep_the_day_before_creation_for_western_timezones(
+    client: AsyncClient, auth_header: dict
+):
+    """The floor carries a one-day grace, and it is load-bearing.
+
+    created_at is an absolute UTC instant; completed_date is a device-local
+    calendar date. A user west of UTC creating a habit in their evening records
+    a first log dated the day *before* the UTC creation date. Without the grace
+    that first log — and the streak it starts — would be discarded.
+    """
+    # 2099-08-20T01:00Z is 2099-08-19 20:00 in UTC-5.
+    created_ms = int(
+        datetime(2099, 8, 20, 1, 0, tzinfo=timezone.utc).timestamp() * 1000
+    )
+    await sync_habit_created_at(client, auth_header, "westerly", created_ms)
+
+    response = await client.post(
+        "/logs/sync",
+        json={"logs": [
+            {"habit_id": "westerly", "completed_date": "2099-08-19"},
+            {"habit_id": "westerly", "completed_date": "2099-08-20"},
+        ]},
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+
+    response = await client.get(
+        "/habits/westerly/metrics?start=2099-08-19&end=2099-08-20&as_of=2099-08-20",
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    assert response.json()["current_streak"] == 2
+    assert response.json()["completed_days"] == 2

--- a/backend/tests/test_leaderboards.py
+++ b/backend/tests/test_leaderboards.py
@@ -9,20 +9,33 @@ def epoch_ms(value: str) -> int:
     return int(datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp() * 1000)
 
 
-async def _seed_pair(db_session, habit_id: str = "my-habit") -> str:
+# Habits are created before anything these tests log. A habit defaults to
+# created_at=now, which would floor out every fixture log dated in the past.
+_LONG_AGO = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+async def _seed_pair(
+    db_session, habit_id: str = "my-habit", created_at: datetime = _LONG_AGO
+) -> str:
     """The authenticated user plus an opponent, each owning one neutral habit.
 
     The auth_header fixture already created "user"; merge gives it the display
     name without colliding on the primary key. Habit/HabitLog have no
     relationship() to User, only a raw foreign key, so the inserts are flushed
     in dependency order rather than left to the unit of work.
+
+    ``created_at`` defaults to well before any date these tests log, because a
+    log predating its habit counts toward nothing; tests that care about that
+    boundary pass an explicit value.
     """
     await db_session.merge(User(id="user", email="me@example.com", username="Me", password_hash="x"))
     db_session.add(User(id="opponent", email="them@example.com", username="Them", password_hash="x"))
     await db_session.flush()
     db_session.add_all([
-        Habit(id=habit_id, user_id="user", name="Mine", impact=3, friction=3, keystone=3, time_cost=3),
-        Habit(id="their-habit", user_id="opponent", name="Theirs", impact=3, friction=3, keystone=3, time_cost=3),
+        Habit(id=habit_id, user_id="user", name="Mine", created_at=created_at,
+              impact=3, friction=3, keystone=3, time_cost=3),
+        Habit(id="their-habit", user_id="opponent", name="Theirs", created_at=created_at,
+              impact=3, friction=3, keystone=3, time_cost=3),
     ])
     await db_session.flush()
     return habit_id
@@ -63,8 +76,10 @@ async def test_head_to_head_aggregates_habit_scores_and_marks_current_user(clien
     # the unit of work will not order the inserts for us.
     await db_session.flush()
     db_session.add_all([
-        Habit(id="my-high", user_id="user", name="High", impact=5, friction=1, keystone=5, time_cost=1),
-        Habit(id="their-neutral", user_id="opponent", name="Neutral", impact=3, friction=3, keystone=3, time_cost=3),
+        Habit(id="my-high", user_id="user", name="High", created_at=_LONG_AGO,
+              impact=5, friction=1, keystone=5, time_cost=1),
+        Habit(id="their-neutral", user_id="opponent", name="Neutral", created_at=_LONG_AGO,
+              impact=3, friction=3, keystone=3, time_cost=3),
     ])
     db_session.add_all([
         HabitLog(id="my-log-1", user_id="user", habit_id="my-high", completed_date=date(2026, 8, 30)),
@@ -242,6 +257,48 @@ async def test_streak_breaks_on_a_gap_and_ignores_a_deleted_log_outside_the_wind
     response = await _head_to_head(
         client, auth_header,
         start="2099-08-26T00:00:00", end="2099-08-30T23:59:59.999", as_of="2099-08-27",
+    )
+
+    assert response.status_code == 200
+    assert _streak_for(response.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_points_exclude_days_before_the_habit_existed(client, db_session, auth_header):
+    """A habit created mid-window accrues nothing for the days before it existed."""
+    # Created 2099-08-15T12:00Z → floor 2099-08-14, mid-way through the window.
+    await _seed_pair(db_session, created_at=datetime(2099, 8, 15, 12, 0, tzinfo=timezone.utc))
+    db_session.add_all([
+        HabitLog(id="before-1", user_id="user", habit_id="my-habit", completed_date=date(2099, 8, 10)),
+        HabitLog(id="before-2", user_id="user", habit_id="my-habit", completed_date=date(2099, 8, 11)),
+        HabitLog(id="after-1", user_id="user", habit_id="my-habit", completed_date=date(2099, 8, 16)),
+    ])
+    await db_session.commit()
+
+    response = await _head_to_head(
+        client, auth_header,
+        start="2099-08-01T00:00:00", end="2099-08-31T23:59:59.999", as_of="2099-08-16",
+    )
+
+    assert response.status_code == 200
+    ranking = next(r for r in response.json()["rankings"] if r["user_id"] == "user")
+    # One neutral habit (3/3/3/3 → 50) counted once, for 2099-08-16 alone.
+    assert ranking["score"] == 50
+
+
+@pytest.mark.asyncio
+async def test_streak_ignores_days_before_the_habit_existed(client, db_session, auth_header):
+    """A day only extends the user-level streak if a habit existed on it."""
+    await _seed_pair(db_session, created_at=datetime(2099, 8, 15, 12, 0, tzinfo=timezone.utc))
+    # An unbroken run of five days ending 2099-08-16, so 12th through 16th.
+    # created_at 2099-08-15 gives a floor of 2099-08-14 once the timezone grace
+    # is applied, so the 12th and 13th drop out and the streak is 3, not 5.
+    db_session.add_all(_run("my-habit", "user", date(2099, 8, 16), 5))
+    await db_session.commit()
+
+    response = await _head_to_head(
+        client, auth_header,
+        start="2099-08-01T00:00:00", end="2099-08-31T23:59:59.999", as_of="2099-08-16",
     )
 
     assert response.status_code == 200

--- a/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
+++ b/docs/superpowers/specs/2026-08-26-habit-weights-scoring-contract.md
@@ -125,6 +125,20 @@ rather than returning a fabricated percentage.
 Logs before creation, logs marked deleted, and logs belonging to another user
 do not count. Historical logs remain valid after a habit is deactivated.
 
+This is a **universal data-validity rule, not a completion-rate one**: it governs
+every derived metric — the completion rate, the per-habit streak of §5, and the
+head-to-head score and streak alike. A habit's creation is a hard boundary, and
+backfilling history from before it is explicitly not supported.
+
+The boundary carries a **one-day grace**: it is `date(created_at) - 1 day`, in
+UTC. This is not slack. `created_at` is an absolute UTC instant while
+`completed_date` is a device-local calendar date, so the two are not directly
+comparable — a user west of UTC creating a habit in their evening lands a UTC
+creation date one day *ahead* of their own, and a strict comparison would discard
+the first log they ever record. One day covers the whole UTC-12..+14 range.
+Carrying the local creation date properly, and removing the need for the grace,
+is tracked in #149.
+
 ### 5. Streak
 
 Streak is the number of consecutive completed calendar days ending at the
@@ -147,6 +161,11 @@ Examples as of Friday:
 The as-of date is a local calendar date, not a timestamp. Inactive status does
 not erase or truncate a streak; the caller can choose whether to request
 metrics for an inactive habit.
+
+A streak **is** bounded below by the habit's creation date, under §4's universal
+rule and with the same one-day grace. Lifecycle *status* never truncates a
+streak; the habit's *existence* does. A day before the habit existed therefore
+breaks the walk exactly as an uncompleted day would.
 
 ## Data flow and interface requirements
 
@@ -217,12 +236,12 @@ therefore not the per-habit streak of §5, and equals
 `GET /habits/{id}/metrics.current_streak` only for a user who owns exactly one
 habit. It is measured from `as_of`, clamped to the period end so a finished window
 reports the streak as it stood at that point, and is otherwise **independent of
-`[start, end]`** — history from before the window counts toward it. It applies no
-creation-date floor: a user-level streak has no single habit creation date to floor
-against. (The per-habit streak is floored at the habit's creation date by the
-metrics implementation; whether §5 intends that is tracked in #164.) §5's rule
-still applies: start at `as_of`, or at the previous calendar day when `as_of` is
-not completed.
+`[start, end]`** — history from before the window counts toward it. §4's creation
+floor applies per habit: a day counts toward the user-level streak only if the
+user completed at least one habit that **already existed on that day**. Points are
+floored the same way, so a habit created mid-window accrues nothing for the days
+before it existed. §5's rule still applies: start at `as_of`, or at the previous
+calendar day when `as_of` is not completed.
 
 The current storage represents completion as a calendar date, so epoch
 boundaries are normalized to UTC dates by the backend. Both representations

--- a/src/__tests__/performance.test.tsx
+++ b/src/__tests__/performance.test.tsx
@@ -47,7 +47,9 @@ describe('Performance benchmarks', () => {
         return database.get<Habit>('habits').create(h => {
           h.userId = 'user';
           h.name = 'Daily Exercise';
-          h.createdAt = Date.now();
+          // Predates the 365 logs below; otherwise the creation floor trims
+          // them and the benchmark stops measuring a 365-day walk.
+          h.createdAt = Date.UTC(2020, 0, 1);
           h.isActive = true;
         });
       });

--- a/src/__tests__/services/HabitService.test.ts
+++ b/src/__tests__/services/HabitService.test.ts
@@ -30,17 +30,23 @@ function formatDate(date: Date): string {
 // the multi-account tests pass a real id.
 const DEFAULT_OWNER = 'user';
 
+// Habits are created long before anything these tests log. A log dated before
+// its habit existed counts toward nothing, so a fixture stamped Date.now()
+// would floor out every backdated log the streak tests rely on.
+const LONG_AGO = Date.UTC(2020, 0, 1);
+
 async function createTestHabit(
   database: Database,
   name: string = 'Exercise',
   synced: boolean = true,
   owner: string = DEFAULT_OWNER,
+  createdAt: number = LONG_AGO,
 ): Promise<Habit> {
   return database.write(async () => {
     return database.get<Habit>('habits').create(h => {
       h.userId = owner;
       h.name = name;
-      h.createdAt = Date.now();
+      h.createdAt = createdAt;
       h.isActive = true;
       h.synced = synced;
     });
@@ -360,6 +366,47 @@ describe('HabitService', () => {
 
       const streak = await service.calculateStreak(habit.id, '2026-03-07');
       expect(streak).toBe(1);
+    });
+
+    it('stops at the habit creation date, matching the server', async () => {
+      // Created 2026-03-06T12:00Z, so the floor is 2026-03-05 -- the same
+      // one-day grace creation_floor applies in backend/app/schemas.py. The
+      // 3rd and 4th predate the habit and must not extend the run, so the
+      // number here matches what GET /habits/{id}/metrics returns and no
+      // longer shifts when the device reconnects.
+      const habit = await createTestHabit(
+        database,
+        'Backdated',
+        true,
+        DEFAULT_OWNER,
+        Date.UTC(2026, 2, 6, 12, 0),
+      );
+      await createTestLog(database, habit.id, '2026-03-03', true);
+      await createTestLog(database, habit.id, '2026-03-04', true);
+      await createTestLog(database, habit.id, '2026-03-05', true);
+      await createTestLog(database, habit.id, '2026-03-06', true);
+      await createTestLog(database, habit.id, '2026-03-07', true);
+
+      const streak = await service.calculateStreak(habit.id, '2026-03-07');
+      expect(streak).toBe(3);
+    });
+
+    it('keeps the day before creation for a habit added west of UTC', async () => {
+      // 2026-03-06T01:00Z is 2026-03-05 20:00 at UTC-5, so the first log a
+      // user there records is dated the day before the UTC creation date.
+      // The grace is what stops it being discarded.
+      const habit = await createTestHabit(
+        database,
+        'Westerly',
+        true,
+        DEFAULT_OWNER,
+        Date.UTC(2026, 2, 6, 1, 0),
+      );
+      await createTestLog(database, habit.id, '2026-03-05', true);
+      await createTestLog(database, habit.id, '2026-03-06', true);
+
+      const streak = await service.calculateStreak(habit.id, '2026-03-06');
+      expect(streak).toBe(2);
     });
 
     it('does not fetch logs older than the 400-day cutoff', async () => {

--- a/src/__tests__/utils/dateUtils.test.ts
+++ b/src/__tests__/utils/dateUtils.test.ts
@@ -29,7 +29,10 @@ async function createTestHabit(
     return database.get<Habit>('habits').create(h => {
       h.userId = 'user';
       h.name = name;
-      h.createdAt = Date.now();
+      // Before any date these tests log: a log predating its habit counts
+      // toward nothing, so a Date.now() stamp would floor out the 2024
+      // fixtures these DST cases rely on.
+      h.createdAt = Date.UTC(2020, 0, 1);
       h.isActive = true;
     });
   });

--- a/src/services/HabitService.ts
+++ b/src/services/HabitService.ts
@@ -708,12 +708,32 @@ export default class HabitService {
       'yyyy-MM-dd',
     );
 
+    // A log dated before the habit existed counts toward nothing, so the walk
+    // must stop there. This mirrors `creation_floor` in backend/app/schemas.py
+    // exactly -- including the one-day grace that keeps a first log recorded
+    // west of UTC from being discarded. Deriving it any other way would put the
+    // server and this fallback back out of step, which is the whole point of
+    // the floor being here: StatsScreen shows the server's number when the
+    // metrics request succeeds and this one when it fails.
+    //
+    // toISOString() is deliberate here, and is the one place it is correct:
+    // created_at is an absolute instant and the server takes its UTC calendar
+    // date, so this must too. Everywhere else, use getTodayString().
+    const habit = await this.getHabitById(habitId);
+    const creationUtcDate = new Date(habit.createdAt).toISOString().slice(0, 10);
+    const creationFloor = format(
+      subDays(new Date(creationUtcDate + 'T00:00:00'), 1),
+      'yyyy-MM-dd',
+    );
+    // ISO dates sort lexicographically, so the later bound is the stricter one.
+    const lowerBound = cutoffDate > creationFloor ? cutoffDate : creationFloor;
+
     const logs = await this.database
       .get<HabitLog>('habit_logs')
       .query(
         Q.where('habit_id', habitId),
         Q.where('user_id', this.userId),
-        Q.where('completed_date', Q.gte(cutoffDate)),
+        Q.where('completed_date', Q.gte(lowerBound)),
         Q.where('completed_date', Q.lte(asOfDate)),
         Q.where('deleted_at', null),
       )


### PR DESCRIPTION
Closes #164

## The decision

Contract §4 said *"Logs before creation … do not count"* from inside the **completion-rate**
section, while §5 defined the streak and never mentioned a floor. The code split the
difference three ways: the metrics streak floored, the leaderboard didn't, and the client
floored nowhere. #164 was filed to settle which was intended rather than to delete a
predicate.

**Settled: the creation date is a hard data-validity boundary, and backfilling is not
supported.** §4's rule is promoted to a universal one governing every derived metric, §5
now states it, and the floor is applied in the four places that previously disagreed.

## What changed

| Where | Before | After |
| --- | --- | --- |
| Metrics streak + completion rate | floored (inline) | floored via one shared `creation_floor` |
| Leaderboard points | no floor | a habit created mid-window accrues nothing for days before it existed |
| Leaderboard streak | no floor | a day counts only if the user completed a habit that existed on it |
| Client `calculateStreak` | **no floor at all** | same floor as the server |

The client change is the user-visible one. `StatsScreen` shows the server's number when the
metrics request succeeds (`:149`) and the local one when it fails (`:170`), so the displayed
streak used to **shift when the device reconnected**. It no longer can.

## The one-day grace is load-bearing, not slack

The floor is `date(created_at) - 1 day`. `created_at` is an absolute **UTC instant**
(`HabitService.ts:228` → `created_at_ms` → server `.date()`), while `completed_date` is a
**device-local calendar date**.

A user at UTC−5 creating a habit at 20:00 local on Aug 30 gets `created_at =
2026-08-31T01:00Z`, so a strict floor is **Aug 31** — while their first log is dated
`"2026-08-30"`. A strict comparison discards the first log they ever record. One day covers
the whole UTC−12…+14 range. Carrying the local creation date properly is **#149**.

Two tests pin this (`test_metrics_keep_the_day_before_creation_for_western_timezones`, and
the client's `keeps the day before creation for a habit added west of UTC`). Both were
confirmed to fail with the grace removed, and nothing else does.

## Enforcement is passive, by design

Rejecting pre-creation logs in `POST /logs/sync` was considered and rejected. The client
retries with backoff to `MAX_LOG_RETRIES = 10` and then treats a log as **permanently
dead** — so the UTC−5 user above would lose their first completion outright with no path
back, and any pre-creation rows already stored would fail forever. `logs.py` is untouched.

## This supersedes part of #148

#148 shipped two days ago documenting that the leaderboard streak *"applies no
creation-date floor: a user-level streak has no single habit creation date to floor
against."* That has a coherent per-habit form — a day counts if the user completed a habit
that existed on it — and now uses it. The contract paragraph is replaced in this same
commit so the doc is never self-contradictory.

## Implementation note

The floors are applied **in Python, not SQL**. Both leaderboard queries already join
`Habit`, so the streak query carries `Habit.created_at` and filters in the loop. This keeps
one definition of the floor and avoids dialect-specific date arithmetic — `func.date(x, '-1
day')` is SQLite syntax and MariaDB wants `INTERVAL`, and since #169 the suite runs on both.

## Verification

* `pytest -q` (SQLite) → **95 passed**
* `TEST_DATABASE_URL=mysql+asyncmy://… pytest -q` (MariaDB 11) → **95 passed**
* `pytest --cov --cov-fail-under=85` → **95.11%**
* `npx tsc --noEmit` → clean · `npx jest --ci` → **378 passed**, 23 suites
* `eslint` → unchanged from `main` (5 pre-existing `curly` warnings)

New tests: metrics ignores pre-creation logs; the timezone grace; leaderboard points
excluded before creation; leaderboard streak not extended by a not-yet-created habit; and
the client matching the server.

**Fixtures across both suites stamped habits with `Date.now()`/`_utcnow()` while logging
past dates** — only valid while no floor existed. They now carry explicit creation dates.
That accounts for the changes in `dateUtils.test.ts` and `performance.test.tsx`.

## Before deploying

Prod (which is the local `backend-api-1` container behind the `cloudflared` systemd tunnel,
**not** `hosting.internal`) is still pre-#148. Run this first — a non-zero count means live
streaks will drop on deploy, and that should be a conscious choice:

```sql
SELECT COUNT(*) FROM habit_logs l JOIN habits h ON h.id = l.habit_id
WHERE l.deleted_at IS NULL AND l.completed_date < DATE(h.created_at) - INTERVAL 1 DAY;
```

## Not in this PR

**#152** is the denominator twin of the points floor here — `habit_counts` still counts
every habit the user owns regardless of when it was created. The two belong together and
#152 is now the remaining half. Also open: **#149** (the proper fix for the UTC/local skew),
**#153**, **#167** (redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
