### PR TITLE
feat: deploy the backend to hosting.internal on a merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,80 +256,15 @@ jobs:
   notify:
     name: Notify
     # Reports the outcome of the whole run, so it waits on every gating job and
-    # runs even when one of them failed or was cancelled.
+    # runs even when one of them failed or was cancelled. The payload itself
+    # lives in the reusable workflow, which deploy-prod.yml also calls.
     needs: [lint-and-type-check, unit-tests, backend-tests, android-build]
     if: >-
       always() &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Discord
-        env:
-          # Interpolated into the environment rather than into the script, so a
-          # branch name can never be executed as shell.
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
-          REPOSITORY: ${{ github.repository }}
-          BRANCH: ${{ github.ref_name }}
-          EVENT: ${{ github.event_name }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # One result per gating job, e.g. "success,success,failure,success".
-          RESULTS: ${{ join(needs.*.result, ',') }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${DISCORD_WEBHOOK}" ]; then
-            echo "::warning::DISCORD_WEBHOOK_URL is not set; skipping notification"
-            exit 0
-          fi
-
-          # `needs` results are success | failure | cancelled | skipped.
-          # Anything that is not a success makes the run a failure.
-          if printf '%s' "${RESULTS}" | grep -qE 'failure|cancelled'; then
-            OUTCOME="failed"
-            COLOR=16711680
-          else
-            OUTCOME="passed"
-            COLOR=65280
-          fi
-
-          MENTION=""
-          if [ "${OUTCOME}" = "failed" ] && [ -n "${DISCORD_ROLE_ID}" ]; then
-            MENTION=" <@&${DISCORD_ROLE_ID}>"
-          fi
-
-          if [ "${OUTCOME}" = "failed" ]; then
-            CONTENT="🚨 **CI failed**${MENTION}"
-          else
-            CONTENT="✅ **CI passed**"
-          fi
-
-          # Built with jq so a branch name containing a quote or backslash
-          # cannot produce malformed JSON.
-          jq -n \
-            --arg content "${CONTENT}" \
-            --arg title "CI ${OUTCOME} — ${REPOSITORY}" \
-            --arg url "${RUN_URL}" \
-            --arg branch "${BRANCH}" \
-            --arg event "${EVENT}" \
-            --arg results "${RESULTS}" \
-            --argjson color "${COLOR}" \
-            '{
-              content: $content,
-              allowed_mentions: {parse: ["roles"]},
-              embeds: [{
-                title: $title,
-                url: $url,
-                color: $color,
-                fields: [
-                  {name: "Branch", value: $branch, inline: true},
-                  {name: "Event", value: $event, inline: true},
-                  {name: "Jobs", value: $results, inline: false}
-                ]
-              }]
-            }' > payload.json
-
-          curl -sS --fail-with-body \
-               -H "Content-Type: application/json" \
-               -X POST -d @payload.json "${DISCORD_WEBHOOK}"
+    uses: ./.github/workflows/notify.yml
+    with:
+      context: CI
+      results: ${{ join(needs.*.result, ',') }}
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,100 @@
+name: Deploy production (.56)
+
+# Deploys the backend to hosting.internal after CI passes on main, using the
+# repo-scoped self-hosted runner on that host. Mirrors the convention already
+# used by genapplyx-sports-dash: single-slot concurrency, and a
+# workflow_dispatch `ref` input so a rollback is a re-run rather than a revert.
+on:
+  # Waits for CI rather than triggering on push, so a deploy can never race the
+  # tests that gate it. sports-dash re-runs its tests inside the deploy job
+  # instead; here the suite plus the Android build is ~13 minutes and is already
+  # a required check, so running it twice would double every deploy.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to deploy (defaults to the last commit CI passed on)
+        required: false
+        default: ''
+
+# Never two deploys mutating the live directory at once.
+concurrency:
+  group: habit-prod-56
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    # A manual run deploys whatever ref was asked for; an automatic one only
+    # proceeds when the CI run it is reacting to actually succeeded.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: [self-hosted, habit-prod]
+    timeout-minutes: 15
+    env:
+      PROD_DIR: /home/not_host/daily-habit-tracker
+      COMPOSE: docker compose -f docker-compose.prod.yml
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Sync to live directory
+        run: |
+          set -euo pipefail
+          mkdir -p "$PROD_DIR"
+          # backend/.env holds the production secrets and is not in the repo, so
+          # it must survive the sync -- excluding it is what keeps JWT_SECRET
+          # stable across deploys.
+          rsync -a --delete \
+                --exclude '.git' \
+                --exclude 'backend/.env' \
+                ./ "$PROD_DIR/"
+
+      - name: Build and start
+        working-directory: /home/not_host/daily-habit-tracker/backend
+        run: $COMPOSE up -d --build
+
+      - name: Apply database migrations
+        working-directory: /home/not_host/daily-habit-tracker/backend
+        # Before the health check, so a deploy that cannot migrate fails here
+        # rather than serving against a schema it does not match.
+        run: $COMPOSE exec -T api sh -c "PYTHONPATH=. alembic upgrade head"
+
+      - name: Health check
+        working-directory: /home/not_host/daily-habit-tracker/backend
+        run: |
+          set -euo pipefail
+          # urllib rather than curl: the image is python:3.12-slim and has no
+          # curl. urlopen raises on a non-2xx status, so a bad response is a
+          # non-zero exit without any extra checking.
+          PROBE="import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"
+          for attempt in $(seq 1 20); do
+            if $COMPOSE exec -T api python -c "$PROBE" >/dev/null 2>&1; then
+              echo "healthy after ${attempt} attempt(s)"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::API did not become healthy after 60s"
+          $COMPOSE logs --tail 50 api
+          exit 1
+
+      - name: Report deployed revision
+        run: echo "Deployed ${GITHUB_SHA} to ${PROD_DIR}"
+
+  notify:
+    name: Notify
+    needs: deploy
+    if: always()
+    uses: ./.github/workflows/notify.yml
+    with:
+      context: Deploy
+      results: ${{ needs.deploy.result }}
+      ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch || github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,99 @@
+name: Notify
+
+# Shared Discord notifier. Called by ci.yml and deploy-prod.yml so a failure in
+# either reaches the same channel, and the payload logic lives in one place
+# rather than being copied into each workflow where the copies would drift.
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: What is being reported, e.g. "CI" or "Deploy".
+        required: true
+        type: string
+      results:
+        description: >-
+          Comma-separated job results. Anything containing "failure" or
+          "cancelled" is reported as a failure. Callers pass
+          join(needs.*.result, ',') for a fan-in, or a single result.
+        required: true
+        type: string
+      ref:
+        description: Branch, tag or SHA the run applied to. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          # Interpolated into the environment rather than into the script, so a
+          # branch name can never be executed as shell.
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+          CONTEXT: ${{ inputs.context }}
+          RESULTS: ${{ inputs.results }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH: ${{ inputs.ref != '' && inputs.ref || github.ref_name }}
+          EVENT: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISCORD_WEBHOOK}" ]; then
+            echo "::warning::DISCORD_WEBHOOK_URL is not set; skipping notification"
+            exit 0
+          fi
+
+          # `needs` results are success | failure | cancelled | skipped.
+          # Anything that is not a success makes the run a failure.
+          if printf '%s' "${RESULTS}" | grep -qE 'failure|cancelled'; then
+            OUTCOME="failed"
+            COLOR=16711680
+          else
+            OUTCOME="passed"
+            COLOR=65280
+          fi
+
+          MENTION=""
+          if [ "${OUTCOME}" = "failed" ] && [ -n "${DISCORD_ROLE_ID}" ]; then
+            MENTION=" <@&${DISCORD_ROLE_ID}>"
+          fi
+
+          if [ "${OUTCOME}" = "failed" ]; then
+            CONTENT="🚨 **${CONTEXT} failed**${MENTION}"
+          else
+            CONTENT="✅ **${CONTEXT} passed**"
+          fi
+
+          # Built with jq so a branch name containing a quote or backslash
+          # cannot produce malformed JSON.
+          jq -n \
+            --arg content "${CONTENT}" \
+            --arg title "${CONTEXT} ${OUTCOME} — ${REPOSITORY}" \
+            --arg url "${RUN_URL}" \
+            --arg branch "${BRANCH}" \
+            --arg event "${EVENT}" \
+            --arg results "${RESULTS}" \
+            --argjson color "${COLOR}" \
+            '{
+              content: $content,
+              allowed_mentions: {parse: ["roles"]},
+              embeds: [{
+                title: $title,
+                url: $url,
+                color: $color,
+                fields: [
+                  {name: "Ref", value: $branch, inline: true},
+                  {name: "Event", value: $event, inline: true},
+                  {name: "Jobs", value: $results, inline: false}
+                ]
+              }]
+            }' > payload.json
+
+          curl -sS --fail-with-body \
+               -H "Content-Type: application/json" \
+               -X POST -d @payload.json "${DISCORD_WEBHOOK}"

--- a/backend/README.md
+++ b/backend/README.md
@@ -177,3 +177,36 @@ without opening inbound ports or configuring a reverse proxy.
 Install `cloudflared` on the host, authenticate, create a tunnel, and run it
 as a systemd service. The full guide is at
 [`docs/cloudflare-tunnel-setup.md`](../docs/cloudflare-tunnel-setup.md).
+
+### Production deployment
+
+Production runs on `hosting.internal` from `docker-compose.prod.yml`, which is a
+standalone file rather than an override of `docker-compose.yml` — the latter is
+the development setup documented above, and Compose merges `ports` by appending,
+so an override could not remove the published ports.
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.prod.yml exec api sh -c "PYTHONPATH=. alembic upgrade head"
+```
+
+It differs from the development stack in three ways:
+
+- **No published host ports.** Port 8000 on that host belongs to another
+  service; the tunnel reaches the API over the compose network as
+  `http://api:8000`, so nothing needs exposing.
+- **A token-managed tunnel.** `TUNNEL_TOKEN` instead of a mounted
+  `config.yml` plus credentials JSON, so no credentials sit on disk. Ingress is
+  configured in the Cloudflare dashboard.
+- **No default database password.** `MARIADB_ROOT_PASSWORD` is required rather
+  than defaulting, so production cannot silently fall back to the development
+  value.
+
+`backend/.env` on the host supplies `DATABASE_URL`, `JWT_SECRET`,
+`JWT_ALGORITHM`, `JWT_EXPIRY_HOURS`, `MARIADB_ROOT_PASSWORD` and `TUNNEL_TOKEN`.
+It is not in the repository and the deploy explicitly preserves it — **changing
+`JWT_SECRET` invalidates every issued token and signs every user out.**
+
+Deploys are automatic: `.github/workflows/deploy-prod.yml` runs on the
+repo's self-hosted runner after CI passes on `main`. A manual run with a `ref`
+input redeploys any tag or SHA, which is the rollback path.

--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -1,0 +1,72 @@
+# Production stack for hosting.internal (192.168.60.56).
+#
+# Standalone rather than an override of docker-compose.yml: that file is the
+# documented local development setup (see README -- MariaDB on 3306, API on
+# 8000), and Compose merges `ports` and `volumes` by appending, so an override
+# could not have removed them. Keeping the two separate leaves `docker compose
+# up -d` working unchanged for development.
+#
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Requires backend/.env on the host with DATABASE_URL, JWT_SECRET,
+# JWT_ALGORITHM, JWT_EXPIRY_HOURS, MARIADB_ROOT_PASSWORD and TUNNEL_TOKEN.
+# JWT_SECRET must be carried over from the previous host verbatim -- changing it
+# invalidates every issued token and signs every user out.
+
+services:
+  db:
+    image: mariadb:11
+    container_name: habit-db
+    restart: unless-stopped
+    environment:
+      # No default: production must not fall back to the development password.
+      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:?set in backend/.env}
+      MARIADB_DATABASE: ${MARIADB_DATABASE:-habits}
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - habit-network
+
+  api:
+    build: .
+    container_name: habit-api
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - habit-network
+    # Deliberately publishes no host port. 8000 on this host already belongs to
+    # workout-api, and the tunnel reaches this service over habit-network as
+    # http://api:8000 -- so nothing needs to be exposed on the host at all.
+
+  tunnel:
+    image: cloudflare/cloudflared:latest
+    container_name: habit-tunnel
+    restart: unless-stopped
+    # Token-managed tunnel, matching workout-tunnel on this host: ingress is
+    # configured in the Cloudflare dashboard rather than a mounted config.yml,
+    # so there are no credentials on disk. The file-based form in
+    # docker-compose.yml stays available for local experimentation.
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:?set in backend/.env}
+    depends_on:
+      api:
+        condition: service_started
+    networks:
+      - habit-network
+
+volumes:
+  db_data:
+
+networks:
+  habit-network:
+    driver: bridge


### PR DESCRIPTION
Closes #172

Repo-side half of the hosting.internal migration. **Not live until the two manual
prerequisites below are done** — merging this is safe, the deploy workflow simply has no
runner to pick it up yet.

## Why

`ci.yml` built and released the Android app on a merge to `main` but touched no server, so
a merged backend change reached production only when someone ran `docker compose up -d
--build` by hand. The running stack turned out to be built from **a second clone of this
repo at `46b8f7b`, 16 commits behind `main`** — which is why #148 and #164 are merged and
still not serving. #167 is the manual correction for that; this removes the need for it.

## What's here

**`backend/docker-compose.prod.yml`** — standalone, not an override. `docker-compose.yml`
is the development setup the README documents (MariaDB on 3306, API on 8000), and Compose
merges `ports` by *appending*, so an override could not have removed them. Keeping them
separate leaves `docker compose up -d` working unchanged for development. It differs in
three ways, each commented in the file: no published host ports (8000 on the target host
belongs to `workout-api`; the tunnel reaches the API over the compose network as
`http://api:8000`), a token-managed tunnel matching `workout-tunnel` so no credentials sit
on disk, and `MARIADB_ROOT_PASSWORD` required rather than defaulting — production can no
longer silently fall back to the committed development password.

**`.github/workflows/deploy-prod.yml`** — mirrors `genapplyx-sports-dash`'s
`deploy-prod.yml` on the same host: `Deploy production (.56)`, `runs-on: [self-hosted,
habit-prod]`, `concurrency: {group: habit-prod-56, cancel-in-progress: false}`, and a
`workflow_dispatch` `ref` input so rollback is a re-run rather than a revert.

Two deliberate departures from that convention:

| | sports-dash | here | why |
| --- | --- | --- | --- |
| Trigger | `push: main` | `workflow_run` on CI completing | sports-dash re-runs `npm test` in the deploy job; this suite plus the Android build is ~13 min and already a required check, so running it twice would double every deploy. Also what #172 asks for — "runs only after the existing gating jobs pass". |
| Migrations | n/a | `alembic upgrade head` before the health check | sports-dash has no database. `backend/Dockerfile` ends at `CMD ["uvicorn", ...]` with no entrypoint, so nothing else would apply them. |

**`.github/workflows/notify.yml`** — #171's notifier extracted to a reusable
`workflow_call`. It lived inside `ci.yml` gated on the four CI jobs, so **a deploy failure
in a separate workflow would have been silent** — breaking #172's "a failed deploy is
reported, not silent". Both workflows now call it, rather than the ~50 lines of jq and curl
being copied into the second one where the copies would drift.

## Verified

* All four workflow files parse; job graph and `runs-on`/`concurrency`/trigger shapes
  asserted.
* The health-check probe was run against the **live API container**: exits 0 on `/health`,
  non-zero on a 404. It uses `urllib` rather than curl because the image is
  `python:3.12-slim` and has no curl.
* `backend/docker-compose.yml` is byte-for-byte unchanged, so local development and the
  README's instructions are unaffected.
* The notifier's payload logic is unchanged from #171, which was tested across six cases
  including a `feat/a"b\c` branch name and a skipped-job-is-not-a-failure check.

## Before this does anything — two manual steps

1. **Register the runner.** Repo-scoped self-hosted runner on `hosting.internal`,
   alongside the four already there, with the label **`habit-prod`**. Suggested to match
   the existing naming: directory `/home/not_host/actions-runner-habit`, service
   `habit-prod-target`.
2. **Create the Cloudflare tunnel** (token style, like `workout-tunnel`) and put
   `TUNNEL_TOKEN` in `backend/.env` on the host. Do **not** add the public hostname until
   cutover — see the plan's ordering, since two tunnels cannot claim one hostname.

Until the runner exists the deploy job stays queued and no notification fires; nothing
breaks.

## Still to come

This is the automation. The data cutover — copying `backend/.env` so `JWT_SECRET` carries
over verbatim, dumping and restoring the ~20 KB database, and swapping the ingress rule off
the workstation's shared tunnel (it also serves `sports.darling.solutions`, so it cannot
simply be moved) — is the operational half and needs the prerequisites above first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
