### PR TITLE
ci: notify Discord with the outcome of the whole CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,3 +252,84 @@ jobs:
             android/app/build/outputs/apk/release/app-release.apk \
             --generate-notes \
             --target ${{ github.sha }}
+
+  notify:
+    name: Notify
+    # Reports the outcome of the whole run, so it waits on every gating job and
+    # runs even when one of them failed or was cancelled.
+    needs: [lint-and-type-check, unit-tests, backend-tests, android-build]
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          # Interpolated into the environment rather than into the script, so a
+          # branch name can never be executed as shell.
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          EVENT: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # One result per gating job, e.g. "success,success,failure,success".
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISCORD_WEBHOOK}" ]; then
+            echo "::warning::DISCORD_WEBHOOK_URL is not set; skipping notification"
+            exit 0
+          fi
+
+          # `needs` results are success | failure | cancelled | skipped.
+          # Anything that is not a success makes the run a failure.
+          if printf '%s' "${RESULTS}" | grep -qE 'failure|cancelled'; then
+            OUTCOME="failed"
+            COLOR=16711680
+          else
+            OUTCOME="passed"
+            COLOR=65280
+          fi
+
+          MENTION=""
+          if [ "${OUTCOME}" = "failed" ] && [ -n "${DISCORD_ROLE_ID}" ]; then
+            MENTION=" <@&${DISCORD_ROLE_ID}>"
+          fi
+
+          if [ "${OUTCOME}" = "failed" ]; then
+            CONTENT="🚨 **CI failed**${MENTION}"
+          else
+            CONTENT="✅ **CI passed**"
+          fi
+
+          # Built with jq so a branch name containing a quote or backslash
+          # cannot produce malformed JSON.
+          jq -n \
+            --arg content "${CONTENT}" \
+            --arg title "CI ${OUTCOME} — ${REPOSITORY}" \
+            --arg url "${RUN_URL}" \
+            --arg branch "${BRANCH}" \
+            --arg event "${EVENT}" \
+            --arg results "${RESULTS}" \
+            --argjson color "${COLOR}" \
+            '{
+              content: $content,
+              allowed_mentions: {parse: ["roles"]},
+              embeds: [{
+                title: $title,
+                url: $url,
+                color: $color,
+                fields: [
+                  {name: "Branch", value: $branch, inline: true},
+                  {name: "Event", value: $event, inline: true},
+                  {name: "Jobs", value: $results, inline: false}
+                ]
+              }]
+            }' > payload.json
+
+          curl -sS --fail-with-body \
+               -H "Content-Type: application/json" \
+               -X POST -d @payload.json "${DISCORD_WEBHOOK}"


### PR DESCRIPTION
Adds a `notify` job reporting whether CI passed or failed, pinging a role only on failure.
From the draft at `Notify-on-CI.yaml`, with the corrections below.

## Why a job, not a standalone workflow

The draft was a step fragment using `job.status`, which describes only the job the step
sits in — dropped into one job it would report that job's result, not the run's. This
gates on `needs: [lint-and-type-check, unit-tests, backend-tests, android-build]` with
`if: always()` and aggregates `needs.*.result`, matching how the existing `release` job
already fans in.

A separate workflow via `workflow_run` was the alternative, but it only ever runs the
copy on the default branch, so it could not report on a PR — which is most of when you
want it.

## Corrections to the draft

| Issue | Fix |
| --- | --- |
| `<@&'$DISCORD_ROLE_ID'>` inside double quotes made the single quotes literal — Discord showed `<@&'123'>`, not a mention | `<@&${DISCORD_ROLE_ID}>` |
| JSON interpolated values directly; a branch name with `"` or `\` produced invalid JSON | built with `jq -n --arg` |
| `${{ github.* }}` expanded straight into the script | passed via `env:` so a ref name can't be executed as shell |
| `curl` had no error handling; a rejected webhook passed silently | `--fail-with-body` |
| Unset webhook posted to an empty URL | warns and exits 0, so CI stays green until the secret exists |
| Role mentions need `allowed_mentions` to actually ping | set |
| No run link | embed title links to the run |

## Verified locally

The script was exercised against six cases before pushing:

| Case | Result |
| --- | --- |
| All jobs pass | green, no ping |
| One job fails | red + role ping |
| A job is `skipped` | still counts as passed, not a failure |
| Branch named `feat/a"b\c` | escaped correctly by jq |
| `DISCORD_ROLE_ID` unset | no dangling `<@&>` |
| `DISCORD_WEBHOOK_URL` unset | clean skip, job green |

## Before it does anything

Two repo secrets are needed — neither exists yet (`gh secret list` shows only the four
Android signing secrets):

```bash
gh secret set DISCORD_WEBHOOK_URL -R domicy/daily-habit-tracker
gh secret set DISCORD_ROLE_ID     -R domicy/daily-habit-tracker
```

Until then the job runs, warns, and exits 0 — including on this PR, which is a live test
of that guard.

## Porting to other repos

Copy the `notify` job and adjust its `needs:` list to that repo's gating jobs. Everything
else is repo-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)